### PR TITLE
fix(vue): watch for scope dispose

### DIFF
--- a/examples/nuxt3/plugins/script.ts
+++ b/examples/nuxt3/plugins/script.ts
@@ -1,4 +1,5 @@
 import { defineNuxtPlugin, useHead, ref } from '#imports'
+import {EffectScope} from "vue";
 
 const configure = [
   'window.loadTurnstile = new Promise(resolve => {',
@@ -21,14 +22,24 @@ const script = {
 export default defineNuxtPlugin(() => {
   const addScript = ref(false)
 
-  useHead({
-    script: () => [
-      { children: configure },
-      addScript.value && script,
-    ].filter((s): s is typeof script => !!s),
+  let scope : EffectScope | null = effectScope()
+
+  scope.run(() => {
+    useHead({
+      script: () => {
+        return [
+          {children: configure},
+          addScript.value && script,
+        ].filter((s): s is typeof script => !!s)
+      },
+    })
   })
 
-  setTimeout(() => {
-    addScript.value = true
+  setInterval(() => {
+    addScript.value = !addScript.value
+    if (scope) {
+      scope.stop()
+      scope = null
+    }
   }, 1000)
 })

--- a/packages/vue/src/runtime/composables/useHead/clientUseHead.ts
+++ b/packages/vue/src/runtime/composables/useHead/clientUseHead.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { getCurrentScope, onScopeDispose, ref, watch, watchEffect, effectScope} from 'vue'
+import { effectScope, getCurrentScope, onScopeDispose, ref, watch, watchEffect } from 'vue'
 import type { ActiveHeadEntry, HeadEntryOptions, MergeHead } from '@unhead/schema'
 import type { ReactiveHead, UseHeadInput } from '../../..'
 import { injectHead, resolveUnrefHeadInput } from '../../..'

--- a/packages/vue/src/runtime/composables/useHead/clientUseHead.ts
+++ b/packages/vue/src/runtime/composables/useHead/clientUseHead.ts
@@ -9,22 +9,15 @@ export function clientUseHead<T extends MergeHead>(input: UseHeadInput<T>, optio
 
   const resolvedInput: Ref<ReactiveHead> = ref({})
 
-  const scope = effectScope()
-
-  let entry: ActiveHeadEntry<UseHeadInput<T>>
-
-  scope.run(() => {
-    watchEffect(() => {
-      resolvedInput.value = resolveUnrefHeadInput(input)
-    })
-    entry = head.push(resolvedInput.value, options)
-    watch(resolvedInput, e => entry.patch(e))
+  watchEffect(() => {
+    resolvedInput.value = resolveUnrefHeadInput(input)
   })
+  const entry: ActiveHeadEntry<UseHeadInput<T>> = head.push(resolvedInput.value, options)
+  watch(resolvedInput, e => entry.patch(e))
 
   if (getCurrentScope()) {
     onScopeDispose(() => {
-      entry?.dispose()
-      scope.stop(true)
+      entry.dispose()
     })
   }
   return entry!

--- a/packages/vue/src/runtime/composables/useHead/clientUseHead.ts
+++ b/packages/vue/src/runtime/composables/useHead/clientUseHead.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { effectScope, getCurrentScope, onScopeDispose, ref, watch, watchEffect } from 'vue'
+import { getCurrentScope, onScopeDispose, ref, watch, watchEffect } from 'vue'
 import type { ActiveHeadEntry, HeadEntryOptions, MergeHead } from '@unhead/schema'
 import type { ReactiveHead, UseHeadInput } from '../../..'
 import { injectHead, resolveUnrefHeadInput } from '../../..'
@@ -20,5 +20,5 @@ export function clientUseHead<T extends MergeHead>(input: UseHeadInput<T>, optio
       entry.dispose()
     })
   }
-  return entry!
+  return entry
 }


### PR DESCRIPTION
Reactivity outside of components seems to be broken (see https://github.com/danielroe/nuxt-turnstile/issues/66#issuecomment-1332827264).

This commit (https://github.com/unjs/unhead/commit/92e17d34908cb185cff5e3d5e0a0e32f509bce8c) should fix that, but it may lead to issues where the watchers will never get disposed properly.

We update the internal logic to use scope effects to allow users to opt-out.