### PR TITLE
fix(unhead): normalise innerHTML objects to json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "@vitest/ui": "^0.25.3",
     "@vue/server-renderer": "^3.2.45",
     "bumpp": "^8.2.1",
-    "eslint": "^8.28.0",
-    "fs-extra": "^10.1.0",
+    "eslint": "^8.29.0",
+    "fs-extra": "^11.1.0",
     "jsdom": "^20.0.3",
     "typescript": "^4.9.3",
     "unbuild": "^1.0.1",
@@ -63,7 +63,7 @@
     "vue": "^3.2.45"
   },
   "dependencies": {
-    "@zhead/schema": "^1.0.4",
+    "@zhead/schema": "^1.0.7",
     "unplugin-auto-import": "^0.12.0"
   }
 }

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -63,6 +63,6 @@
   },
   "devDependencies": {
     "@babel/types": "^7.20.5",
-    "zhead": "^1.0.4"
+    "zhead": "^1.0.7"
   }
 }

--- a/packages/addons/src/unplugin/TreeshakeServerComposables.ts
+++ b/packages/addons/src/unplugin/TreeshakeServerComposables.ts
@@ -42,7 +42,7 @@ export const TreeshakeServerComposables = createUnplugin<PluginOptions>((userCon
     },
 
     async transform(code, id) {
-      if (!code.includes('useServerHead') && !code.includes('useSeoMeta'))
+      if (!code.includes('useServerHead') && !code.includes('useSeoMeta') && !code.includes('useSchemaOrg'))
         return null
 
       let transformed
@@ -53,6 +53,8 @@ export const TreeshakeServerComposables = createUnplugin<PluginOptions>((userCon
             RemoveFunctions([
               'useServerHead',
               'useSeoMeta',
+              // schema.org support
+              'useSchemaOrg',
             ]),
           ],
         })

--- a/packages/addons/src/unplugin/TreeshakeServerComposables.ts
+++ b/packages/addons/src/unplugin/TreeshakeServerComposables.ts
@@ -42,7 +42,7 @@ export const TreeshakeServerComposables = createUnplugin<PluginOptions>((userCon
     },
 
     async transform(code, id) {
-      if (!code.includes('useServerHead') && !code.includes('useSeoMeta') && !code.includes('useSchemaOrg'))
+      if (!code.includes('useServerHead') && !code.includes('useSeoMeta'))
         return null
 
       let transformed
@@ -53,8 +53,6 @@ export const TreeshakeServerComposables = createUnplugin<PluginOptions>((userCon
             RemoveFunctions([
               'useServerHead',
               'useSeoMeta',
-              // schema.org support
-              'useSchemaOrg',
             ]),
           ],
         })

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -38,6 +38,6 @@
     "@unhead/schema": "workspace:*"
   },
   "devDependencies": {
-    "zhead": "^1.0.4"
+    "zhead": "^1.0.7"
   }
 }

--- a/packages/dom/src/renderDOMHead.ts
+++ b/packages/dom/src/renderDOMHead.ts
@@ -178,6 +178,7 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
 /**
  * Global instance of the dom update promise. Used for debounding head updates.
  */
+// eslint-disable-next-line import/no-mutable-exports
 export let domUpdatePromise: Promise<void> | null = null
 
 /**

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -39,7 +39,7 @@
     "stub": "unbuild . --stub"
   },
   "dependencies": {
-    "@zhead/schema": "^1.0.4",
+    "@zhead/schema": "^1.0.7",
     "hookable": "^5.4.2"
   }
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -3,6 +3,6 @@ export * from './tags'
 export * from './head'
 export * from './hooks'
 
-export type { MergeHead, TagKey, DataKeys, DefinedValueOrEmptyObject } from '@zhead/schema'
+export type { MergeHead, TagKey, DataKeys, DefinedValueOrEmptyObject, SpeculationRules } from '@zhead/schema'
 
 export {}

--- a/packages/schema/src/tags.ts
+++ b/packages/schema/src/tags.ts
@@ -39,23 +39,25 @@ export interface TagPosition {
   body?: true
 }
 
+export type InnerContentVal = string | Record<string, any>
+
 export interface InnerContent {
   /**
    * Text content of the tag.
    *
    * Alias for children
    */
-  innerHTML?: string
+  innerHTML?: InnerContentVal
   /**
    * Sets the textContent of an element.
    */
-  children?: string
+  children?: InnerContentVal
   /**
    * Sets the textContent of an element. This will be HTML encoded.
    *
    * Alias for children
    */
-  textContent?: string
+  textContent?: InnerContentVal
 }
 
 export interface TagPriority {

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -38,6 +38,6 @@
     "@unhead/schema": "workspace:*"
   },
   "devDependencies": {
-    "zhead": "^1.0.4"
+    "zhead": "^1.0.7"
   }
 }

--- a/packages/unhead/package.json
+++ b/packages/unhead/package.json
@@ -40,6 +40,6 @@
     "hookable": "^5.4.2"
   },
   "devDependencies": {
-    "zhead": "^1.0.4"
+    "zhead": "^1.0.7"
   }
 }

--- a/packages/unhead/src/createHead.ts
+++ b/packages/unhead/src/createHead.ts
@@ -57,6 +57,7 @@ export function createHeadCore<T extends {} = Head>(options: CreateHeadOptions =
   options.plugins.forEach(p => p.hooks && hooks.addHooks(p.hooks))
 
   // does the dom rendering by default
+  // es-lint-disable-next-line @typescript-eslint/no-use-before-define
   const updated = () => hooks.callHook('entries:updated', head)
 
   const head: Unhead<T> = {

--- a/packages/unhead/src/runtime/state.ts
+++ b/packages/unhead/src/runtime/state.ts
@@ -1,5 +1,6 @@
 import type { Unhead } from '@unhead/schema'
 
+// eslint-disable-next-line import/no-mutable-exports
 export let activeHead: Unhead<any> | undefined
 
 export const setActiveHead = (head: Unhead<any> | undefined) => (activeHead = head)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,10 @@ importers:
       '@types/jsdom': ^20.0.1
       '@vitest/ui': ^0.25.3
       '@vue/server-renderer': ^3.2.45
-      '@zhead/schema': ^1.0.4
+      '@zhead/schema': ^1.0.7
       bumpp: ^8.2.1
-      eslint: ^8.28.0
-      fs-extra: ^10.1.0
+      eslint: ^8.29.0
+      fs-extra: ^11.1.0
       jsdom: ^20.0.3
       typescript: ^4.9.3
       unbuild: ^1.0.1
@@ -24,17 +24,17 @@ importers:
       vitest: ^0.25.3
       vue: ^3.2.45
     dependencies:
-      '@zhead/schema': 1.0.4
+      '@zhead/schema': 1.0.7
       unplugin-auto-import: 0.12.0
     devDependencies:
-      '@antfu/eslint-config': 0.33.1_hsf322ms6xhhd4b5ne6lb74y4a
+      '@antfu/eslint-config': 0.33.1_s5ps7njkmjlaqajutnox5ntcla
       '@types/fs-extra': 9.0.13
       '@types/jsdom': 20.0.1
       '@vitest/ui': 0.25.3
       '@vue/server-renderer': 3.2.45_vue@3.2.45
       bumpp: 8.2.1
-      eslint: 8.28.0
-      fs-extra: 10.1.0
+      eslint: 8.29.0
+      fs-extra: 11.1.0
       jsdom: 20.0.3
       typescript: 4.9.3
       unbuild: 1.0.1
@@ -125,7 +125,7 @@ importers:
       unhead: workspace:*
       unplugin: ^1.0.0
       unplugin-ast: ^0.5.8
-      zhead: ^1.0.4
+      zhead: ^1.0.7
     dependencies:
       '@rollup/pluginutils': 5.0.2
       '@unhead/schema': link:../schema
@@ -134,46 +134,46 @@ importers:
       unplugin-ast: 0.5.8
     devDependencies:
       '@babel/types': 7.20.5
-      zhead: 1.0.4
+      zhead: 1.0.7
 
   packages/dom:
     specifiers:
       '@unhead/schema': workspace:*
-      zhead: ^1.0.4
+      zhead: ^1.0.7
     dependencies:
       '@unhead/schema': link:../schema
     devDependencies:
-      zhead: 1.0.4
+      zhead: 1.0.7
 
   packages/schema:
     specifiers:
-      '@zhead/schema': ^1.0.4
+      '@zhead/schema': ^1.0.7
       hookable: ^5.4.2
     dependencies:
-      '@zhead/schema': 1.0.4
+      '@zhead/schema': 1.0.7
       hookable: 5.4.2
 
   packages/ssr:
     specifiers:
       '@unhead/schema': workspace:*
-      zhead: ^1.0.4
+      zhead: ^1.0.7
     dependencies:
       '@unhead/schema': link:../schema
     devDependencies:
-      zhead: 1.0.4
+      zhead: 1.0.7
 
   packages/unhead:
     specifiers:
       '@unhead/dom': workspace:*
       '@unhead/schema': workspace:*
       hookable: ^5.4.2
-      zhead: ^1.0.4
+      zhead: ^1.0.7
     dependencies:
       '@unhead/dom': link:../dom
       '@unhead/schema': link:../schema
       hookable: 5.4.2
     devDependencies:
-      zhead: 1.0.4
+      zhead: 1.0.7
 
   packages/vue:
     specifiers:
@@ -207,23 +207,23 @@ packages:
       '@jridgewell/trace-mapping': 0.3.17
     dev: true
 
-  /@antfu/eslint-config-basic/0.33.1_czs5uoqkd3podpy6vgtsxfc7au:
+  /@antfu/eslint-config-basic/0.33.1_yjegg5cyoezm3fzsmuszzhetym:
     resolution: {integrity: sha512-2aubzjJSGcPJkHgNWOzOWaVdya9km0985wQTWJhT7WZEgZRMSjX+KIzMSz0l6HxvTmCCV71uAhBI1+5C+X2YQg==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      eslint: 8.28.0
-      eslint-plugin-antfu: 0.33.1_hsf322ms6xhhd4b5ne6lb74y4a
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.28.0
+      eslint: 8.29.0
+      eslint-plugin-antfu: 0.33.1_s5ps7njkmjlaqajutnox5ntcla
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.29.0
       eslint-plugin-html: 7.1.0
-      eslint-plugin-import: 2.26.0_vbnhqcxlbs7ynbxw44hu2vq7eq
-      eslint-plugin-jsonc: 2.5.0_eslint@8.28.0
-      eslint-plugin-markdown: 3.0.0_eslint@8.28.0
-      eslint-plugin-n: 15.5.1_eslint@8.28.0
+      eslint-plugin-import: 2.26.0_ub3senzxbs32f65wl7xoyha6lu
+      eslint-plugin-jsonc: 2.5.0_eslint@8.29.0
+      eslint-plugin-markdown: 3.0.0_eslint@8.29.0
+      eslint-plugin-n: 15.5.1_eslint@8.29.0
       eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-promise: 6.1.1_eslint@8.28.0
-      eslint-plugin-unicorn: 45.0.1_eslint@8.28.0
-      eslint-plugin-yml: 1.2.0_eslint@8.28.0
+      eslint-plugin-promise: 6.1.1_eslint@8.29.0
+      eslint-plugin-unicorn: 45.0.1_eslint@8.29.0
+      eslint-plugin-yml: 1.2.0_eslint@8.29.0
       jsonc-eslint-parser: 2.1.0
       yaml-eslint-parser: 1.1.0
     transitivePeerDependencies:
@@ -234,16 +234,16 @@ packages:
       - typescript
     dev: true
 
-  /@antfu/eslint-config-ts/0.33.1_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@antfu/eslint-config-ts/0.33.1_s5ps7njkmjlaqajutnox5ntcla:
     resolution: {integrity: sha512-wsu9eltvDNaB+SFISFq/+wvMf2uZYmoHb/zFgltHXUnInYbj4qlCOYzfUy9dPcPrxtaPdWoOC8P8WOKsSnbOvA==}
     peerDependencies:
       eslint: '>=7.4.0'
       typescript: '>=3.9'
     dependencies:
-      '@antfu/eslint-config-basic': 0.33.1_czs5uoqkd3podpy6vgtsxfc7au
-      '@typescript-eslint/eslint-plugin': 5.45.0_czs5uoqkd3podpy6vgtsxfc7au
-      '@typescript-eslint/parser': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
-      eslint: 8.28.0
+      '@antfu/eslint-config-basic': 0.33.1_yjegg5cyoezm3fzsmuszzhetym
+      '@typescript-eslint/eslint-plugin': 5.45.0_yjegg5cyoezm3fzsmuszzhetym
+      '@typescript-eslint/parser': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
+      eslint: 8.29.0
       typescript: 4.9.3
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
@@ -251,15 +251,15 @@ packages:
       - supports-color
     dev: true
 
-  /@antfu/eslint-config-vue/0.33.1_czs5uoqkd3podpy6vgtsxfc7au:
+  /@antfu/eslint-config-vue/0.33.1_yjegg5cyoezm3fzsmuszzhetym:
     resolution: {integrity: sha512-zIO8Y7/lAnxcbz9Vo68IYX9ujRAHwpWx3uurirAkH+/UNREen+SP/obPab/C9ts3kgEsIQXNxBzwXYf4VpAUUQ==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-basic': 0.33.1_czs5uoqkd3podpy6vgtsxfc7au
-      '@antfu/eslint-config-ts': 0.33.1_hsf322ms6xhhd4b5ne6lb74y4a
-      eslint: 8.28.0
-      eslint-plugin-vue: 9.8.0_eslint@8.28.0
+      '@antfu/eslint-config-basic': 0.33.1_yjegg5cyoezm3fzsmuszzhetym
+      '@antfu/eslint-config-ts': 0.33.1_s5ps7njkmjlaqajutnox5ntcla
+      eslint: 8.29.0
+      eslint-plugin-vue: 9.8.0_eslint@8.29.0
       local-pkg: 0.4.2
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -269,24 +269,24 @@ packages:
       - typescript
     dev: true
 
-  /@antfu/eslint-config/0.33.1_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@antfu/eslint-config/0.33.1_s5ps7njkmjlaqajutnox5ntcla:
     resolution: {integrity: sha512-g9s+8J7SIdbsqceDU14TNi/n65skquMtp05T/7GNz/Erz5QcsbhykW0X7uogO38skTnr5Qpm2OZ4ehzviLdciw==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-vue': 0.33.1_czs5uoqkd3podpy6vgtsxfc7au
-      '@typescript-eslint/eslint-plugin': 5.45.0_czs5uoqkd3podpy6vgtsxfc7au
-      '@typescript-eslint/parser': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
-      eslint: 8.28.0
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.28.0
+      '@antfu/eslint-config-vue': 0.33.1_yjegg5cyoezm3fzsmuszzhetym
+      '@typescript-eslint/eslint-plugin': 5.45.0_yjegg5cyoezm3fzsmuszzhetym
+      '@typescript-eslint/parser': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
+      eslint: 8.29.0
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.29.0
       eslint-plugin-html: 7.1.0
-      eslint-plugin-import: 2.26.0_vbnhqcxlbs7ynbxw44hu2vq7eq
-      eslint-plugin-jsonc: 2.5.0_eslint@8.28.0
-      eslint-plugin-n: 15.5.1_eslint@8.28.0
-      eslint-plugin-promise: 6.1.1_eslint@8.28.0
-      eslint-plugin-unicorn: 45.0.1_eslint@8.28.0
-      eslint-plugin-vue: 9.8.0_eslint@8.28.0
-      eslint-plugin-yml: 1.2.0_eslint@8.28.0
+      eslint-plugin-import: 2.26.0_ub3senzxbs32f65wl7xoyha6lu
+      eslint-plugin-jsonc: 2.5.0_eslint@8.29.0
+      eslint-plugin-n: 15.5.1_eslint@8.29.0
+      eslint-plugin-promise: 6.1.1_eslint@8.29.0
+      eslint-plugin-unicorn: 45.0.1_eslint@8.29.0
+      eslint-plugin-vue: 9.8.0_eslint@8.29.0
+      eslint-plugin-yml: 1.2.0_eslint@8.29.0
       jsonc-eslint-parser: 2.1.0
       yaml-eslint-parser: 1.1.0
     transitivePeerDependencies:
@@ -1599,13 +1599,13 @@ packages:
     dev: true
     optional: true
 
-  /@eslint-community/eslint-utils/4.1.2_eslint@8.28.0:
+  /@eslint-community/eslint-utils/4.1.2_eslint@8.29.0:
     resolution: {integrity: sha512-7qELuQWWjVDdVsFQ5+beUl+KPczrEDA7S3zM4QUd/bJl7oXgsmpXaEVqrRTnOBqenOV4rWf2kVZk2Ot085zPWA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.28.0
+      eslint: 8.29.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -1616,8 +1616,8 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.4.1
-      globals: 13.17.0
-      ignore: 5.2.0
+      globals: 13.18.0
+      ignore: 5.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -1767,7 +1767,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.13.0
+      fastq: 1.14.0
 
   /@nuxt/devalue/2.0.0:
     resolution: {integrity: sha512-YBI/6o2EBz02tdEJRBK8xkt3zvOFOWlLBf7WKYGBsSYSRtjjgrqPe2skp6VLLmKx5WbHHDNcW+6oACaurxGzeA==}
@@ -2421,7 +2421,7 @@ packages:
       '@types/node': 18.11.9
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.45.0_czs5uoqkd3podpy6vgtsxfc7au:
+  /@typescript-eslint/eslint-plugin/5.45.0_yjegg5cyoezm3fzsmuszzhetym:
     resolution: {integrity: sha512-CXXHNlf0oL+Yg021cxgOdMHNTXD17rHkq7iW6RFHoybdFgQBjU3yIXhhcPpGwr1CjZlo6ET8C6tzX5juQoXeGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2432,12 +2432,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/parser': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
       '@typescript-eslint/scope-manager': 5.45.0
-      '@typescript-eslint/type-utils': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
-      '@typescript-eslint/utils': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/type-utils': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
+      '@typescript-eslint/utils': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
       debug: 4.3.4
-      eslint: 8.28.0
+      eslint: 8.29.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
@@ -2448,7 +2448,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.45.0_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@typescript-eslint/parser/5.45.0_s5ps7njkmjlaqajutnox5ntcla:
     resolution: {integrity: sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2462,7 +2462,7 @@ packages:
       '@typescript-eslint/types': 5.45.0
       '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.3
       debug: 4.3.4
-      eslint: 8.28.0
+      eslint: 8.29.0
       typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2476,7 +2476,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.45.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.45.0_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@typescript-eslint/type-utils/5.45.0_s5ps7njkmjlaqajutnox5ntcla:
     resolution: {integrity: sha512-DY7BXVFSIGRGFZ574hTEyLPRiQIvI/9oGcN8t1A7f6zIs6ftbrU0nhyV26ZW//6f85avkwrLag424n+fkuoJ1Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2487,9 +2487,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.3
-      '@typescript-eslint/utils': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/utils': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
       debug: 4.3.4
-      eslint: 8.28.0
+      eslint: 8.29.0
       tsutils: 3.21.0_typescript@4.9.3
       typescript: 4.9.3
     transitivePeerDependencies:
@@ -2522,7 +2522,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.45.0_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@typescript-eslint/utils/5.45.0_s5ps7njkmjlaqajutnox5ntcla:
     resolution: {integrity: sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2533,9 +2533,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.45.0
       '@typescript-eslint/types': 5.45.0
       '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.3
-      eslint: 8.28.0
+      eslint: 8.29.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.28.0
+      eslint-utils: 3.0.0_eslint@8.29.0
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
@@ -2559,7 +2559,7 @@ packages:
   /@unhead/schema/1.0.3:
     resolution: {integrity: sha512-Alt7YdY4ksM1dty/hQpRFaCmnDv11h79gvi3RgALYe8J16uvR+55WChwtjFMUDUDUx4nLNmsxohfj22IYaqfwg==}
     dependencies:
-      '@zhead/schema': 1.0.4
+      '@zhead/schema': 1.0.7
       hookable: 5.4.2
     dev: true
 
@@ -3324,8 +3324,8 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
     dev: true
 
-  /@zhead/schema/1.0.4:
-    resolution: {integrity: sha512-v/CM22nH0TW9VU5IcRXlshwrMtsZPnFQWhcLBvpZjOJvfEmjl8cUb6OIJQJRR2WESNjjPW2Cji8mgL9XSVLjxA==}
+  /@zhead/schema/1.0.7:
+    resolution: {integrity: sha512-jN2ipkz39YrHd8uulgw/Y7x8iOxvR/cTkin/E9zRQVP5JBIrrJMiGyFFj6JBW4Q029xJ5dKtpwy/3RZWpz+dkQ==}
 
   /abab/2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -5356,7 +5356,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.4_kr6tb4mi2cmpd7whrqyyy67tyi:
+  /eslint-module-utils/2.7.4_ka2zl4kbfnnb6pzn3mgzpmhlt4:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5377,43 +5377,43 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/parser': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
       debug: 3.2.7
-      eslint: 8.28.0
+      eslint: 8.29.0
       eslint-import-resolver-node: 0.3.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-antfu/0.33.1_hsf322ms6xhhd4b5ne6lb74y4a:
+  /eslint-plugin-antfu/0.33.1_s5ps7njkmjlaqajutnox5ntcla:
     resolution: {integrity: sha512-QhEFqyMpsXDV+Rz/mzGs6LSb6XAeCtS0YgmcqAEeTYL+rCmEaxGWiOKDphhEUcVf7qT86fZkF8h7ffBwId30bA==}
     dependencies:
-      '@typescript-eslint/utils': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/utils': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-es/4.1.0_eslint@8.28.0:
+  /eslint-plugin-es/4.1.0_eslint@8.29.0:
     resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.28.0
+      eslint: 8.29.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-eslint-comments/3.2.0_eslint@8.28.0:
+  /eslint-plugin-eslint-comments/3.2.0_eslint@8.29.0:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
       escape-string-regexp: 1.0.5
-      eslint: 8.28.0
+      eslint: 8.29.0
       ignore: 5.2.0
     dev: true
 
@@ -5423,7 +5423,7 @@ packages:
       htmlparser2: 8.0.1
     dev: true
 
-  /eslint-plugin-import/2.26.0_vbnhqcxlbs7ynbxw44hu2vq7eq:
+  /eslint-plugin-import/2.26.0_ub3senzxbs32f65wl7xoyha6lu:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5433,14 +5433,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/parser': 5.45.0_s5ps7njkmjlaqajutnox5ntcla
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.28.0
+      eslint: 8.29.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_kr6tb4mi2cmpd7whrqyyy67tyi
+      eslint-module-utils: 2.7.4_ka2zl4kbfnnb6pzn3mgzpmhlt4
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -5454,40 +5454,40 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jsonc/2.5.0_eslint@8.28.0:
+  /eslint-plugin-jsonc/2.5.0_eslint@8.29.0:
     resolution: {integrity: sha512-G257khwkrOQ5MJpSzz4yQh5K12W4xFZRcHmVlhVFWh2GCLDX+JwHnmkQoUoFDbOieSPBMsPFZDTJScwrXiWlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      eslint: 8.28.0
-      eslint-utils: 3.0.0_eslint@8.28.0
+      eslint: 8.29.0
+      eslint-utils: 3.0.0_eslint@8.29.0
       jsonc-eslint-parser: 2.1.0
       natural-compare: 1.4.0
     dev: true
 
-  /eslint-plugin-markdown/3.0.0_eslint@8.28.0:
+  /eslint-plugin-markdown/3.0.0_eslint@8.29.0:
     resolution: {integrity: sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.28.0
+      eslint: 8.29.0
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-n/15.5.1_eslint@8.28.0:
+  /eslint-plugin-n/15.5.1_eslint@8.29.0:
     resolution: {integrity: sha512-kAd+xhZm7brHoFLzKLB7/FGRFJNg/srmv67mqb7tto22rpr4wv/LV6RuXzAfv3jbab7+k1wi42PsIhGviywaaw==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
       builtins: 5.0.1
-      eslint: 8.28.0
-      eslint-plugin-es: 4.1.0_eslint@8.28.0
-      eslint-utils: 3.0.0_eslint@8.28.0
+      eslint: 8.29.0
+      eslint-plugin-es: 4.1.0_eslint@8.29.0
+      eslint-utils: 3.0.0_eslint@8.29.0
       ignore: 5.2.0
       is-core-module: 2.11.0
       minimatch: 3.1.2
@@ -5500,26 +5500,26 @@ packages:
     engines: {node: '>=5.0.0'}
     dev: true
 
-  /eslint-plugin-promise/6.1.1_eslint@8.28.0:
+  /eslint-plugin-promise/6.1.1_eslint@8.29.0:
     resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.28.0
+      eslint: 8.29.0
     dev: true
 
-  /eslint-plugin-unicorn/45.0.1_eslint@8.28.0:
+  /eslint-plugin-unicorn/45.0.1_eslint@8.29.0:
     resolution: {integrity: sha512-tLnIw5oDJJc3ILYtlKtqOxPP64FZLTkZkgeuoN6e7x6zw+rhBjOxyvq2c7577LGxXuIhBYrwisZuKNqOOHp3BA==}
     engines: {node: '>=14.18'}
     peerDependencies:
       eslint: '>=8.28.0'
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
-      '@eslint-community/eslint-utils': 4.1.2_eslint@8.28.0
+      '@eslint-community/eslint-utils': 4.1.2_eslint@8.29.0
       ci-info: 3.6.1
       clean-regexp: 1.0.0
-      eslint: 8.28.0
+      eslint: 8.29.0
       esquery: 1.4.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.0
@@ -5534,32 +5534,32 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /eslint-plugin-vue/9.8.0_eslint@8.28.0:
+  /eslint-plugin-vue/9.8.0_eslint@8.29.0:
     resolution: {integrity: sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.28.0
-      eslint-utils: 3.0.0_eslint@8.28.0
+      eslint: 8.29.0
+      eslint-utils: 3.0.0_eslint@8.29.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.0.10
       semver: 7.3.8
-      vue-eslint-parser: 9.1.0_eslint@8.28.0
+      vue-eslint-parser: 9.1.0_eslint@8.29.0
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-yml/1.2.0_eslint@8.28.0:
+  /eslint-plugin-yml/1.2.0_eslint@8.29.0:
     resolution: {integrity: sha512-v0jAU/F5SJg28zkpxwGpY04eGZMWFP6os8u2qaEAIRjSH2GqrNl0yBR5+sMHLU/026kAduxVbvLSqmT3Mu3O0g==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
       debug: 4.3.4
-      eslint: 8.28.0
+      eslint: 8.29.0
       lodash: 4.17.21
       natural-compare: 1.4.0
       yaml-eslint-parser: 1.1.0
@@ -5590,13 +5590,13 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@8.28.0:
+  /eslint-utils/3.0.0_eslint@8.29.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.28.0
+      eslint: 8.29.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -5615,8 +5615,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint/8.28.0:
-    resolution: {integrity: sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==}
+  /eslint/8.29.0:
+    resolution: {integrity: sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
@@ -5631,7 +5631,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.28.0
+      eslint-utils: 3.0.0_eslint@8.29.0
       eslint-visitor-keys: 3.3.0
       espree: 9.4.1
       esquery: 1.4.0
@@ -5640,14 +5640,14 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.17.0
+      globals: 13.18.0
       grapheme-splitter: 1.0.4
-      ignore: 5.2.0
+      ignore: 5.2.1
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-sdsl: 4.1.5
+      js-sdsl: 4.2.0
       js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
@@ -5844,8 +5844,8 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fastq/1.13.0:
-    resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
+  /fastq/1.14.0:
+    resolution: {integrity: sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==}
     dependencies:
       reusify: 1.0.4
 
@@ -6012,6 +6012,15 @@ packages:
   /fs-extra/10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.10
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
+  /fs-extra/11.1.0:
+    resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
+    engines: {node: '>=14.14'}
     dependencies:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
@@ -6211,8 +6220,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /globals/13.17.0:
-    resolution: {integrity: sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==}
+  /globals/13.18.0:
+    resolution: {integrity: sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -6549,6 +6558,11 @@ packages:
 
   /ignore/5.2.0:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
+    engines: {node: '>= 4'}
+    dev: true
+
+  /ignore/5.2.1:
+    resolution: {integrity: sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -6945,8 +6959,8 @@ packages:
     engines: {node: '>=0.6.0'}
     dev: true
 
-  /js-sdsl/4.1.5:
-    resolution: {integrity: sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==}
+  /js-sdsl/4.2.0:
+    resolution: {integrity: sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==}
     dev: true
 
   /js-tokens/4.0.0:
@@ -10588,14 +10602,14 @@ packages:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
     dev: true
 
-  /vue-eslint-parser/9.1.0_eslint@8.28.0:
+  /vue-eslint-parser/9.1.0_eslint@8.29.0:
     resolution: {integrity: sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
       debug: 4.3.4
-      eslint: 8.28.0
+      eslint: 8.29.0
       eslint-scope: 7.1.1
       eslint-visitor-keys: 3.3.0
       espree: 9.4.1
@@ -11162,10 +11176,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zhead/1.0.4:
-    resolution: {integrity: sha512-E0vbe9nW70f57fdfUdFt9odmDEubySleEbd+hyCjkCHxev419HsxQ1mEaQEEmGdaxxslZFrekjGMLeioiJKodQ==}
+  /zhead/1.0.7:
+    resolution: {integrity: sha512-p/PBV+KtdsyIPr+tPHVXIGe028EmBFtsbSYKURS2foTDKr6d33zaRrC3GzmGeQSc0vZezmD5C3Okh1P26Nb1Qg==}
     dependencies:
-      '@zhead/schema': 1.0.4
+      '@zhead/schema': 1.0.7
     dev: true
 
   /zip-stream/4.1.0:

--- a/test/unhead/dom/innerHTML.test.ts
+++ b/test/unhead/dom/innerHTML.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from 'vitest'
+import { useHead } from 'unhead'
+import type { SpeculationRules } from '@zhead/schema'
+import { useDOMHead, useDelayedSerializedDom } from './util'
+
+describe('dom innerHTML', () => {
+  it('json', async () => {
+    useDOMHead()
+
+    useHead({
+      script: [
+        {
+          innerHTML: {
+            test: 'test',
+            something: {
+              else: 123,
+            },
+          },
+        },
+        {
+          type: 'speculationrules',
+          innerHTML: <SpeculationRules> {
+            prefetch: [
+              {
+                source: 'list',
+                urls: ['/test'],
+                requires: ['anonymous-client-ip-when-cross-origin'],
+              },
+            ],
+          },
+        },
+      ],
+    })
+    expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
+        "<!DOCTYPE html><html><head>
+
+        <script>{\\"test\\":\\"test\\",\\"something\\":{\\"else\\":123}}</script><script type=\\"speculationrules\\">{\\"prefetch\\":[{\\"source\\":\\"list\\",\\"urls\\":[\\"/test\\"],\\"requires\\":[\\"anonymous-client-ip-when-cross-origin\\"]}]}</script></head>
+        <body>
+
+        <div>
+        <h1>hello world</h1>
+        </div>
+
+
+
+        </body></html>"
+      `)
+  })
+
+  it('noscript', async () => {
+    useDOMHead()
+
+    useHead({
+      noscript: [
+        {
+          children: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXX"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+        },
+      ],
+    })
+    expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+
+      <noscript>&lt;iframe src=\\"https://www.googletagmanager.com/ns.html?id=GTM-XXXXXX\\"
+          height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"&gt;&lt;/iframe&gt;</noscript></head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+})

--- a/test/unhead/dom/util.ts
+++ b/test/unhead/dom/util.ts
@@ -3,6 +3,7 @@ import type { JSDOM } from 'jsdom'
 import type { CreateHeadOptions } from '@unhead/schema'
 import { useDom } from '../../fixtures'
 
+// eslint-disable-next-line import/no-mutable-exports
 export let activeDom: JSDOM | null = null
 
 export function useDOMHead(options: CreateHeadOptions = {}) {

--- a/test/unhead/ssr/innerHTML.test.ts
+++ b/test/unhead/ssr/innerHTML.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from 'vitest'
+import { createHead } from 'unhead'
+import { renderSSRHead } from '../../../packages/ssr'
+
+describe('ssr innerHTML', () => {
+  it('json', async () => {
+    const head = createHead()
+    head.push({
+      script: [
+        {
+          innerHTML: {
+            test: 'test',
+            something: {
+              else: 123,
+            },
+          },
+        },
+      ],
+    })
+    const ctx = await renderSSRHead(head)
+    expect(ctx).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<script>{\\"test\\":\\"test\\",\\"something\\":{\\"else\\":123}}</script>",
+        "htmlAttrs": "",
+      }
+    `)
+  })
+
+  it('noscript', async () => {
+    const head = createHead()
+    head.push({
+      noscript: [
+        {
+          children: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXX"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+        },
+      ],
+    })
+    const ctx = await renderSSRHead(head)
+    expect(ctx).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<noscript><iframe src=\\"https://www.googletagmanager.com/ns.html?id=GTM-XXXXXX\\"
+          height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"></iframe></noscript>",
+        "htmlAttrs": "",
+      }
+    `)
+  })
+})


### PR DESCRIPTION
When providing an object as the innerHTML, we should automatically normalise it to a JSON string.

```ts
    useHead({
       script: [
        {
          innerHTML: {
            test: 'test',
            something: {
              else: 123,
            },
          },
        },
    })
```

```html
 <script>{\"test\":\"test\",\"something\":{\"else\":123}}</script>
```