### PR TITLE
fix: compact with vitest-environment-nuxt

### DIFF
--- a/packages/dom/src/renderDOMHead.ts
+++ b/packages/dom/src/renderDOMHead.ts
@@ -123,9 +123,12 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
     .forEach(([pos, queue]) => {
       if (!queue.length)
         return
+      const children = dom?.[pos as 'head' | 'body']?.children
+      if (!children)
+        return
 
       // 3a. try and find a matching existing element (we only scan the DOM once per render tree)
-      for (const $el of [...dom[pos as 'head' | 'body'].children].reverse()) {
+      for (const $el of [...children].reverse()) {
         const elTag = $el.tagName.toLowerCase()
         // only valid element tags
         if (!HasElementTags.includes(elTag))


### PR DESCRIPTION
In `vitest-environment-nuxt` we enumerate the browser env (providing `window`) while it's not real dom, so `dom[pos]` can be undefined, causing the test crash.

<img width="913" alt="image" src="https://user-images.githubusercontent.com/11247099/212868484-cb38d338-4159-4b85-8ae6-068eeab885a7.png">
