### PR TITLE
fix(dom): support envs without `isEqualNode`

### DIFF
--- a/packages/dom/src/renderDOMHead.ts
+++ b/packages/dom/src/renderDOMHead.ts
@@ -141,7 +141,7 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
             .reduce((props, name) => ({ ...props, [name]: $el.getAttribute(name) }), {}),
         })
 
-        const matchIdx = queue.findIndex(ctx => ctx && (ctx.tag._d === dedupeKey || $el.isEqualNode(ctx.$el!)))
+        const matchIdx = queue.findIndex(ctx => ctx && (ctx.tag._d === dedupeKey || $el.isEqualNode?.(ctx.$el!)))
         if (matchIdx !== -1) {
           const ctx = queue[matchIdx]
           ctx.$el = $el


### PR DESCRIPTION
When being used in a test environment, with `happy-dom`, this method is not implemented.

More context: https://github.com/capricorn86/happy-dom/issues/656

I was facing this issue testing a Nuxt app, with vitest (and https://github.com/danielroe/vitest-environment-nuxt).

Making the check optional, makes my tests pass. But it might be too naive?