### PR TITLE
Skip empty 'spaces' in classlist.add

### DIFF
--- a/packages/dom/src/setAttrs.ts
+++ b/packages/dom/src/setAttrs.ts
@@ -24,7 +24,7 @@ export const setAttrs = (ctx: DomRenderTagContext, newEntry = false, markSideEff
         if (markSideEffect)
           markSideEffect(ctx, classSdeKey, () => $el.classList.remove(c))
 
-        if (!$el.classList.contains(c))
+        if (!$el.classList.contains(c) && c !== '')
           $el.classList.add(c)
       }
       return

--- a/packages/dom/src/setAttrs.ts
+++ b/packages/dom/src/setAttrs.ts
@@ -24,7 +24,7 @@ export const setAttrs = (ctx: DomRenderTagContext, newEntry = false, markSideEff
         if (markSideEffect)
           markSideEffect(ctx, classSdeKey, () => $el.classList.remove(c))
 
-        if (!$el.classList.contains(c) && c !== '')
+        if (!$el.classList.contains(c) && c)
           $el.classList.add(c)
       }
       return

--- a/packages/dom/src/setAttrs.ts
+++ b/packages/dom/src/setAttrs.ts
@@ -19,12 +19,14 @@ export const setAttrs = (ctx: DomRenderTagContext, newEntry = false, markSideEff
       if (!value)
         return
       for (const c of value.split(' ')) {
+        if (!c)
+          return
         const classSdeKey = `${attrSdeKey}:${c}`
         // always clear side effects
         if (markSideEffect)
           markSideEffect(ctx, classSdeKey, () => $el.classList.remove(c))
 
-        if (!$el.classList.contains(c) && c)
+        if (!$el.classList.contains(c))
           $el.classList.add(c)
       }
       return


### PR DESCRIPTION
fixes: #104

This was the quickest fix to skip empty strings in the classList.add

_Might be better to filter them before?_
**edit:** moved the check up a bit.