### PR TITLE
fix(unhead): data-* booleans no longer omitted

### DIFF
--- a/packages/unhead/src/utils/normalise.ts
+++ b/packages/unhead/src/utils/normalise.ts
@@ -49,6 +49,8 @@ export async function normaliseTag<T extends HeadTag>(tagName: T['tag'], input: 
 export async function normaliseProps<T extends HeadTag['props']>(props: T): Promise<T> {
   // handle boolean props, see https://html.spec.whatwg.org/#boolean-attributes
   for (const k of Object.keys(props)) {
+    // data keys get special treatment, we opt for more verbose syntax
+    const isDataKey = k.startsWith('data-')
     // first resolve any promises
     if (props[k] instanceof Promise) {
       // @ts-expect-error untyped
@@ -56,10 +58,15 @@ export async function normaliseProps<T extends HeadTag['props']>(props: T): Prom
     }
     if (String(props[k]) === 'true') {
       // @ts-expect-error untyped
-      props[k] = ''
+      props[k] = isDataKey? 'true' : ''
     }
     else if (String(props[k]) === 'false') {
-      delete props[k]
+      if (isDataKey) {
+        // @ts-expect-error untyped
+        props[k] = 'false'
+      } else {
+        delete props[k]
+      }
     }
   }
   return props

--- a/test/unhead/e2e/data-booleans.test.ts
+++ b/test/unhead/e2e/data-booleans.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from 'vitest'
+import { createHead, useServerHead } from 'unhead'
+import { renderSSRHead } from '@unhead/ssr'
+import { renderDOMHead } from '@unhead/dom'
+import { useDom } from '../../fixtures'
+
+describe('unhead e2e data true', () => {
+  it('truthy', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useServerHead({
+      meta: [
+        {
+          name: 'foo',
+          ['data-foo']: 'true',
+          ['data-bar']: 'false',
+          ['data-bar-false']: false,
+          ['data-foo-true']: true,
+          content: 'true',
+        },
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<meta name=\\"foo\\" data-foo=\\"true\\" data-bar=\\"false\\" data-bar-false=\\"false\\" data-foo-true=\\"true\\" content=\\"\\">",
+        "htmlAttrs": "",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      meta: [
+        {
+          name: 'foo',
+          ['data-foo']: 'true',
+          content: 'true',
+        },
+      ],
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <meta name=\\"foo\\" data-foo=\\"true\\" data-bar=\\"false\\" data-bar-false=\\"false\\" data-foo-true=\\"true\\" content=\\"\\">
+      </head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+})

--- a/test/unhead/e2e/e2e.test.ts
+++ b/test/unhead/e2e/e2e.test.ts
@@ -3,7 +3,7 @@ import { createHead, useHead, useServerHead } from 'unhead'
 import { renderSSRHead } from '@unhead/ssr'
 import { renderDOMHead } from '@unhead/dom'
 import type { Head } from '@unhead/schema'
-import { useDom } from '../fixtures'
+import { useDom } from '../../fixtures'
 
 describe('unhead e2e', () => {
   it('basic hydration', async () => {

--- a/test/vue/ssr/examples.test.ts
+++ b/test/vue/ssr/examples.test.ts
@@ -108,7 +108,7 @@ describe('vue ssr examples', () => {
     }))
 
     expect(headResult.htmlAttrs).toMatchInlineSnapshot(
-      '" data-something=\\"\\""',
+      '" data-something=\\"true\\""',
     )
   })
 


### PR DESCRIPTION
## Issue

Fixes #103

## Description

Booleans are currently handled in Unhead per the HTML spec which says that says boolean props do not need to explicitly include `="true"` to be considered a truthy boolean. Likewise falsey values are just dropped

This change makes it so that `data-*` attributes will keep the more verbose syntax, as third-parties packages don't always adhere to the spec.

**Truthy Example**

```ts
useHead({
  name: 'my-analytics',
  content: 'my-key',
  ['data-spa-mode']: true,
})
```

New logic includes `="true"`

```diff
-<meta name="my-analytics" content="my-key" data-spa-mode />
+<meta name="my-analytics" content="my-key" data-spa-mode="true" />
```

**Falsey Example**

```ts
useHead({
  name: 'my-analytics',
  content: 'my-key',
  ['data-spa-mode']: false,
})
```

New value includes the entire data prop.

```diff
-<meta name="my-analytics" content="my-key" />
+<meta name="my-analytics" content="my-key" data-spa-mode="false" />
```