### PR TITLE
fix(unhead): improved class normalising

### DIFF
--- a/packages/unhead/src/utils/normalise.ts
+++ b/packages/unhead/src/utils/normalise.ts
@@ -41,13 +41,13 @@ export async function normaliseTag<T extends HeadTag>(tagName: T['tag'], input: 
   return tag
 }
 
-export function normaliseClassProp(v: Record<string, string | Array<string>> | Array<string> | string) {
+export function normaliseClassProp(v: Required<Required<Head>['htmlAttrs']['class']>) {
   if (typeof v === 'object' && !Array.isArray(v)) {
-    v = Object.keys(v)
-      .filter(k => v[k])
+    // @ts-expect-error untyped
+    v = Object.keys(v).filter(k => v[k])
   }
   // finally, check we don't have spaces, we may need to split again
-  return (Array.isArray(v) ? v.join(' ') : v)
+  return (Array.isArray(v) ? v.join(' ') : v as string)
     .split(' ')
     .filter(c => c.trim())
     .filter(Boolean)

--- a/packages/unhead/src/utils/normalise.ts
+++ b/packages/unhead/src/utils/normalise.ts
@@ -30,20 +30,28 @@ export async function normaliseTag<T extends HeadTag>(tagName: T['tag'], input: 
       delete tag.props[k]
     })
 
-  // class object boolean support
-  if (typeof tag.props.class === 'object' && !Array.isArray(tag.props.class)) {
-    tag.props.class = Object.keys(tag.props.class)
-      .filter(k => tag.props.class[k])
+  if (tag.props.class) {
+    tag.props.class = normaliseClassProp(tag.props.class)
   }
-  // class array support
-  if (Array.isArray(tag.props.class))
-    tag.props.class = tag.props.class.join(' ')
 
   // allow meta to be resolved into multiple tags if an array is provided on content
   if (tag.props.content && Array.isArray(tag.props.content))
     return tag.props.content.map(v => ({ ...tag, props: { ...tag.props, content: v } } as T))
 
   return tag
+}
+
+export function normaliseClassProp(v: Record<string, string | Array<string>> | Array<string> | string) {
+  if (typeof v === 'object' && !Array.isArray(v)) {
+    v = Object.keys(v)
+      .filter(k => v[k])
+  }
+  // finally, check we don't have spaces, we may need to split again
+  return (Array.isArray(v) ? v.join(' ') : v)
+    .split(' ')
+    .filter(c => c.trim())
+    .filter(Boolean)
+    .join(' ')
 }
 
 export async function normaliseProps<T extends HeadTag['props']>(props: T): Promise<T> {

--- a/test/unhead/e2e/double-space-class-list.test.ts
+++ b/test/unhead/e2e/double-space-class-list.test.ts
@@ -1,0 +1,135 @@
+import { describe, it } from 'vitest'
+import { createHead, useServerHead } from 'unhead'
+import { renderSSRHead } from '@unhead/ssr'
+import { renderDOMHead } from '@unhead/dom'
+import { useDom } from '../../fixtures'
+
+describe('e2e double-space-class-list', () => {
+  it('arrays', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useServerHead({
+      htmlAttrs: {
+        class: 'a bunch of  different classes'
+      },
+      bodyAttrs: {
+        class: [
+          // make sure we support this, just in case
+          'foo   bar  baz',
+          'relative   min-h-screen'
+        ]
+      }
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": " class=\\"foo bar baz relative min-h-screen\\"",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "",
+        "htmlAttrs": " class=\\"a bunch of different classes\\"",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      bodyAttrs: {
+        class: [
+          // make sure we support this, just in case
+          'foo   bar  baz',
+          'relative   min-h-screen'
+        ]
+      }
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html class=\\"a bunch of different classes\\"><head>
+
+      </head>
+      <body class=\\"foo bar baz relative min-h-screen\\">
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+
+  it('objects', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useServerHead({
+      htmlAttrs: {
+        class: {
+          'a bunch of  different classes': true,
+        }
+      },
+      bodyAttrs: {
+        class: {
+          'foo          bar': true,
+          ' baz ': false,
+        }
+      }
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": " class=\\"foo bar\\"",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "",
+        "htmlAttrs": " class=\\"a bunch of different classes\\"",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      htmlAttrs: {
+        class: {
+          'a bunch of  different classes': true,
+        }
+      },
+      bodyAttrs: {
+        class: {
+          'foo          bar': true,
+          ' baz ': false,
+        }
+      }
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html class=\\"a bunch of different classes\\"><head>
+
+      </head>
+      <body class=\\"foo bar\\">
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+
+})


### PR DESCRIPTION
## Issue

Fixes #104

## Description

The `class` API is quite powerful in Unhead, it allows you to provide a class as a class list string, an array of classes, an array of class list strings, or an object, where the key can either be a class or a class list.

When providing a class list, it's possible that empty spaces are introduced. These are currently causing errors in the DOM (see #104).

This PR fixes that issue and properly normalises it before SSR or DOM rendering.

```ts
useHead({
  htmlAttrs: {
    class: {
      'a bunch of  different classes': true,
    }
  },
  bodyAttrs: {
    class: ['foo bar ', ' baz ']
  }
})
```
