### PR TITLE
feat: improved inner content handling

### DIFF
--- a/packages/dom/src/renderDOMHead.ts
+++ b/packages/dom/src/renderDOMHead.ts
@@ -16,7 +16,7 @@ export interface RenderDomHeadOptions {
 }
 
 export function hashTag(tag: HeadTag) {
-  const str = `${tag.children || ''}:${Object.entries(tag.props).map(([key, value]) => `${key}:${String(value)}`).join(',')}`
+  const str = `${tag.textContent || tag.innerHTML || ''}:${Object.entries(tag.props).map(([key, value]) => `${key}:${String(value)}`).join(',')}`
   return `${tag.tag}:${hashCode(str)}`
 }
 
@@ -90,7 +90,7 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
     // 1. render tags which don't create a new element
     if (tag.tag === 'title') {
       // we don't handle title side effects
-      dom.title = tag.children || ''
+      dom.title = tag.textContent || ''
       renders.push(ctx)
       continue
     }

--- a/packages/dom/src/setAttrs.ts
+++ b/packages/dom/src/setAttrs.ts
@@ -38,8 +38,9 @@ export const setAttrs = (ctx: DomRenderTagContext, newEntry = false, markSideEff
   })
   // @todo test side effects?
   if (TagsWithInnerContent.includes(tag.tag)) {
-    const html = tag.children || ''
-    if (newEntry || $el.innerHTML !== html)
-      $el.innerHTML = html
+    if (tag.textContent && tag.textContent !== $el.textContent)
+      $el.textContent = tag.textContent
+    else if (tag.innerHTML && (tag.innerHTML !== $el.innerHTML))
+      $el.innerHTML = tag.innerHTML
   }
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -3,6 +3,6 @@ export * from './tags'
 export * from './head'
 export * from './hooks'
 
-export type { MergeHead, TagKey, DataKeys, DefinedValueOrEmptyObject, SpeculationRules } from 'zhead'
+export type { MergeHead, DataKeys, DefinedValueOrEmptyObject, SpeculationRules } from 'zhead'
 
 export {}

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -111,20 +111,20 @@ export interface Head<E extends MergeHead = SchemaAugmentations> {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
    */
-  style?: Style<E['style']>[]
+  style?: (Style<E['style']> | string)[]
   /**
    * The <script> HTML element is used to embed executable code or data; this is typically used to embed or refer to JavaScript code.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
    */
-  script?: Script<E['script']>[]
+  script?: (Script<E['script']> | string)[]
   /**
    * The <noscript> HTML element defines a section of HTML to be inserted if a script type on the page is unsupported
    * or if scripting is currently turned off in the browser.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript
    */
-  noscript?: Noscript<E['noscript']>[]
+  noscript?: (Noscript<E['noscript']> | string)[]
   /**
    * Attributes for the <html> HTML element.
    *

--- a/packages/schema/src/tags.ts
+++ b/packages/schema/src/tags.ts
@@ -1,4 +1,4 @@
-import type { HeadTag as BaseHeadTag, MaybePromiseProps } from 'zhead'
+import type { Head, MaybePromiseProps } from 'zhead'
 
 export interface ResolvesDuplicates {
   /**
@@ -45,19 +45,19 @@ export interface InnerContent {
   /**
    * Text content of the tag.
    *
-   * Alias for children
+   * Warning: This is not safe for XSS. Do not use this with user input, use `textContent` instead.
    */
   innerHTML?: InnerContentVal
   /**
-   * Sets the textContent of an element.
-   */
-  children?: InnerContentVal
-  /**
-   * Sets the textContent of an element. This will be HTML encoded.
-   *
-   * Alias for children
+   * Sets the textContent of an element. Safer for XSS.
    */
   textContent?: InnerContentVal
+  /**
+   * Sets the textContent of an element.
+   *
+   * @deprecated Use `textContent` or `innerHTML`.
+   */
+  children?: InnerContentVal
 }
 
 export interface TagPriority {
@@ -77,7 +77,9 @@ export interface TagPriority {
 
 export type TagUserProperties = TagPriority & TagPosition & MaybePromiseProps<InnerContent> & ResolvesDuplicates
 
-export interface TagInternalProperties {
+export type TagKey = keyof Head
+
+export interface HeadTag extends TagPriority, TagPosition, ResolvesDuplicates {
   /**
    * Entry ID
    */
@@ -90,8 +92,10 @@ export interface TagInternalProperties {
    * Dedupe key
    */
   _d?: string
+  tag: TagKey
+  props: Record<string, string>
+  innerHTML?: string
+  textContent?: string
 }
-
-export type HeadTag = BaseHeadTag & TagUserProperties & TagInternalProperties
 
 export type HeadTagKeys = (keyof HeadTag)[]

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -23,4 +23,4 @@ export const ValidHeadTags = [
 
 export const UniqueTags = ['base', 'title', 'titleTemplate', 'bodyAttrs', 'htmlAttrs']
 
-export const TagConfigKeys = ['tagPosition', 'tagPriority', 'tagDuplicateStrategy']
+export const TagConfigKeys = ['tagPosition', 'tagPriority', 'tagDuplicateStrategy', 'innerHTML', 'textContent']

--- a/packages/shared/src/dedupesTagsPlugin.ts
+++ b/packages/shared/src/dedupesTagsPlugin.ts
@@ -95,7 +95,7 @@ export const DedupesTagsPlugin = (options?: DedupesTagsPluginOptions) => {
             }
             const propCount = Object.keys(tag.props).length
             // if the new tag does not have any props, we're trying to remove the dupedTag
-            if (((propCount === 0) || (propCount === 1 && typeof tag.props['data-h-key'] !== 'undefined')) && !tag.children) {
+            if (((propCount === 0) || (propCount === 1 && typeof tag.props['data-h-key'] !== 'undefined')) && !tag.innerHTML && !tag.textContent) {
               delete deduping[dedupeKey]
               return
             }

--- a/packages/ssr/src/util/tagToString.ts
+++ b/packages/ssr/src/util/tagToString.ts
@@ -22,7 +22,7 @@ export function encodeInnerHtml(str: string) {
         return '&gt;'
       case '"':
         return '&quot;'
-      case "'":
+      case '\'':
         return '&#x27;'
       case '/':
         return '&#x2F;'
@@ -39,9 +39,10 @@ export const tagToString = <T extends HeadTag>(tag: T) => {
   if (!TagsWithInnerContent.includes(tag.tag))
     return SelfClosingTags.includes(tag.tag) ? openTag : `${openTag}</${tag.tag}>`
 
-  let content = tag.children || ''
-  if (content && tag.tag === 'title')
+  // dangerously using innerHTML, we don't encode this
+  let content = tag.innerHTML || ''
+  if (tag.textContent)
     // content needs to be encoded to avoid XSS, only for title
-    content = encodeInnerHtml(content)
+    content = encodeInnerHtml(tag.textContent)
   return SelfClosingTags.includes(tag.tag) ? openTag : `${openTag}${content}</${tag.tag}>`
 }

--- a/packages/unhead/src/plugin/titleTemplatePlugin.ts
+++ b/packages/unhead/src/plugin/titleTemplatePlugin.ts
@@ -21,11 +21,11 @@ export const TitleTemplatePlugin = () => {
         const titleIdx = tags.findIndex(i => i.tag === 'title')
         if (titleIdx !== -1 && titleTemplateIdx !== -1) {
           const newTitle = renderTitleTemplate(
-            tags[titleTemplateIdx].children!,
-            tags[titleIdx].children,
+            tags[titleTemplateIdx].textContent!,
+            tags[titleIdx].textContent,
           )
           if (newTitle !== null) {
-            tags[titleIdx].children = newTitle || tags[titleIdx].children
+            tags[titleIdx].textContent = newTitle || tags[titleIdx].textContent
           }
           else {
             // remove the title tag
@@ -35,10 +35,10 @@ export const TitleTemplatePlugin = () => {
         // titleTemplate is set but title is not set, convert to a title
         else if (titleTemplateIdx !== -1) {
           const newTitle = renderTitleTemplate(
-            tags[titleTemplateIdx].children!,
+            tags[titleTemplateIdx].textContent!,
           )
           if (newTitle !== null) {
-            tags[titleTemplateIdx].children = newTitle
+            tags[titleTemplateIdx].textContent = newTitle
             tags[titleTemplateIdx].tag = 'title'
             titleTemplateIdx = -1
           }

--- a/packages/vue/src/types/schema.ts
+++ b/packages/vue/src/types/schema.ts
@@ -70,20 +70,20 @@ export interface ReactiveHead<E extends MergeHead = MergeHead> {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
    */
-  style?: MaybeComputedRef<Style<E['style']>[]>
+  style?: MaybeComputedRef<(Style<E['style']> | string)[]>
   /**
    * The <script> HTML element is used to embed executable code or data; this is typically used to embed or refer to JavaScript code.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
    */
-  script?: MaybeComputedRef<Script<E['script']>[]>
+  script?: MaybeComputedRef<(Script<E['script']> | string)[]>
   /**
    * The <noscript> HTML element defines a section of HTML to be inserted if a script type on the page is unsupported
    * or if scripting is currently turned off in the browser.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript
    */
-  noscript?: MaybeComputedRef<Noscript<E['noscript']>[]>
+  noscript?: MaybeComputedRef<(Noscript<E['noscript']> | string)[]>
   /**
    * Attributes for the <html> HTML element.
    *

--- a/test/unhead/e2e/json.test.ts
+++ b/test/unhead/e2e/json.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from 'vitest'
+import { createHead, useHead } from 'unhead'
+import { renderSSRHead } from '@unhead/ssr'
+import { renderDOMHead } from '@unhead/dom'
+import { useDom } from '../../fixtures'
+
+describe('unhead e2e json', () => {
+  it('pretend json', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useHead({
+      script: [
+        {
+          key: 'json',
+          type: 'application/ld+json',
+          children: 'pretend json',
+        },
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<script type=\\"application/ld+json\\"></script>",
+        "htmlAttrs": "",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      script: [
+        {
+          key: 'json',
+          type: 'application/ld+json',
+          children: 'pretend json',
+        },
+      ],
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <script type=\\"application/ld+json\\"></script>
+      <script type=\\"application/ld+json\\"></script></head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+})

--- a/test/unhead/e2e/shorthands.test.ts
+++ b/test/unhead/e2e/shorthands.test.ts
@@ -1,0 +1,155 @@
+import { describe, it } from 'vitest'
+import { createHead, useHead } from 'unhead'
+import { renderSSRHead } from '@unhead/ssr'
+import { renderDOMHead } from '@unhead/dom'
+import { useDom } from '../../fixtures'
+
+describe('unhead e2e shorthands', () => {
+  it('css', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useHead({
+      style: [
+        '.test { color: red; }'
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<style>.test { color: red; }</style>",
+        "htmlAttrs": "",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      style: [
+        '.test { color: red; }'
+      ],
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <style>.test { color: red; }</style>
+      <style>.test { color: red; }</style></head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+  it('script', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useHead({
+      script: [
+        'console.log(\'Hello World\')'
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<script>console.log('Hello World')</script>",
+        "htmlAttrs": "",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      script: [
+        'console.log(\'Hello World\')'
+      ],
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <script>console.log('Hello World')</script>
+      <script>console.log('Hello World')</script></head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+  it('noscript', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useHead({
+      noscript: [
+        '<iframe src="https://www.googletagmanager.com/ns.html?${serialize(params)}" height="0" width="0" style="display:none;visibility:hidden"></iframe>'
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<noscript><iframe src=\\"https://www.googletagmanager.com/ns.html?\${serialize(params)}\\" height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"></iframe></noscript>",
+        "htmlAttrs": "",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      noscript: [
+        '<iframe src="https://www.googletagmanager.com/ns.html?${serialize(params)}" height="0" width="0" style="display:none;visibility:hidden"></iframe>'
+      ],
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <noscript></noscript><noscript>&lt;iframe src=\\"https://www.googletagmanager.com/ns.html?\${serialize(params)}\\" height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"&gt;&lt;/iframe&gt;</noscript></head><body><iframe src=\\"https://www.googletagmanager.com/ns.html?\${serialize(params)}\\" height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"></iframe>
+
+
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+})

--- a/test/unhead/e2e/textContent.test.ts
+++ b/test/unhead/e2e/textContent.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from 'vitest'
+import { createHead, useHead } from 'unhead'
+import { renderSSRHead } from '@unhead/ssr'
+import { renderDOMHead } from '@unhead/dom'
+import { useDom } from '../../fixtures'
+
+describe('unhead e2e textContent', () => {
+  it('pretend json', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useHead({
+      style: [
+        {
+          textContent: '.test { color: red; }',
+        },
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<style>.test { color: red; }</style>",
+        "htmlAttrs": "",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      style: [
+        {
+          textContent: '.test { color: red; }',
+        },
+      ],
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <style>.test { color: red; }</style>
+      <style>.test { color: red; }</style></head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+})

--- a/test/unhead/hooks/infer-seo-meta.test.ts
+++ b/test/unhead/hooks/infer-seo-meta.test.ts
@@ -21,7 +21,7 @@ describe('hooks', () => {
     expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
 
-      <title>Hello World</title><meta name=\\"description\\" content=\\"description\\"><meta property=\\"og:title\\" content=\\"Hello World\\"><meta name=\\"og:description\\" content=\\"description\\"><meta name=\\"robots\\" content=\\"max-snippet: -1; max-image-preview: large; max-video-preview: -1\\"></head>
+      <title>Hello World</title><meta name=\\"robots\\" content=\\"max-snippet: -1; max-image-preview: large; max-video-preview: -1\\"><meta name=\\"description\\" content=\\"description\\"><meta property=\\"og:title\\" content=\\"Hello World\\"><meta property=\\"og:description\\" content=\\"description\\"></head>
       <body>
 
       <div>

--- a/test/unhead/promises.test.ts
+++ b/test/unhead/promises.test.ts
@@ -20,9 +20,9 @@ describe('promises', () => {
           "_d": "title",
           "_e": 0,
           "_p": 0,
-          "children": "hello",
           "props": {},
           "tag": "title",
+          "textContent": "hello",
         },
         {
           "_e": 0,
@@ -35,7 +35,7 @@ describe('promises', () => {
         {
           "_e": 0,
           "_p": 2,
-          "children": "test",
+          "innerHTML": "test",
           "props": {},
           "tag": "script",
         },

--- a/test/unhead/resolveTags.test.ts
+++ b/test/unhead/resolveTags.test.ts
@@ -22,9 +22,9 @@ describe('resolveTags', () => {
           "_d": "title",
           "_e": 0,
           "_p": 0,
-          "children": "My title",
           "props": {},
           "tag": "title",
+          "textContent": "My title",
         },
         {
           "_d": "meta:name:description",

--- a/test/vue/dom/keepalive.test.ts
+++ b/test/vue/dom/keepalive.test.ts
@@ -52,9 +52,9 @@ describe('keepalive', () => {
           "_d": "title",
           "_e": 0,
           "_p": 0,
-          "children": "home",
           "props": {},
           "tag": "title",
+          "textContent": "home",
         },
       ]
     `
@@ -64,9 +64,9 @@ describe('keepalive', () => {
           "_d": "title",
           "_e": 1,
           "_p": 1024,
-          "children": "about",
           "props": {},
           "tag": "title",
+          "textContent": "about",
         },
       ]
     `

--- a/test/vue/e2e/shorthands.test.ts
+++ b/test/vue/e2e/shorthands.test.ts
@@ -1,0 +1,155 @@
+import { describe, it } from 'vitest'
+import { createHead, useHead } from '@unhead/vue'
+import { renderSSRHead } from '@unhead/ssr'
+import { renderDOMHead } from '@unhead/dom'
+import { useDom } from '../../fixtures'
+
+describe('unhead vue e2e shorthands', () => {
+  it('css', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useHead({
+      style: [
+        '.test { color: red; }'
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<style>.test { color: red; }</style>",
+        "htmlAttrs": "",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      style: [
+        '.test { color: red; }'
+      ],
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <style>.test { color: red; }</style>
+      <style>.test { color: red; }</style></head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+  it('script', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useHead({
+      script: [
+        'console.log(\'Hello World\')'
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<script>console.log('Hello World')</script>",
+        "htmlAttrs": "",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      script: [
+        'console.log(\'Hello World\')'
+      ],
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <script>console.log('Hello World')</script>
+      <script>console.log('Hello World')</script></head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+  it('noscript', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createHead()
+    // i.e App.vue
+    useHead({
+      noscript: [
+        '<iframe src="https://www.googletagmanager.com/ns.html?${serialize(params)}" height="0" width="0" style="display:none;visibility:hidden"></iframe>'
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<noscript><iframe src=\\"https://www.googletagmanager.com/ns.html?\${serialize(params)}\\" height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"></iframe></noscript>",
+        "htmlAttrs": "",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createHead()
+    csrHead.push({
+      noscript: [
+        '<iframe src="https://www.googletagmanager.com/ns.html?${serialize(params)}" height="0" width="0" style="display:none;visibility:hidden"></iframe>'
+      ],
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <noscript></noscript><noscript>&lt;iframe src=\\"https://www.googletagmanager.com/ns.html?\${serialize(params)}\\" height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"&gt;&lt;/iframe&gt;</noscript></head><body><iframe src=\\"https://www.googletagmanager.com/ns.html?\${serialize(params)}\\" height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"></iframe>
+
+
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+})

--- a/test/vue/promises.test.ts
+++ b/test/vue/promises.test.ts
@@ -20,9 +20,9 @@ describe('vue promises', () => {
           "_d": "title",
           "_e": 0,
           "_p": 0,
-          "children": "hello",
           "props": {},
           "tag": "title",
+          "textContent": "hello",
         },
         {
           "_e": 0,
@@ -35,7 +35,7 @@ describe('vue promises', () => {
         {
           "_e": 0,
           "_p": 2,
-          "children": "test",
+          "innerHTML": "test",
           "props": {},
           "tag": "script",
         },


### PR DESCRIPTION
## Description
We want to make providing inner content more intuitive, it should:
- have a closer mapping to the DOM attributes `innerHTML` and `textContent`, this will make it more obvious to end users the expected behavior of their code
- provide automatic sanitisation when it is safe to do so (i.e JSON can be safely sanitisated)
- minimise the amount of boilerplate for simple embeddings

With these changes:

- `children` is deprecated, you should use `innerHTML` or `textContent`

```diff
useHead({
  script: [
    {
-        children: 'console.log("hello world")' 
+       innerHTML: 'console.log("hello world")'
    }
  ]
})
```

- when passing in script content that is either `application/json` or `application/ld+json`, it will be sanitized to be valid JSON

```ts
useHead({
  script: [
    {
       type: 'application/json',
       // will be sanitised 
       innerHTML: "should be json",
    }
  ]
})
```

- `textContent` will properly set `.textContent` instead of `innerHTML` now, this provides basic sanitization. Internally this is used for `<title>`

- `script`, `noscript`, `style` now supports a simpler syntax

```ts
useHead({
  style: [
    'body { background-color: red; }'
  ],
  script: [
   'console.log("hello world")'
  ]
})
```
