### PR TITLE
fix(useSeoMeta): use correct og tag for site name

### DIFF
--- a/packages/unhead/src/utils/meta/utils.ts
+++ b/packages/unhead/src/utils/meta/utils.ts
@@ -26,6 +26,9 @@ export const MetaPackingSchema: Record<string, PackingDefinition> = {
     keyValue: 'fb:app_id',
     metaKey: 'property',
   },
+  ogSiteName: {
+    keyValue: 'og:site_name'
+  },
   msapplicationTileImage: {
     keyValue: 'msapplication-TileImage',
   },

--- a/test/unhead/ssr/composables.test.ts
+++ b/test/unhead/ssr/composables.test.ts
@@ -59,6 +59,7 @@ describe('composables', () => {
       charset: 'utf-8',
       description: 'test',
       ogLocaleAlternate: ['fr', 'zh'],
+      ogSiteName: 'Example Name'
     })
 
     const ctx = await renderSSRHead(head)
@@ -70,7 +71,8 @@ describe('composables', () => {
         "headTags": "<meta charset=\\"utf-8\\">
       <meta name=\\"description\\" content=\\"test\\">
       <meta property=\\"og:locale:alternate\\" content=\\"fr\\">
-      <meta property=\\"og:locale:alternate\\" content=\\"zh\\">",
+      <meta property=\\"og:locale:alternate\\" content=\\"zh\\">
+      <meta property=\\"og:site_name\\" content=\\"Example Name\\">",
         "htmlAttrs": "",
       }
     `)


### PR DESCRIPTION
The `og:site_name` key was not resolved correctly, instead `og:site:name` was used. This should be fixed with this PR.

Resolves https://github.com/nuxt/nuxt/issues/19460