### PR TITLE
fix(unhead): support templateParams in `link` tags

### DIFF
--- a/packages/unhead/src/createHead.ts
+++ b/packages/unhead/src/createHead.ts
@@ -25,9 +25,9 @@ import { IsBrowser } from './env'
 
 export const CorePlugins = () => [
   // dedupe needs to come first
-  TemplateParamsPlugin(),
   DedupesTagsPlugin(),
   SortTagsPlugin(),
+  TemplateParamsPlugin(),
   TitleTemplatePlugin(),
   ProvideTagHashPlugin(),
   EventHandlersPlugin(),

--- a/packages/unhead/src/createHead.ts
+++ b/packages/unhead/src/createHead.ts
@@ -25,9 +25,9 @@ import { IsBrowser } from './env'
 
 export const CorePlugins = () => [
   // dedupe needs to come first
+  TemplateParamsPlugin(),
   DedupesTagsPlugin(),
   SortTagsPlugin(),
-  TemplateParamsPlugin(),
   TitleTemplatePlugin(),
   ProvideTagHashPlugin(),
   EventHandlersPlugin(),

--- a/packages/unhead/src/plugin/templateParamsPlugin.ts
+++ b/packages/unhead/src/plugin/templateParamsPlugin.ts
@@ -56,6 +56,9 @@ export function TemplateParamsPlugin() {
           else if (tag.tag === 'meta' && typeof tag.props.content === 'string') {
             tag.props.content = processTemplateParams(tag.props.content, params)
           }
+          else if (tag.tag === 'link' && typeof tag.props.href === 'string') {
+            tag.props.href = processTemplateParams(tag.props.href, params)
+          }
           else if (tag.tag === 'script' && ['application/json', 'application/ld+json'].includes(tag.props.type) && typeof tag.innerHTML === 'string') {
             try {
               tag.innerHTML = JSON.stringify(JSON.parse(tag.innerHTML), (key, val) => {

--- a/test/unhead/dom/templateParams.test.ts
+++ b/test/unhead/dom/templateParams.test.ts
@@ -54,6 +54,11 @@ describe('templateParams', () => {
       ],
     })
 
+    useHead({
+      templateParams: {
+        path: '/some/other/page',
+      },
+    })
     expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
 

--- a/test/unhead/dom/templateParams.test.ts
+++ b/test/unhead/dom/templateParams.test.ts
@@ -38,6 +38,10 @@ describe('templateParams', () => {
           content: 'Welcome to %site.name.',
         },
         {
+          property: 'og:image',
+          content: 'https://firebasestorage.googleapis.com/v0/b/buuger.appspot.com/o/accounts%2Ffotobuukmy%2Fseries%2Fwedding-studio%2Fbuuks%2Fapril-film-studio%2Fcover.jpg?alt=media&token=8b93a6d5-dec2-4f28-9792-4568d73eeb5b',
+        },
+        {
           property: 'og:site_name',
           content: '%site.name',
         },
@@ -54,15 +58,10 @@ describe('templateParams', () => {
       ],
     })
 
-    useHead({
-      templateParams: {
-        path: '/some/other/page',
-      },
-    })
     expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
 
-      <title>My Page - My Site</title><script id=\\"site-data\\" type=\\"application/json\\">{\\"pageTitle\\":\\"My Page\\",\\"siteName\\":\\"My Site\\",\\"siteUrl\\":\\"https://example.com\\"}</script><meta property=\\"twitter:image\\" content=\\"https://cdn.example.com/some%20image.jpg\\"><meta name=\\"description\\" content=\\"Welcome to My Site.\\"><meta property=\\"og:site_name\\" content=\\"My Site\\"><meta property=\\"og:url\\" content=\\"https://example.com/my-page\\"><link rel=\\"canonical\\" href=\\"https://example.com/some/page\\"></head>
+      <title>My Page - My Site</title><script id=\\"site-data\\" type=\\"application/json\\">{\\"pageTitle\\":\\"My Page\\",\\"siteName\\":\\"My Site\\",\\"siteUrl\\":\\"https://example.com\\"}</script><meta property=\\"twitter:image\\" content=\\"https://cdn.example.com/some%20image.jpg\\"><meta name=\\"description\\" content=\\"Welcome to My Site.\\"><meta property=\\"og:image\\" content=\\"https://firebasestorage.googleapis.com/v0/b/buuger.appspot.com/o/accounts%2Ffotobuukmy%2Fseries%2Fwedding-studio%2Fbuuks%2Fapril-film-studio%2Fcover.jpg?alt=media&amp;token=8b93a6d5-dec2-4f28-9792-4568d73eeb5b\\"><meta property=\\"og:site_name\\" content=\\"My Site\\"><meta property=\\"og:url\\" content=\\"https://example.com/my-page\\"><link rel=\\"canonical\\" href=\\"https://example.com/some/page\\"></head>
       <body>
 
       <div>
@@ -125,6 +124,48 @@ describe('templateParams', () => {
       "<!DOCTYPE html><html><head>
 
       <title>Home &amp; //&lt;\\"With Encoding\\"&gt;\\\\</title><script type=\\"application/json\\">{\\"title\\":\\"Home & //<\\\\\\"With Encoding\\\\\\">\\\\\\\\\\"}</script></head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+
+  it('inheritance', async () => {
+    useDOMHead()
+
+    useHead({
+      templateParams: {
+        site: {
+          name: 'My Site',
+          url: 'https://example.com',
+        },
+        separator: '-',
+        path: '',
+      },
+      meta: [
+        {
+          property: 'og:url',
+          content: '%site.url%path',
+        },
+      ],
+    })
+
+    useHead({
+      templateParams: {
+        path: '/some/page',
+      },
+    })
+
+    expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+
+      <meta property=\\"og:url\\" content=\\"https://example.com/some/page\\"></head>
       <body>
 
       <div>

--- a/test/unhead/dom/templateParams.test.ts
+++ b/test/unhead/dom/templateParams.test.ts
@@ -13,6 +13,7 @@ describe('templateParams', () => {
           url: 'https://example.com',
         },
         separator: '-',
+        path: '/some/page',
       },
       title: 'My Page',
       titleTemplate: '%s %separator %site.name',
@@ -45,12 +46,18 @@ describe('templateParams', () => {
           content: '%site.url/my-page',
         },
       ],
+      link: [
+        {
+          rel: 'canonical',
+          href: '%site.url%path',
+        },
+      ],
     })
 
     expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
 
-      <title>My Page - My Site</title><script id=\\"site-data\\" type=\\"application/json\\">{\\"pageTitle\\":\\"My Page\\",\\"siteName\\":\\"My Site\\",\\"siteUrl\\":\\"https://example.com\\"}</script><meta property=\\"twitter:image\\" content=\\"https://cdn.example.com/some%20image.jpg\\"><meta name=\\"description\\" content=\\"Welcome to My Site.\\"><meta property=\\"og:site_name\\" content=\\"My Site\\"><meta property=\\"og:url\\" content=\\"https://example.com/my-page\\"></head>
+      <title>My Page - My Site</title><script id=\\"site-data\\" type=\\"application/json\\">{\\"pageTitle\\":\\"My Page\\",\\"siteName\\":\\"My Site\\",\\"siteUrl\\":\\"https://example.com\\"}</script><meta property=\\"twitter:image\\" content=\\"https://cdn.example.com/some%20image.jpg\\"><meta name=\\"description\\" content=\\"Welcome to My Site.\\"><meta property=\\"og:site_name\\" content=\\"My Site\\"><meta property=\\"og:url\\" content=\\"https://example.com/my-page\\"><link rel=\\"canonical\\" href=\\"https://example.com/some/page\\"></head>
       <body>
 
       <div>


### PR DESCRIPTION
Added support for templateParams plugin in link tags. E.g.

```
useHead({
      templateParams: {
        site: {
          name: 'My Site',
          url: 'https://example.com',
        },
        separator: '-',
        path: '/some/page',
      },
      link: [
        {
          rel: 'canonical',
          href: '%site.url%path',
        },
      ],
    })
```