### PR TITLE
fix(unhead): dedupe logic regression

### DIFF
--- a/packages/dom/src/renderDOMHead.ts
+++ b/packages/dom/src/renderDOMHead.ts
@@ -76,7 +76,7 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
   function setupTagRenderCtx(tag: HeadTag) {
     const entry = head.headEntries().find(e => e._i === tag._e)
     const renderCtx: DomRenderTagContext = {
-      renderId: tag._d || hashTag(tag),
+      renderId: (!tag.key && tag._d) ? tag._d : hashTag(tag),
       $el: null,
       shouldRender: true,
       tag,

--- a/packages/unhead/src/plugin/provideTagHashPlugin.ts
+++ b/packages/unhead/src/plugin/provideTagHashPlugin.ts
@@ -1,4 +1,4 @@
-import { HasElementTags, defineHeadPlugin, hashTag } from '@unhead/shared'
+import { defineHeadPlugin, hashCode, hashTag } from '@unhead/shared'
 import { getActiveHead } from '..'
 import { IsBrowser } from '../env'
 
@@ -6,37 +6,29 @@ export const ProvideTagHashPlugin = () => {
   return defineHeadPlugin({
     hooks: {
       'tag:normalise': (ctx) => {
-        const { tag, entry, resolvedOptions } = ctx
+        const { tag, resolvedOptions } = ctx
 
         if (resolvedOptions.experimentalHashHydration === true) {
           // always generate a hash
           tag._h = hashTag(tag)
         }
 
-        const isDynamic = typeof tag.props._dynamic !== 'undefined'
-        // only valid tags with a key
-        if (!HasElementTags.includes(tag.tag) || !tag.key)
+        // only tags which can't dedupe themselves, ssr only
+        if (![
+          'link',
+          'style',
+          'script',
+          'noscript',
+        ].includes(tag.tag) || !tag.key || IsBrowser || getActiveHead()?.resolvedOptions?.document)
           return
 
-        // ssr only from here
-        if (IsBrowser || getActiveHead()?.resolvedOptions?.document)
-          return
 
         // when we are SSR rendering tags which are server only and have a dedupe key, we need to provide a hash
         // client side should not be here if the entry is server mode (entry should be ignored)
         // if a user provides a key we will also add the hash as a way to ensure hydration works, good for
         // when SSR / CSR does not match
-        if (entry._m === 'server' || isDynamic) {
-          tag._h = tag._h || hashTag(tag)
-          tag.props[`data-h-${tag._h}`] = ''
-        }
-      },
-      'tags:resolve': (ctx) => {
-        // remove dynamic prop
-        ctx.tags = ctx.tags.map((t) => {
-          delete t.props._dynamic
-          return t
-        })
+        tag._h = hashCode(tag.key)
+        tag.props[`data-h-${tag._h}`] = ''
       },
     },
   })

--- a/packages/unhead/src/plugin/provideTagHashPlugin.ts
+++ b/packages/unhead/src/plugin/provideTagHashPlugin.ts
@@ -1,6 +1,5 @@
 import { defineHeadPlugin, hashCode, hashTag } from '@unhead/shared'
 import { getActiveHead } from '..'
-import { IsBrowser } from '../env'
 
 export const ProvideTagHashPlugin = () => {
   return defineHeadPlugin({

--- a/packages/unhead/src/plugin/provideTagHashPlugin.ts
+++ b/packages/unhead/src/plugin/provideTagHashPlugin.ts
@@ -19,7 +19,7 @@ export const ProvideTagHashPlugin = () => {
           'style',
           'script',
           'noscript',
-        ].includes(tag.tag) || !tag.key || IsBrowser || getActiveHead()?.resolvedOptions?.document)
+        ].includes(tag.tag) || !tag.key || getActiveHead()?.resolvedOptions?.document)
           return
 
 

--- a/packages/unhead/src/utils/normalise.ts
+++ b/packages/unhead/src/utils/normalise.ts
@@ -1,5 +1,5 @@
 import type { Head, HeadEntry, HeadTag } from '@unhead/schema'
-import { TagConfigKeys, TagsWithInnerContent, ValidHeadTags, asArray, hashCode } from '@unhead/shared'
+import { TagConfigKeys, TagsWithInnerContent, ValidHeadTags, asArray } from '@unhead/shared'
 
 export async function normaliseTag<T extends HeadTag>(tagName: T['tag'], input: HeadTag['props'] | string): Promise<T | T[] | false> {
   const tag = { tag: tagName, props: {} } as T
@@ -19,13 +19,12 @@ export async function normaliseTag<T extends HeadTag>(tagName: T['tag'], input: 
       return false
 
     // if string starts with "/", "http://" or "https://" then assume it's a src
-    if (tagName === 'script' && (/^(https?:)?\/\//.test(input) || input.startsWith('/'))) {
+    if (tagName === 'script' && (/^(https?:)?\/\//.test(input) || input.startsWith('/')))
       tag.props.src = input
-    }
-    else {
+
+    else
       tag.innerHTML = input
-      tag.key = hashCode(input)
-    }
+
     return tag
   }
 

--- a/packages/vue/src/utils.ts
+++ b/packages/vue/src/utils.ts
@@ -1,5 +1,4 @@
-import { isRef, unref } from 'vue'
-import { HasElementTags } from '@unhead/shared'
+import { unref } from 'vue'
 
 // copied from @vueuse/shared
 function resolveUnref(r: any) {
@@ -18,23 +17,14 @@ export function resolveUnrefHeadInput(ref: any, lastKey: string | number = ''): 
     return root.map(r => resolveUnrefHeadInput(r, lastKey))
 
   if (typeof root === 'object') {
-    let dynamic = false
-    const unrefdObj = Object.fromEntries(
+    return Object.fromEntries(
       Object.entries(root).map(([k, v]) => {
-        // title template and raw dom events should stay function, we support a ref'd string though
+        // title template and raw dom events should stay functions, we support a ref'd string though
         if (k === 'titleTemplate' || k.startsWith('on'))
           return [k, unref(v)]
-        if (typeof v === 'function' || isRef(v))
-          dynamic = true
-
         return [k, resolveUnrefHeadInput(v, k)]
       }),
     )
-    // flag any tags which are dynamic
-    if (dynamic && HasElementTags.includes(String(lastKey)))
-      unrefdObj._dynamic = true
-
-    return unrefdObj
   }
   return root
 }

--- a/test/unhead/e2e/json.test.ts
+++ b/test/unhead/e2e/json.test.ts
@@ -27,7 +27,7 @@ describe('unhead e2e json', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<script type=\\"application/ld+json\\"></script>",
+        "headTags": "<script type=\\"application/ld+json\\" data-h-7632c5f=\\"\\"></script>",
         "htmlAttrs": "",
       }
     `)
@@ -49,8 +49,8 @@ describe('unhead e2e json', () => {
 
     expect(dom.serialize()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
-      <script type=\\"application/ld+json\\"></script>
-      <script type=\\"application/ld+json\\"></script></head>
+      <script type=\\"application/ld+json\\" data-h-7632c5f=\\"\\"></script>
+      </head>
       <body>
 
       <div>

--- a/test/unhead/ssr/deduping.test.ts
+++ b/test/unhead/ssr/deduping.test.ts
@@ -210,7 +210,7 @@ describe('dedupe', () => {
     expect(headTags).toMatchInlineSnapshot(
       `
       "<meta name=\\"description\\" content=\\"test\\">
-      <link rel=\\"icon\\" href=\\"/favicon.ico\\">"
+      <link rel=\\"icon\\" href=\\"/favicon.ico\\" data-h-e16a2dd=\\"\\">"
     `,
     )
   })

--- a/test/unhead/ssr/tagPriority.test.ts
+++ b/test/unhead/ssr/tagPriority.test.ts
@@ -193,7 +193,7 @@ describe('tag priority', () => {
     expect(headTags).toMatchInlineSnapshot(
       `
       "<script src=\\"/must-be-first-script.js\\"></script>
-      <script src=\\"/not-important-script.js\\"></script>"
+      <script src=\\"/not-important-script.js\\" data-h-99144d0=\\"\\"></script>"
     `,
     )
   })
@@ -235,10 +235,10 @@ describe('tag priority', () => {
     const { headTags } = await renderSSRHead(head)
     expect(headTags).toMatchInlineSnapshot(
       `
-      "<script src=\\"/must-be-first-script.js\\"></script>
+      "<script src=\\"/must-be-first-script.js\\" data-h-1ce209d=\\"\\"></script>
       <script src=\\"/after-first-script.js\\"></script>
       <script src=\\"/before-not-important.js\\"></script>
-      <script src=\\"/not-important-script.js\\"></script>"
+      <script src=\\"/not-important-script.js\\" data-h-99144d0=\\"\\"></script>"
     `,
     )
   })

--- a/test/vue/e2e/shorthands.test.ts
+++ b/test/vue/e2e/shorthands.test.ts
@@ -42,7 +42,7 @@ describe('unhead vue e2e shorthands', () => {
     expect(dom.serialize()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
       <style>.test { color: red; }</style>
-      <style>.test { color: red; }</style></head>
+      </head>
       <body>
 
       <div>
@@ -91,7 +91,7 @@ describe('unhead vue e2e shorthands', () => {
     expect(dom.serialize()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
       <script>console.log('Hello World')</script>
-      <script>console.log('Hello World')</script></head>
+      </head>
       <body>
 
       <div>

--- a/test/vue/ssr/deduping.test.ts
+++ b/test/vue/ssr/deduping.test.ts
@@ -26,7 +26,7 @@ describe('vue ssr deduping', () => {
     )
 
     expect(headResult.headTags).toMatchInlineSnapshot(
-      '"<script>console.log(\'B\')</script>"',
+      '"<script data-h-722c761=\\"\\">console.log(\'B\')</script>"',
     )
   })
 })


### PR DESCRIPTION
## Issue

https://github.com/unjs/unhead/issues/135

## Description

Something is quite wrong with the client hydration when you provide a key. Not sure when this regression occurs but it relates to some of the optimisations I did around determining if data needed the `data-h` key injected.