### PR TITLE
fix: change replaceAll to replace with regex

### DIFF
--- a/packages/unhead/src/plugin/templateParamsPlugin.ts
+++ b/packages/unhead/src/plugin/templateParamsPlugin.ts
@@ -29,7 +29,7 @@ export function processTemplateParams(s: string, config: TemplateParams) {
     const re = sub(token.slice(1))
     if (typeof re === 'string') {
       // replace the re using regex as word seperators
-      s = s.replaceAll(new RegExp(`\\${token}(\\W|$)`, 'g'), `${re}$1`).trim()
+      s = s.replace(new RegExp(`\\${token}(\\W|$)`, 'g'), `${re}$1`).trim()
     }
   })
 


### PR DESCRIPTION
replaceAll and replace are the same, when given a global regex to replace.

Closes https://github.com/unjs/unhead/issues/154