### PR TITLE
Broken github edit link

### DIFF
--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -14,6 +14,7 @@ export default defineAppConfig({
       repo: 'unhead',
       branch: 'main',
       edit: true,
+      dir: 'docs/content',
     },
     main: {
       fluid: true,


### PR DESCRIPTION
The documentation base folder was changed and this is not reflected in the configuration file.