### PR TITLE
fix(payload): remove redundant script type

### DIFF
--- a/packages/unhead/src/plugins/payload.ts
+++ b/packages/unhead/src/plugins/payload.ts
@@ -13,7 +13,7 @@ export default defineHeadPlugin(head => ({
       Object.keys(csrPayload).length && ctx.tags.push({
         tag: 'script',
         innerHTML: JSON.stringify(csrPayload),
-        props: { type: 'text/javascript', id: 'unhead:payload' },
+        props: { id: 'unhead:payload' },
       })
     },
   },

--- a/test/unhead/ssr/templateParams.test.ts
+++ b/test/unhead/ssr/templateParams.test.ts
@@ -67,7 +67,7 @@ describe('ssr templateParams', () => {
 
     expect(headTags).toMatchInlineSnapshot(`
       "<title>My Awesome Site</title>
-      <script type=\\"text/javascript\\" id=\\"unhead:payload\\">{\\"titleTemplate\\":\\"%s %separator %siteName\\",\\"templateParams\\":{\\"separator\\":\\"|\\",\\"siteName\\":\\"My Awesome Site\\"}}</script>"
+      <script id=\\"unhead:payload\\">{\\"titleTemplate\\":\\"%s %separator %siteName\\",\\"templateParams\\":{\\"separator\\":\\"|\\",\\"siteName\\":\\"My Awesome Site\\"}}</script>"
     `)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

> The [HTML5 standard encourages](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type) omitting the type attribute when the script is a JavaScript resource and only use it to specify module or other non-javascript MIME types.

See https://html-validate.org/rules/script-type.html

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
