### PR TITLE
fix(templateParams): separator over-replacement

### DIFF
--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -28,9 +28,9 @@ secondary:
 // all the goodies
 useHead({
   title: 'Hello World',
-  titleTemplate: '%s %seperator %siteName',
+  titleTemplate: '%s %separator %siteName',
   // template params
-  templateParams: { seperator: '|', siteName: 'My App' },
+  templateParams: { separator: '|', siteName: 'My App' },
   // class API support
   bodyAttrs: { class: { overflow: () => isModalOpen } },
   // deduping

--- a/docs/content/_code-examples.md
+++ b/docs/content/_code-examples.md
@@ -5,9 +5,9 @@
 useHead({
   // Titles
   title: 'Hello World',
-  titleTemplate: '%s %seperator %siteName',
+  titleTemplate: '%s %separator %siteName',
   // Template params
-  templateParams: { seperator: '|', siteName: 'My App' },
+  templateParams: { separator: '|', siteName: 'My App' },
   // Classes
   bodyAttrs: { class: { overflow: true } },
   // Deduping

--- a/packages/unhead/src/plugins/templateParams.ts
+++ b/packages/unhead/src/plugins/templateParams.ts
@@ -10,7 +10,7 @@ export default defineHeadPlugin({
       const idx = tags.findIndex(tag => tag.tag === 'templateParams')
       // we always process params so we can substitute the title
       const params = idx !== -1 ? tags[idx].props as unknown as TemplateParams : {}
-      // ensure a seperator exists
+      // ensure a separator exists
       params.separator = params.separator || '|'
       // pre-process title
       params.pageTitle = processTemplateParams(params.pageTitle as string || title || '', params)

--- a/packages/unhead/src/plugins/templateParams.ts
+++ b/packages/unhead/src/plugins/templateParams.ts
@@ -11,18 +11,19 @@ export default defineHeadPlugin({
       // we always process params so we can substitute the title
       const params = idx !== -1 ? tags[idx].props as unknown as TemplateParams : {}
       // ensure a separator exists
-      params.separator = params.separator || '|'
+      const sep = params.separator || '|'
+      delete params.separator
       // pre-process title
-      params.pageTitle = processTemplateParams(params.pageTitle as string || title || '', params)
+      params.pageTitle = processTemplateParams(params.pageTitle as string || title || '', params, sep)
       for (const tag of tags) {
         if (['titleTemplate', 'title'].includes(tag.tag) && typeof tag.textContent === 'string')
-          tag.textContent = processTemplateParams(tag.textContent, params)
+          tag.textContent = processTemplateParams(tag.textContent, params, sep)
         else if (tag.tag === 'meta' && typeof tag.props.content === 'string')
-          tag.props.content = processTemplateParams(tag.props.content, params)
+          tag.props.content = processTemplateParams(tag.props.content, params, sep)
         else if (tag.tag === 'link' && typeof tag.props.href === 'string')
-          tag.props.href = processTemplateParams(tag.props.href, params)
+          tag.props.href = processTemplateParams(tag.props.href, params, sep)
         else if (tag.tag === 'script' && ['application/json', 'application/ld+json'].includes(tag.props.type) && tag.innerHTML)
-          tag.innerHTML = processTemplateParams(tag.innerHTML, params)
+          tag.innerHTML = processTemplateParams(tag.innerHTML, params, sep)
       }
       ctx.tags = tags.filter(tag => tag.tag !== 'templateParams')
     },

--- a/test/unhead/ssr/templateParams.test.ts
+++ b/test/unhead/ssr/templateParams.test.ts
@@ -42,6 +42,27 @@ describe('ssr templateParams', () => {
     `)
   })
 
+  it('does not affect other content', async () => {
+    const head = createHead()
+    head.push({
+      title: 'This|is|an|example||with||multiple||||pipes',
+      script: [
+        {
+          type: 'application/json',
+          innerHTML: {
+            title: '{"title":"This|is|an|example||with||multiple||||pipes"}',
+          },
+        },
+      ],
+    })
+    const { headTags } = await renderSSRHead(head)
+
+    expect(headTags).toMatchInlineSnapshot(`
+      "<title>This|is|an|example||with||multiple||||pipes</title>
+      <script type=\\"application/json\\">{\\"title\\":\\"{\\\\\\"title\\\\\\":\\\\\\"This|is|an|example||with||multiple||||pipes\\\\\\"}\\"}</script>"
+    `)
+  })
+
   it('json', async () => {
     const head = createHead()
     head.push({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/22890

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We're currently hard replacing all sequential pipe characters by default, even within JSON and where there are no template parameters. Because this affects JSON, it's also affecting any values in Nuxt state.

I'm opening this quickly in case it's helpful but will come back to have a look at a potential solutions later on.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
