### PR TITLE
fix(ssr): fix JSON innerHTML encoding

### DIFF
--- a/packages/ssr/src/util/tagToString.ts
+++ b/packages/ssr/src/util/tagToString.ts
@@ -43,13 +43,14 @@ export function tagToString<T extends HeadTag>(tag: T) {
   if (!TagsWithInnerContent.includes(tag.tag))
     return SelfClosingTags.includes(tag.tag) ? openTag : `${openTag}</${tag.tag}>`
 
+  if (tag.innerHTML && ['application/ld+json', 'application/json'].includes(tag.props.type))
+    // ensure </script> tags get encoded
+    tag.innerHTML = escapeJson(tag.innerHTML)
+
   // dangerously using innerHTML, we don't encode this
   let content = String(tag.innerHTML || '')
   if (tag.textContent)
     // content needs to be encoded to avoid XSS, only for title
     content = escapeHtml(String(tag.textContent))
-  if (tag.innerHTML && ['application/ld+json', 'application/json'].includes(tag.props.type))
-    // ensure </script> tags get encoded
-    tag.innerHTML = escapeJson(tag.innerHTML)
   return SelfClosingTags.includes(tag.tag) ? openTag : `${openTag}${content}</${tag.tag}>`
 }

--- a/test/unhead/ssr/innerHTML.test.ts
+++ b/test/unhead/ssr/innerHTML.test.ts
@@ -29,6 +29,30 @@ describe('ssr innerHTML', () => {
     `)
   })
 
+  it('json escaping', async () => {
+    const head = createHead()
+    head.push({
+      script: [
+        {
+          type: 'application/json',
+          innerHTML: {
+            escape: '</script>',
+          },
+        },
+      ],
+    })
+    const ctx = await renderSSRHead(head)
+    expect(ctx).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<script type=\\"application/json\\">{\\"escape\\":\\"\\\\u003C/script>\\"}</script>",
+        "htmlAttrs": "",
+      }
+    `)
+  });
+
   it('noscript', async () => {
     const head = createHead()
     head.push({

--- a/test/unhead/ssr/templateParams.test.ts
+++ b/test/unhead/ssr/templateParams.test.ts
@@ -80,7 +80,7 @@ describe('ssr templateParams', () => {
 
     expect(headTags).toMatchInlineSnapshot(`
       "<title>Home &amp; &#x2F;&#x2F;&lt;&quot;With Encoding&quot;&gt;\\\\</title>
-      <script type=\\"application/json\\">{\\"title\\":\\"Home & //<\\\\\\"With Encoding\\\\\\">\\\\\\"}</script>"
+      <script type=\\"application/json\\">{\\"title\\":\\"Home & //\\\\u003C\\\\\\"With Encoding\\\\\\">\\\\\\"}</script>"
     `)
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

#218 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Noticed that `escapeJSON` in `tagToString` is called but its output is not used.
Moved up a few lines so its result is used when setting `content` later.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. (n/a?)
