### PR TITLE
fix(seo-meta): rework meta tag mapping

### DIFF
--- a/packages/shared/src/meta.ts
+++ b/packages/shared/src/meta.ts
@@ -11,43 +11,65 @@ interface PackingDefinition {
 }
 
 const MetaPackingSchema: Record<string, PackingDefinition> = {
-  robots: {
+  appleItunesApp: {
     unpack: {
-      keyValueSeparator: ':',
+      entrySeparator: ', ',
+      resolve({ key, value }) {
+        return `${fixKeyCase(key)}=${value}`
+      },
     },
   },
-  // Pragma directives
-  contentSecurityPolicy: {
-    unpack: {
-      keyValueSeparator: ' ',
-      entrySeparator: '; ',
-    },
-    metaKey: 'http-equiv',
-  },
-  fbAppId: {
-    keyValue: 'fb:app_id',
+  articleAuthor: {
+    keyValue: 'article:author',
     metaKey: 'property',
   },
-  ogSiteName: {
-    keyValue: 'og:site_name',
+  articleExpirationTime: {
+    keyValue: 'article:expiration_time',
+    metaKey: 'property',
   },
-  msapplicationTileImage: {
-    keyValue: 'msapplication-TileImage',
+  articleModifiedTime: {
+    keyValue: 'article:modified_time',
+    metaKey: 'property',
   },
-  /**
-   * Tile colour for windows
-   */
-  msapplicationTileColor: {
-    keyValue: 'msapplication-TileColor',
+  articlePublishedTime: {
+    keyValue: 'article:published_time',
+    metaKey: 'property',
   },
-  /**
-   * URL of a config for windows tile.
-   */
-  msapplicationConfig: {
-    keyValue: 'msapplication-Config',
+  articleSection: {
+    keyValue: 'article:section',
+    metaKey: 'property',
+  },
+  articleTag: {
+    keyValue: 'article:tag',
+    metaKey: 'property',
+  },
+  bookAuthor: {
+    keyValue: 'book:author',
+    metaKey: 'property',
+  },
+  bookIsbn: {
+    keyValue: 'book:isbn',
+    metaKey: 'property',
+  },
+  bookReleaseDate: {
+    keyValue: 'book:release_date',
+    metaKey: 'property',
+  },
+  bookTag: {
+    keyValue: 'book:tag',
+    metaKey: 'property',
   },
   charset: {
     metaKey: 'charset',
+  },
+  contentSecurityPolicy: {
+    unpack: {
+      entrySeparator: '; ',
+      resolve({ key, value }) {
+        return `${fixKeyCase(key)} ${value}`
+      },
+    },
+    metaKey: 'http-equiv',
   },
   contentType: {
     metaKey: 'http-equiv',
@@ -55,20 +77,257 @@ const MetaPackingSchema: Record<string, PackingDefinition> = {
   defaultStyle: {
     metaKey: 'http-equiv',
   },
-  xUaCompatible: {
-    metaKey: 'http-equiv',
+  fbAppId: {
+    keyValue: 'fb:app_id',
+    metaKey: 'property',
+  },
+  msapplicationConfig: {
+    keyValue: 'msapplication-Config',
+  },
+  msapplicationTileColor: {
+    keyValue: 'msapplication-TileColor',
+  },
+  msapplicationTileImage: {
+    keyValue: 'msapplication-TileImage',
+  },
+  ogAudioSecureUrl: {
+    keyValue: 'og:audio:secure_url',
+    metaKey: 'property',
+  },
+  ogAudioType: {
+    keyValue: 'og:audio:type',
+    metaKey: 'property',
+  },
+  ogAudioUrl: {
+    keyValue: 'og:audio',
+    metaKey: 'property',
+  },
+  ogDescription: {
+    keyValue: 'og:description',
+    metaKey: 'property',
+  },
+  ogDeterminer: {
+    keyValue: 'og:determiner',
+    metaKey: 'property',
+  },
+  ogImage: {
+    keyValue: 'og:image',
+    metaKey: 'property',
+  },
+  ogImageAlt: {
+    keyValue: 'og:image:alt',
+    metaKey: 'property',
+  },
+  ogImageHeight: {
+    keyValue: 'og:image:height',
+    metaKey: 'property',
+  },
+  ogImageSecureUrl: {
+    keyValue: 'og:image:secure_url',
+    metaKey: 'property',
+  },
+  ogImageType: {
+    keyValue: 'og:image:type',
+    metaKey: 'property',
+  },
+  ogImageUrl: {
+    keyValue: 'og:image',
+    metaKey: 'property',
+  },
+  ogImageWidth: {
+    keyValue: 'og:image:width',
+    metaKey: 'property',
+  },
+  ogLocale: {
+    keyValue: 'og:locale',
+    metaKey: 'property',
+  },
+  ogLocaleAlternate: {
+    keyValue: 'og:locale:alternate',
+    metaKey: 'property',
+  },
+  ogSiteName: {
+    keyValue: 'og:site_name',
+    metaKey: 'property',
+  },
+  ogTitle: {
+    keyValue: 'og:title',
+    metaKey: 'property',
+  },
+  ogType: {
+    keyValue: 'og:type',
+    metaKey: 'property',
+  },
+  ogUrl: {
+    keyValue: 'og:url',
+    metaKey: 'property',
+  },
+  ogVideo: {
+    keyValue: 'og:video',
+    metaKey: 'property',
+  },
+  ogVideoAlt: {
+    keyValue: 'og:video:alt',
+    metaKey: 'property',
+  },
+  ogVideoHeight: {
+    keyValue: 'og:video:height',
+    metaKey: 'property',
+  },
+  ogVideoSecureUrl: {
+    keyValue: 'og:video:secure_url',
+    metaKey: 'property',
+  },
+  ogVideoType: {
+    keyValue: 'og:video:type',
+    metaKey: 'property',
+  },
+  ogVideoUrl: {
+    keyValue: 'og:video',
+    metaKey: 'property',
+  },
+  ogVideoWidth: {
+    keyValue: 'og:video:width',
+    metaKey: 'property',
+  },
+  profileFirstName: {
+    keyValue: 'profile:first_name',
+    metaKey: 'property',
+  },
+  profileGender: {
+    keyValue: 'profile:gender',
+    metaKey: 'property',
+  },
+  profileLastName: {
+    keyValue: 'profile:last_name',
+    metaKey: 'property',
+  },
+  profileUsername: {
+    keyValue: 'profile:username',
+    metaKey: 'property',
   },
   refresh: {
+    metaKey: 'http-equiv',
+    unpack: {
+      entrySeparator: ';',
+      keyValueSeparator: '=',
+      resolve({ key, value }) {
+        if (key === 'seconds')
+          return `${value}`
+      },
+    },
+  },
+  robots: {
+    unpack: {
+      entrySeparator: ', ',
+      resolve({ key, value }) {
+        if (typeof value === 'boolean')
+          return `${fixKeyCase(key)}`
+        else
+          return `${fixKeyCase(key)}:${value}`
+      },
+    },
+  },
+  twitterAppIdGoogleplay: {
+    keyValue: 'twitter:app:id:googleplay',
+  },
+  twitterAppIdIpad: {
+    keyValue: 'twitter:app:id:ipad',
+  },
+  twitterAppIdIphone: {
+    keyValue: 'twitter:app:id:iphone',
+  },
+  twitterAppNameGoogleplay: {
+    keyValue: 'twitter:app:name:googleplay',
+  },
+  twitterAppNameIpad: {
+    keyValue: 'twitter:app:name:ipad',
+  },
+  twitterAppNameIphone: {
+    keyValue: 'twitter:app:name:iphone',
+  },
+  twitterAppUrlGoogleplay: {
+    keyValue: 'twitter:app:url:googleplay',
+  },
+  twitterAppUrlIpad: {
+    keyValue: 'twitter:app:url:ipad',
+  },
+  twitterAppUrlIphone: {
+    keyValue: 'twitter:app:url:iphone',
+  },
+  twitterCard: {
+    keyValue: 'twitter:card',
+  },
+  twitterCreator: {
+    keyValue: 'twitter:creator',
+  },
+  twitterCreatorId: {
+    keyValue: 'twitter:creator:id',
+  },
+  twitterData1: {
+    keyValue: 'twitter:data1',
+  },
+  twitterData2: {
+    keyValue: 'twitter:data2',
+  },
+  twitterDescription: {
+    keyValue: 'twitter:description',
+  },
+  twitterImage: {
+    keyValue: 'twitter:image',
+  },
+  twitterImageAlt: {
+    keyValue: 'twitter:image:alt',
+  },
+  /*************************************************/
+  // not part of Twitter's card specification anymore
+  twitterImageHeight: {
+    keyValue: 'twitter:image:height',
+  },
+  twitterImageType: {
+    keyValue: 'twitter:image:type',
+  },
+  twitterImageUrl: {
+    keyValue: 'twitter:image',
+  },
+  twitterImageWidth: {
+    keyValue: 'twitter:image:width',
+  },
+  /**************************************************/
+  twitterLabel1: {
+    keyValue: 'twitter:label1',
+  },
+  twitterLabel2: {
+    keyValue: 'twitter:label2',
+  },
+  twitterPlayer: {
+    keyValue: 'twitter:player',
+  },
+  twitterPlayerHeight: {
+    keyValue: 'twitter:player:height',
+  },
+  twitterPlayerStream: {
+    keyValue: 'twitter:player:stream',
+  },
+  twitterPlayerWidth: {
+    keyValue: 'twitter:player:width',
+  },
+  twitterSite: {
+    keyValue: 'twitter:site',
+  },
+  twitterSiteId: {
+    keyValue: 'twitter:site:id',
+  },
+  twitterTitle: {
+    keyValue: 'twitter:title',
+  },
+  xUaCompatible: {
     metaKey: 'http-equiv',
   },
 } as const
 
-const ColonPrefixKeys = /^(og|twitter|fb)/
-
-const PropertyPrefixKeys = /^(og|fb)/
-
 export function resolveMetaKeyType(key: string): string {
-  return PropertyPrefixKeys.test(key) ? 'property' : (MetaPackingSchema[key]?.metaKey || 'name')
+  return MetaPackingSchema[key]?.metaKey || 'name'
 }
 
 export function resolveMetaKeyValue(key: string): string {
@@ -76,13 +335,7 @@ export function resolveMetaKeyValue(key: string): string {
 }
 
 function fixKeyCase(key: string) {
-  key = key.replace(/([A-Z])/g, '-$1').toLowerCase()
-  if (ColonPrefixKeys.test(key)) {
-    key = key
-      .replace('secure-url', 'secure_url')
-      .replace(/-/g, ':')
-  }
-  return key
+  return key.replace(/([A-Z])/g, '-$1').toLowerCase()
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
@@ -112,7 +365,6 @@ export function resolvePackedMetaObjectValue(value: string, key: string): string
   return unpackToString(
     changeKeyCasingDeep(value), {
       entrySeparator: ', ',
-      keyValueSeparator: '=',
       resolve({ value, key }) {
         if (value === null)
           return ''
@@ -124,44 +376,64 @@ export function resolvePackedMetaObjectValue(value: string, key: string): string
   )
 }
 
-const OpenGraphInputs = ['og:Image', 'og:Video', 'og:Audio', 'twitter:Image']
-
 const SimpleArrayUnpackMetas: (keyof MetaFlatInput)[] = ['themeColor']
+
+function getMeta(key: string, value: string) {
+  const meta: Record<string, string> = {}
+  const metaKeyType = resolveMetaKeyType(key)
+
+  if (metaKeyType === 'charset') {
+    meta[metaKeyType] = value
+  }
+  else {
+    meta[metaKeyType] = resolveMetaKeyValue(key)
+    meta.content = value
+  }
+
+  return meta
+}
+
+function flattenMetaObjects(input: Record<string, any>, prefix: string = '') {
+  const extras: Record<string, any>[] = []
+
+  for (const [key, value] of Object.entries(input)) {
+    const fullkey = `${prefix}${prefix === '' ? key : key.charAt(0).toUpperCase() + key.slice(1)}`
+    const unpacker = MetaPackingSchema[key]?.unpack
+
+    if (unpacker) {
+      extras.push(getMeta(fullkey, unpackToString(value, unpacker)))
+      delete input[key]
+      continue
+    }
+
+    if (typeof value === 'object') {
+      const children = Array.isArray(value) ? value : [value]
+
+      for (const child of children) {
+        if (typeof child === 'object')
+          extras.push(...flattenMetaObjects(child, fullkey))
+        else
+          extras.push(getMeta(fullkey, child))
+      }
+
+      delete input[key]
+    }
+    else {
+      extras.push(getMeta(fullkey, value))
+      if (typeof input === 'object')
+        delete input[key]
+    }
+  }
+
+  return extras
+}
 
 /**
  * Converts a flat meta object into an array of meta entries.
  * @param input
  */
 export function unpackMeta<T extends MetaFlatInput>(input: T): Required<Head>['meta'] {
-  const extras: Record<string, any>[] = []
-
-  OpenGraphInputs.forEach((key) => {
-    const propKey = key.toLowerCase()
-    const inputKey = `${key.replace(':', '')}` as keyof MetaFlatInput
-    const val = input[inputKey]
-    if (typeof val === 'object') {
-      (Array.isArray(val) ? val : [val])
-        .forEach((entry) => {
-          if (!entry)
-            return
-          const unpackedEntry = unpackToArray(entry as Record<string, any>, {
-            key: key.startsWith('og') ? 'property' : 'name',
-            value: 'content',
-            resolveKeyData({ key }) {
-              return fixKeyCase(`${propKey}${key !== 'url' ? `:${key}` : ''}`)
-            },
-            resolveValueData({ value }) {
-              return typeof value === 'number' ? value.toString() : value
-            },
-          })
-          extras.push(
-            // need to sort the entry and make sure the `og:image` is first
-            ...unpackedEntry.sort((a, b) => (a.property === propKey ? -1 : b.property === propKey ? 1 : 0)),
-          )
-        })
-      delete input[inputKey]
-    }
-  })
+  const extras: Record<string, string>[] = []
 
   SimpleArrayUnpackMetas.forEach((meta: keyof T) => {
     if (input[meta] && typeof input[meta] !== 'string') {
@@ -177,6 +449,22 @@ export function unpackMeta<T extends MetaFlatInput>(input: T): Required<Head>['m
       })
     }
   })
+
+  extras.push(
+    // need to sort the entry and make sure the `og:image` is first
+    ...flattenMetaObjects(input).sort((a, b) => {
+      if (a.property?.startsWith('og:image')) {
+        if (b.property?.startsWith('og:image'))
+          return 0
+        else
+          return -1
+      }
+
+      if (b.property?.startsWith('og:image'))
+        return 1
+
+      return 0
+    }))
 
   const meta = unpackToArray((input), {
     key({ key }) {

--- a/test/unhead/ssr/ssr.test.ts
+++ b/test/unhead/ssr/ssr.test.ts
@@ -153,10 +153,10 @@ describe('ssr', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<meta name=\\"description\\" content=\\"This is my amazing site, let me tell you all about it.\\">
+        "headTags": "<meta property=\\"og:image\\" content=\\"https://example.com/image.png\\">
+      <meta name=\\"description\\" content=\\"This is my amazing site, let me tell you all about it.\\">
       <meta property=\\"og:description\\" content=\\"This is my amazing site, let me tell you all about it.\\">
       <meta property=\\"og:title\\" content=\\"My Amazing Site\\">
-      <meta property=\\"og:image\\" content=\\"https://example.com/image.png\\">
       <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">",
         "htmlAttrs": "",
       }

--- a/test/unhead/useSeoMeta.test.ts
+++ b/test/unhead/useSeoMeta.test.ts
@@ -94,4 +94,308 @@ describe('useSeoMeta', () => {
       }
     `)
   })
+
+  it('generates correct meta tags', async () => {
+    const head = createHead()
+    const dateString = new Date(0).toISOString()
+
+    useSeoMeta({
+      appleItunesApp: {
+        appId: 'id',
+        appArgument: 'https://example.com',
+      },
+      appleMobileWebAppCapable: 'yes',
+      appleMobileWebAppStatusBarStyle: 'black',
+      appleMobileWebAppTitle: 'Title',
+      applicationName: 'Name',
+      articleAuthor: ['https://example.com/some.html', 'https://example.com/one.html'],
+      articleExpirationTime: dateString,
+      articleModifiedTime: dateString,
+      articlePublishedTime: dateString,
+      articleSection: 'Technology',
+      articleTag: ['Apple', 'Steve Jobs'],
+      author: 'Name',
+      bookAuthor: ['https://example.com/some.html', 'https://example.com/one.html'],
+      bookIsbn: '978-3-16-148410-0',
+      bookReleaseDate: dateString,
+      bookTag: ['Apple', 'Steve Jobs'],
+      charset: 'utf-8',
+      colorScheme: 'normal',
+      contentSecurityPolicy: {
+        baseUri: 'https://example.com',
+        childSrc: '\'none\'',
+        connectSrc: '\'none\'',
+        defaultSrc: '\'none\'',
+        fontSrc: '\'none\'',
+        formAction: '\'none\'',
+        frameAncestors: '\'none\'',
+        imgSrc: '\'none\'',
+        manifestSrc: '\'none\'',
+        mediaSrc: '\'none\'',
+        objectSrc: '\'none\'',
+        prefetchSrc: '\'none\'',
+        reportTo: '\'none\'',
+        reportUri: '\'none\'',
+        requireSriFor: '\'none\'',
+        requireTrustedTypesFor: '\'none\'',
+        sandbox: '\'none\'',
+        scriptSrc: '\'none\'',
+        scriptSrcAttr: '\'none\'',
+        scriptSrcElem: '\'none\'',
+        styleSrc: '\'none\'',
+        styleSrcAttr: '\'none\'',
+        styleSrcElem: '\'none\'',
+        trustedTypes: '\'none\'',
+        upgradeInsecureRequests: '\'none\'',
+        workerSrc: '\'none\'',
+      },
+      contentType: 'text/html; charset=utf-8',
+      creator: 'Name',
+      defaultStyle: 'style',
+      description: 'Description',
+      fbAppId: 'id',
+      formatDetection: 'telephone=no',
+      generator: 'Generator',
+      google: 'nopagereadaloud',
+      googlebot: 'notranslate',
+      googleSiteVerification: 'key',
+      mobileWebAppCapable: 'yes',
+      msapplicationConfig: 'config',
+      msapplicationTileColor: '#fff',
+      msapplicationTileImage: 'https://example.com',
+      ogAudio: [{
+        secureUrl: 'https://example.com',
+        type: 'audio/mpeg',
+        url: 'https://example.com',
+      }],
+      ogAudioSecureUrl: 'https://example.com',
+      ogAudioType: 'audio/mpeg',
+      ogAudioUrl: 'https://example.com',
+      ogDescription: 'Description',
+      ogDeterminer: 'auto',
+      ogImage: [{
+        alt: 'Alt',
+        height: 1337,
+        secureUrl: 'https://example.com',
+        type: 'image/gif',
+        url: 'https://example.com',
+        width: 1337,
+      }],
+      ogImageAlt: 'Alt',
+      ogImageHeight: 1337,
+      ogImageSecureUrl: 'https://example.com',
+      ogImageType: 'image/gif',
+      ogImageUrl: 'https://example.com',
+      ogImageWidth: 1337,
+      ogLocale: 'en-US',
+      ogLocaleAlternate: 'de-DE',
+      ogSiteName: 'Name',
+      ogTitle: 'Title',
+      ogType: 'article',
+      ogUrl: 'https://example.com',
+      ogVideo: [{
+        alt: 'Alt',
+        height: 1337,
+        secureUrl: 'https://example.com',
+        type: 'application/x-shockwave-flash',
+        url: 'https://example.com',
+        width: 1337,
+      }],
+      ogVideoAlt: 'Alt',
+      ogVideoHeight: 1337,
+      ogVideoSecureUrl: 'https://example.com',
+      ogVideoType: 'application/x-shockwave-flash',
+      ogVideoUrl: 'https://example.com',
+      ogVideoWidth: 1337,
+      profileFirstName: 'Firstname',
+      profileGender: 'male',
+      profileLastName: 'Lastname',
+      profileUsername: 'Username',
+      publisher: 'Name',
+      rating: 'adult',
+      referrer: 'no-referrer',
+      refresh: {
+        seconds: 1,
+        url: 'https://example.com',
+      },
+      robots: {
+        all: true,
+        follow: true,
+        index: true,
+        indexifembedded: true,
+        maxImagePreview: 'large',
+        maxSnippet: 1,
+        maxVideoPreview: 2,
+        noarchive: true,
+        nofollow: true,
+        noimageindex: true,
+        noindex: true,
+        none: true,
+        nositelinkssearchbox: true,
+        nosnippet: true,
+        notranslate: true,
+        unavailable_after: dateString,
+      },
+      themeColor: '#fff',
+      title: 'Title',
+      titleTemplate: '%s',
+      twitterAppIdGoogleplay: 'id',
+      twitterAppIdIpad: 'id',
+      twitterAppIdIphone: 'id',
+      twitterAppNameGoogleplay: 'name',
+      twitterAppNameIpad: 'name',
+      twitterAppNameIphone: 'name',
+      twitterAppUrlGoogleplay: 'https://example.com',
+      twitterAppUrlIpad: 'https://example.com',
+      twitterAppUrlIphone: 'https://example.com',
+      twitterCard: 'summary_large_image',
+      twitterCreator: '@username',
+      twitterCreatorId: 'id',
+      twitterData1: 'data1',
+      twitterData2: 'data2',
+      twitterDescription: 'Description',
+      twitterImage: 'https://example.com',
+      twitterImageAlt: 'Alt',
+      twitterImageHeight: 1337,
+      twitterImageType: 'image/gif',
+      twitterImageWidth: 1337,
+      twitterLabel1: 'label1',
+      twitterLabel2: 'label2',
+      twitterPlayer: 'https://example.com',
+      twitterPlayerHeight: 1337,
+      twitterPlayerStream: 'https://example.com',
+      twitterPlayerWidth: 1337,
+      twitterSite: '@username',
+      twitterSiteId: 'id',
+      twitterTitle: 'Title',
+      viewport: 'width=device-width, initial-scale=1',
+      xUaCompatible: 'IE=edge',
+    })
+
+    expect(await renderSSRHead(head)).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<meta charset=\\"utf-8\\">
+      <meta http-equiv=\\"content-security-policy\\" content=\\"base-uri https://example.com; child-src 'none'; connect-src 'none'; default-src 'none'; font-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'none'; manifest-src 'none'; media-src 'none'; object-src 'none'; prefetch-src 'none'; report-to 'none'; report-uri 'none'; require-sri-for 'none'; require-trusted-types-for 'none'; sandbox 'none'; script-src 'none'; script-src-attr 'none'; script-src-elem 'none'; style-src 'none'; style-src-attr 'none'; style-src-elem 'none'; trusted-types 'none'; upgrade-insecure-requests 'none'; worker-src 'none'\\">
+      <title>Title</title>
+      <meta property=\\"og:image:alt\\" content=\\"Alt\\">
+      <meta property=\\"og:image:height\\" content=\\"1337\\">
+      <meta property=\\"og:image:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image:type\\" content=\\"image/gif\\">
+      <meta property=\\"og:image\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image:width\\" content=\\"1337\\">
+      <meta property=\\"og:image:alt\\" content=\\"Alt\\">
+      <meta property=\\"og:image:height\\" content=\\"1337\\">
+      <meta property=\\"og:image:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image:type\\" content=\\"image/gif\\">
+      <meta property=\\"og:image\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image:width\\" content=\\"1337\\">
+      <meta name=\\"apple-itunes-app\\" content=\\"app-id=id, app-argument=https://example.com\\">
+      <meta name=\\"apple-mobile-web-app-capable\\" content=\\"yes\\">
+      <meta name=\\"apple-mobile-web-app-status-bar-style\\" content=\\"black\\">
+      <meta name=\\"apple-mobile-web-app-title\\" content=\\"Title\\">
+      <meta name=\\"application-name\\" content=\\"Name\\">
+      <meta property=\\"article:author\\" content=\\"https://example.com/some.html\\">
+      <meta property=\\"article:author\\" content=\\"https://example.com/one.html\\">
+      <meta property=\\"article:expiration_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+      <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+      <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+      <meta property=\\"article:section\\" content=\\"Technology\\">
+      <meta property=\\"article:tag\\" content=\\"Apple\\">
+      <meta property=\\"article:tag\\" content=\\"Steve Jobs\\">
+      <meta name=\\"author\\" content=\\"Name\\">
+      <meta property=\\"book:author\\" content=\\"https://example.com/some.html\\">
+      <meta property=\\"book:author\\" content=\\"https://example.com/one.html\\">
+      <meta property=\\"book:isbn\\" content=\\"978-3-16-148410-0\\">
+      <meta property=\\"book:release_date\\" content=\\"1970-01-01T00:00:00.000Z\\">
+      <meta property=\\"book:tag\\" content=\\"Apple\\">
+      <meta property=\\"book:tag\\" content=\\"Steve Jobs\\">
+      <meta name=\\"color-scheme\\" content=\\"normal\\">
+      <meta http-equiv=\\"content-type\\" content=\\"text/html; charset=utf-8\\">
+      <meta name=\\"creator\\" content=\\"Name\\">
+      <meta http-equiv=\\"default-style\\" content=\\"style\\">
+      <meta name=\\"description\\" content=\\"Description\\">
+      <meta property=\\"fb:app_id\\" content=\\"id\\">
+      <meta name=\\"format-detection\\" content=\\"telephone=no\\">
+      <meta name=\\"generator\\" content=\\"Generator\\">
+      <meta name=\\"google\\" content=\\"nopagereadaloud\\">
+      <meta name=\\"googlebot\\" content=\\"notranslate\\">
+      <meta name=\\"google-site-verification\\" content=\\"key\\">
+      <meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">
+      <meta name=\\"msapplication-Config\\" content=\\"config\\">
+      <meta name=\\"msapplication-TileColor\\" content=\\"#fff\\">
+      <meta name=\\"msapplication-TileImage\\" content=\\"https://example.com\\">
+      <meta property=\\"og:audio:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:audio:type\\" content=\\"audio/mpeg\\">
+      <meta property=\\"og:audio\\" content=\\"https://example.com\\">
+      <meta property=\\"og:audio:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:audio:type\\" content=\\"audio/mpeg\\">
+      <meta property=\\"og:audio\\" content=\\"https://example.com\\">
+      <meta property=\\"og:description\\" content=\\"Description\\">
+      <meta property=\\"og:determiner\\" content=\\"auto\\">
+      <meta property=\\"og:locale\\" content=\\"en-US\\">
+      <meta property=\\"og:locale:alternate\\" content=\\"de-DE\\">
+      <meta property=\\"og:site_name\\" content=\\"Name\\">
+      <meta property=\\"og:title\\" content=\\"Title\\">
+      <meta property=\\"og:type\\" content=\\"article\\">
+      <meta property=\\"og:url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:video:alt\\" content=\\"Alt\\">
+      <meta property=\\"og:video:height\\" content=\\"1337\\">
+      <meta property=\\"og:video:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:video:type\\" content=\\"application/x-shockwave-flash\\">
+      <meta property=\\"og:video\\" content=\\"https://example.com\\">
+      <meta property=\\"og:video:width\\" content=\\"1337\\">
+      <meta property=\\"og:video:alt\\" content=\\"Alt\\">
+      <meta property=\\"og:video:height\\" content=\\"1337\\">
+      <meta property=\\"og:video:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:video:type\\" content=\\"application/x-shockwave-flash\\">
+      <meta property=\\"og:video\\" content=\\"https://example.com\\">
+      <meta property=\\"og:video:width\\" content=\\"1337\\">
+      <meta property=\\"profile:first_name\\" content=\\"Firstname\\">
+      <meta property=\\"profile:gender\\" content=\\"male\\">
+      <meta property=\\"profile:last_name\\" content=\\"Lastname\\">
+      <meta property=\\"profile:username\\" content=\\"Username\\">
+      <meta name=\\"publisher\\" content=\\"Name\\">
+      <meta name=\\"rating\\" content=\\"adult\\">
+      <meta name=\\"referrer\\" content=\\"no-referrer\\">
+      <meta http-equiv=\\"refresh\\" content=\\"1;url=https://example.com\\">
+      <meta name=\\"robots\\" content=\\"all, follow, index, indexifembedded, max-image-preview:large, max-snippet:1, max-video-preview:2, noarchive, nofollow, noimageindex, noindex, none, nositelinkssearchbox, nosnippet, notranslate, unavailable_after:1970-01-01T00:00:00.000Z\\">
+      <meta name=\\"theme-color\\" content=\\"#fff\\">
+      <meta name=\\"twitter:app:id:googleplay\\" content=\\"id\\">
+      <meta name=\\"twitter:app:id:ipad\\" content=\\"id\\">
+      <meta name=\\"twitter:app:id:iphone\\" content=\\"id\\">
+      <meta name=\\"twitter:app:name:googleplay\\" content=\\"name\\">
+      <meta name=\\"twitter:app:name:ipad\\" content=\\"name\\">
+      <meta name=\\"twitter:app:name:iphone\\" content=\\"name\\">
+      <meta name=\\"twitter:app:url:googleplay\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:app:url:ipad\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:app:url:iphone\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+      <meta name=\\"twitter:creator\\" content=\\"@username\\">
+      <meta name=\\"twitter:creator:id\\" content=\\"id\\">
+      <meta name=\\"twitter:data1\\" content=\\"data1\\">
+      <meta name=\\"twitter:data2\\" content=\\"data2\\">
+      <meta name=\\"twitter:description\\" content=\\"Description\\">
+      <meta name=\\"twitter:image\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:image:alt\\" content=\\"Alt\\">
+      <meta name=\\"twitter:image:height\\" content=\\"1337\\">
+      <meta name=\\"twitter:image:type\\" content=\\"image/gif\\">
+      <meta name=\\"twitter:image:width\\" content=\\"1337\\">
+      <meta name=\\"twitter:label1\\" content=\\"label1\\">
+      <meta name=\\"twitter:label2\\" content=\\"label2\\">
+      <meta name=\\"twitter:player\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:player:height\\" content=\\"1337\\">
+      <meta name=\\"twitter:player:stream\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:player:width\\" content=\\"1337\\">
+      <meta name=\\"twitter:site\\" content=\\"@username\\">
+      <meta name=\\"twitter:site:id\\" content=\\"id\\">
+      <meta name=\\"twitter:title\\" content=\\"Title\\">
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+      <meta http-equiv=\\"x-ua-compatible\\" content=\\"IE=edge\\">",
+        "htmlAttrs": "",
+      }
+    `)
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The new meta tags added in https://github.com/harlan-zw/zhead/pull/18 are not prefixed with `og`. That way, they are not properly added to the head (see first test commit).
I observe that keys (`name` or `property`) us a custom formats:

- `msapplication-TileImage`
- `og:audio:secure_url\`

So there is no standard way to format such a key. The html standard keys seem to be all lowercase with dashes, so I kept this as standard formatting.
For all other keys, I propose to extend the `MetaPackingSchema`, dropping the prefix logic that's currently used e.g. for open graph tags as that logic may overlap with future keys (imagine meta information about ogres like `ogre:name` :grin: you get the idea).
The algorithm I implemented should work for any depth of object nesting.

Please correct me if I could make better use of `packrup`. It's somehow not trivial to grasp right away for my `head` if I could utilize that library better.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
