### PR TITLE
fix(vue-2): rework how vue 2 plugin gets head instance

### DIFF
--- a/docs/content/1.setup/4.vue/0.installation.md
+++ b/docs/content/1.setup/4.vue/0.installation.md
@@ -47,10 +47,11 @@ import { createHead } from '@unhead/vue'
 import { UnheadPlugin } from '@unhead/vue/vue2'
 
 const head = createHead()
-Vue.use(UnheadPlugin, head)
+Vue.use(UnheadPlugin)
 
 new Vue({
   el: '#app',
+  unhead: head,
 })
 ```
 

--- a/examples/vue-2/src/main.js
+++ b/examples/vue-2/src/main.js
@@ -7,8 +7,9 @@ Vue.config.productionTip = false
 
 const head = createHead()
 
-Vue.use(UnheadPlugin, head);
+Vue.use(UnheadPlugin);
 
 new Vue({
   render: h => h(App),
+  unhead: head,
 }).$mount('#app')

--- a/packages/vue/src/vue2/index.ts
+++ b/packages/vue/src/vue2/index.ts
@@ -2,56 +2,53 @@ import { getCurrentInstance } from 'vue'
 import type { Plugin } from 'vue'
 import { headSymbol } from '../createHead'
 import { useHead } from '../composables/useHead'
-import type { VueHeadClient } from '../types'
 import { Vue3 } from '../env'
 
-export const HeadOptions = {
-  created() {
-    let source = false
-    if (Vue3) {
-      const instance = getCurrentInstance()
-      if (!instance)
-        return
-      const options = instance.type
-      if (!options || !('head' in options))
-        return
-
-      source = typeof options.head === 'function'
-        ? () => options.head.call(instance.proxy)
-        : options.head
-    }
-    else {
-      // @ts-expect-error vue 2
-      const head = this.$options.head
-      if (head) {
-        source = typeof head === 'function'
-          ? () => head.call(this)
-          : head
-      }
-    }
-
-    // @ts-expect-error vue 2
-    source && useHead(source)
-  },
-}
-
-export const UnheadPlugin: Plugin = function (_Vue, head: VueHeadClient<any>) {
+export const UnheadPlugin: Plugin = function (_Vue) {
   // copied from https://github.com/vuejs/pinia/blob/v2/packages/pinia/src/vue2-plugin.ts
   _Vue.mixin({
-    ...HeadOptions,
+    created() {
+      let source = false
+      if (Vue3) {
+        const instance = getCurrentInstance()
+        if (!instance)
+          return
+        const options = instance.type
+        if (!options || !('head' in options))
+          return
+
+        source = typeof options.head === 'function'
+          ? () => options.head.call(instance.proxy)
+          : options.head
+      }
+      else {
+        const head = this.$options.head
+        if (head) {
+          source = typeof head === 'function'
+            ? () => head.call(this)
+            : head
+        }
+      }
+
+      // @ts-expect-error vue 2
+      source && useHead(source)
+    },
+
     beforeCreate() {
       const options = this.$options
-      const origProvide = options.provide
-      options.provide = function () {
-        let origProvideResult
-        if (typeof origProvide === 'function')
-          origProvideResult = origProvide.call(this)
-        else
-          origProvideResult = origProvide || {}
+      if (options.unhead) {
+        const origProvide = options.provide
+        options.provide = function () {
+          let origProvideResult
+          if (typeof origProvide === 'function')
+            origProvideResult = origProvide.call(this)
+          else
+            origProvideResult = origProvide || {}
 
-        return {
-          ...origProvideResult,
-          [headSymbol]: head,
+          return {
+            ...origProvideResult,
+            [headSymbol]: options.unhead,
+          }
         }
       }
     },


### PR DESCRIPTION
Make vue 2 plugin not reference head directly, get it from root component options instead

### 🔗 Linked issue

#216 

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The comment in 1dfe189e about the pinia plugin sparked a thought for an alternative way for the plugin to work. Basically instead of passing the unhead instance to `Vue.use`, have the plugin get it from `this.$options.unhead` (which would only be present on the root component).

The changes in 1dfe189e would still result in the behavior described [here](https://github.com/unjs/unhead/issues/216#issuecomment-1711902384).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
