### PR TITLE
feat!: universal head injection, drop `activeHead`

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -29,7 +29,7 @@ export const TagConfigKeys = ['tagPosition', 'tagPriority', 'tagDuplicateStrateg
 export const IsBrowser = typeof window !== 'undefined'
 
 export const composableNames = [
-  'getActiveHead',
+  'injectHead',
   'useHead',
   'useSeoMeta',
   'useHeadSafe',

--- a/packages/unhead/src/composables/injectHead.ts
+++ b/packages/unhead/src/composables/injectHead.ts
@@ -1,0 +1,24 @@
+const _global
+  = typeof globalThis !== 'undefined'
+    ? globalThis
+    : typeof window !== 'undefined'
+      ? window
+      : typeof global !== 'undefined'
+        ? global
+        : typeof self !== 'undefined'
+          ? self
+          : {}
+
+const globalKey = '__unhead_injection_handler__'
+
+export function setHeadInjectionHandler<T>(handler: () => T | undefined) {
+  // @ts-expect-error global injection
+  _global[globalKey] = handler
+}
+
+/* #__PURE__ */ export function injectHead<T>(): T | undefined {
+  if (globalKey in _global) {
+    // @ts-expect-error global injection
+    return _global[globalKey]() as T
+  }
+}

--- a/packages/unhead/src/composables/injectHead.ts
+++ b/packages/unhead/src/composables/injectHead.ts
@@ -21,4 +21,6 @@ export function setHeadInjectionHandler<T>(handler: () => T | undefined) {
     // @ts-expect-error global injection
     return _global[globalKey]() as T
   }
+  else { console.warn('No head injection handler found. Did you forget to call `setHeadInjectionHandler`?') }
+  console.warn('The head injection handler didn\'t return a head instance.')
 }

--- a/packages/unhead/src/composables/useActiveHead.ts
+++ b/packages/unhead/src/composables/useActiveHead.ts
@@ -1,5 +1,0 @@
-import { activeHead } from '../createHead'
-
-export function getActiveHead() {
-  return activeHead
-}

--- a/packages/unhead/src/composables/useHead.ts
+++ b/packages/unhead/src/composables/useHead.ts
@@ -3,7 +3,7 @@ import type {
   Head,
   HeadEntryOptions,
 } from '@unhead/schema'
-import { getActiveHead } from './useActiveHead'
+import { injectHead } from './injectHead'
 
 export function useHead<T extends Head>(input: T, options: HeadEntryOptions = {}): ActiveHeadEntry<T> | void {
   const head = options.head || injectHead()

--- a/packages/unhead/src/composables/useHead.ts
+++ b/packages/unhead/src/composables/useHead.ts
@@ -6,6 +6,6 @@ import type {
 import { getActiveHead } from './useActiveHead'
 
 export function useHead<T extends Head>(input: T, options: HeadEntryOptions = {}): ActiveHeadEntry<T> | void {
-  const head = options.head || getActiveHead()
+  const head = options.head || injectHead()
   return head?.push(input, options)
 }

--- a/packages/unhead/src/createHead.ts
+++ b/packages/unhead/src/createHead.ts
@@ -19,19 +19,15 @@ import SortPlugin from './plugins/sort'
 import TemplateParamsPlugin from './plugins/templateParams'
 import TitleTemplatePlugin from './plugins/titleTemplate'
 
-// TODO drop support for non-context head
-// eslint-disable-next-line import/no-mutable-exports
-export let activeHead: Unhead<any> | undefined
-
-// TODO rename to createDomHead
+// TODO rename to createDomHead, move to client subpath
 /* @__NO_SIDE_EFFECTS__ */ export function createHead<T extends {} = Head>(options: CreateHeadOptions = {}) {
   const head = createHeadCore<T>(options)
   head.use(DomPlugin())
-  return activeHead = head
+  return head
 }
 
 /* @__NO_SIDE_EFFECTS__ */ export function createServerHead<T extends {} = Head>(options: CreateHeadOptions = {}) {
-  return activeHead = createHeadCore<T>(options)
+  return createHeadCore<T>(options)
 }
 
 function filterMode(mode: RuntimeMode | undefined, ssr: boolean) {

--- a/packages/unhead/src/createHead.ts
+++ b/packages/unhead/src/createHead.ts
@@ -18,16 +18,26 @@ import HashKeyedPlugin from './plugins/hashKeyed'
 import SortPlugin from './plugins/sort'
 import TemplateParamsPlugin from './plugins/templateParams'
 import TitleTemplatePlugin from './plugins/titleTemplate'
+import { setHeadInjectionHandler } from './composables/injectHead'
 
 // TODO rename to createDomHead, move to client subpath
 /* @__NO_SIDE_EFFECTS__ */ export function createHead<T extends {} = Head>(options: CreateHeadOptions = {}) {
-  const head = createHeadCore<T>(options)
+  const head = createSharedHead<T>(options)
   head.use(DomPlugin())
   return head
 }
 
+// TODO move to server subpath
 /* @__NO_SIDE_EFFECTS__ */ export function createServerHead<T extends {} = Head>(options: CreateHeadOptions = {}) {
+  // not safe to set a global head instance
   return createHeadCore<T>(options)
+}
+
+export function createSharedHead<T extends {} = Head>(options: CreateHeadOptions = {}) {
+  const head = createHeadCore<T>(options)
+  // safe to set a global head instance in a browser
+  setHeadInjectionHandler(() => head)
+  return head
 }
 
 function filterMode(mode: RuntimeMode | undefined, ssr: boolean) {

--- a/packages/unhead/src/index.ts
+++ b/packages/unhead/src/index.ts
@@ -13,7 +13,7 @@ export * from './optionalPlugins/capoPlugin'
 
 // composables
 export * from './autoImports'
-export * from './composables/useActiveHead'
+export * from './composables/injectHead'
 export * from './composables/useHead'
 export * from './composables/useHeadSafe'
 export * from './composables/useServerHead'

--- a/packages/unhead/src/index.ts
+++ b/packages/unhead/src/index.ts
@@ -1,10 +1,11 @@
-import { createHead, createHeadCore, createServerHead } from './createHead'
+import { createHead, createHeadCore, createServerHead, createSharedHead } from './createHead'
 
 // create
 export {
   createHead,
   createServerHead,
   createHeadCore,
+  createSharedHead,
 }
 
 // optional plugins

--- a/packages/vue/src/autoImports.ts
+++ b/packages/vue/src/autoImports.ts
@@ -1,9 +1,5 @@
 import { composableNames } from '@unhead/shared'
 
-const coreComposableNames = [
-  'injectHead',
-]
-
 export const unheadVueComposablesImports = {
-  '@unhead/vue': [...coreComposableNames, ...composableNames],
+  '@unhead/vue': composableNames,
 }

--- a/packages/vue/src/components/Head.ts
+++ b/packages/vue/src/components/Head.ts
@@ -77,6 +77,11 @@ export const Head: DefineComponent = /* @__PURE__ */ defineComponent({
 
   setup(_, { slots }) {
     const head = injectHead()
+    if (!head) {
+      return () => {
+        return null
+      }
+    }
 
     const obj: Ref<ReactiveHead> = ref({})
 

--- a/packages/vue/src/composables/injectHead.ts
+++ b/packages/vue/src/composables/injectHead.ts
@@ -1,35 +1,13 @@
 import type { MergeHead } from '@unhead/schema'
-import { inject } from 'vue'
-import { getActiveHead } from 'unhead'
+import { hasInjectionContext, inject } from 'vue'
+import { injectHead as _injectHead } from 'unhead'
 import type { VueHeadClient } from '../types'
 import { headSymbol } from '../createHead'
 
-const _global
-  = typeof globalThis !== 'undefined'
-    ? globalThis
-    : typeof window !== 'undefined'
-      ? window
-      : typeof global !== 'undefined'
-        ? global
-        : typeof self !== 'undefined'
-          ? self
-          : {}
-
-const globalKey = '__unhead_injection_handler__'
-
-export function setHeadInjectionHandler(handler: () => VueHeadClient<any> | undefined) {
-  // @ts-expect-error global injection
-  _global[globalKey] = handler
-}
-
 export function injectHead<T extends MergeHead>() {
-  if (globalKey in _global) {
-    // @ts-expect-error global injection
-    return _global[globalKey]() as VueHeadClient<T>
-  }
-  // fallback resolver
-  const head = inject(headSymbol)
-  if (!head && process.env.NODE_ENV !== 'production')
-    console.warn('Unhead is missing Vue context, falling back to shared context. This may have unexpected results.')
-  return (head || getActiveHead()) as VueHeadClient<T>
+  // requires Vue 3.3
+  if (hasInjectionContext())
+    return inject<VueHeadClient<T>>(headSymbol)
+
+  return _injectHead<VueHeadClient<T>>()
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,4 +1,4 @@
-import { CapoPlugin, HashHydrationPlugin, createHeadCore } from 'unhead'
+import { CapoPlugin, HashHydrationPlugin, createHeadCore, setHeadInjectionHandler } from 'unhead'
 import { createHead, createServerHead } from './createHead'
 import { resolveUnrefHeadInput } from './utils'
 
@@ -35,5 +35,6 @@ export * from './composables/useSeoMeta'
 export * from './composables/useServerHead'
 export * from './composables/useServerHeadSafe'
 export * from './composables/useServerSeoMeta'
+export { setHeadInjectionHandler }
 
 export type { HeadTag, MergeHead, ActiveHeadEntry, Head, Unhead, HeadEntryOptions } from '@unhead/schema'

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -35,6 +35,7 @@ export * from './composables/useSeoMeta'
 export * from './composables/useServerHead'
 export * from './composables/useServerHeadSafe'
 export * from './composables/useServerSeoMeta'
+export * from './composables/useScript'
 export { setHeadInjectionHandler }
 
 export type { HeadTag, MergeHead, ActiveHeadEntry, Head, Unhead, HeadEntryOptions } from '@unhead/schema'

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -35,7 +35,6 @@ export * from './composables/useSeoMeta'
 export * from './composables/useServerHead'
 export * from './composables/useServerHeadSafe'
 export * from './composables/useServerSeoMeta'
-export * from './composables/useScript'
 export { setHeadInjectionHandler }
 
 export type { HeadTag, MergeHead, ActiveHeadEntry, Head, Unhead, HeadEntryOptions } from '@unhead/schema'

--- a/test/unhead/dom/order.test.ts
+++ b/test/unhead/dom/order.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 import type { HeadTag } from '@unhead/schema'
-import { createHead, getActiveHead, useHead } from 'unhead'
+import { createHead, injectHead, useHead } from 'unhead'
 import { renderDOMHead } from '@unhead/dom'
 import { useDom } from '../../fixtures'
 
@@ -22,7 +22,7 @@ describe('dom order', () => {
       script: [{ children: 'document.documentElement.classList.remove("no-js")' }],
     })
 
-    const head = getActiveHead()
+    const head = injectHead()
 
     const dom = useDom()
 

--- a/test/unhead/state.test.ts
+++ b/test/unhead/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'vitest'
-import { createHead, getActiveHead, useHead } from 'unhead'
+import { createHead, injectHead, useHead } from 'unhead'
 
 describe('state', () => {
   it('exists', async () => {
@@ -9,7 +9,7 @@ describe('state', () => {
       title: 'hello',
     })
 
-    const head = getActiveHead()
+    const head = injectHead()
     expect(head.headEntries()).toMatchInlineSnapshot(`
       [
         {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This change drops the use of the implicit shared context provided by the `activeHead ` export. Now we explicitly have the user opt-in to a shared head instance or they need to provide their own function to resolve the context.

:warning: Breaking Changes

- Removes the import `getActiveHead()`, instead you should use `injectHead()`.
- Does not automatically set a global head instance for servers, you will need to apply the context manually.

If you're not processing requests in parallel (such as a testing environment) then doing something like this is safe

```ts
const head = createSharedHead()

// just works - will leak in a server environment across parallel requests
useHead({ title: 'hello world' })
```

Otherwise, you will need to attach the head to a context and use that. For example, in Nuxt we do the below. The `useNuxtApp()` context is provided with [unctx](https://github.com/unjs/unctx).

```ts
setHeadInjectionHandler(() => useNuxtApp().vueApp._context.provides.usehead)
```

Note: It's important not to pass in a reference to a context within this function unless you're share it will be unique accross requests.

```ts
// bad
const nuxtApp = useNuxtApp() // context will leak across requests
setHeadInjectionHandler(() => nuxtApp.vueApp._context.provides.usehead)
```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
