### PR TITLE
fix: useSeoMeta regressions

### DIFF
--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -52,7 +52,7 @@ export interface BaseMeta extends Omit<_Meta, 'content'> {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content
    */
-  content?: MaybeArray<Stringable>
+  content?: MaybeArray<Stringable> | null
 }
 
 export type EntryAugmentation = undefined | Record<string, any>

--- a/packages/shared/export-size-report.json
+++ b/packages/shared/export-size-report.json
@@ -15,212 +15,212 @@
     {
       "name": "unpackMeta",
       "path": "dist/index.mjs",
-      "minified": 5783,
-      "minzipped": 1773,
-      "bundled": 9214
+      "minified": 3826,
+      "minzipped": 1374,
+      "bundled": 6843
     },
     {
       "name": "normaliseEntryTags",
       "path": "dist/index.mjs",
-      "minified": 5486,
-      "minzipped": 1661,
-      "bundled": 7520
+      "minified": 3648,
+      "minzipped": 1306,
+      "bundled": 5582
     },
     {
       "name": "normaliseTag",
       "path": "dist/index.mjs",
-      "minified": 5010,
-      "minzipped": 1489,
-      "bundled": 6731
+      "minified": 3172,
+      "minzipped": 1129,
+      "bundled": 4793
     },
     {
       "name": "whitelistSafeInput",
       "path": "dist/index.mjs",
-      "minified": 5051,
-      "minzipped": 1425,
-      "bundled": 7865
+      "minified": 3224,
+      "minzipped": 1072,
+      "bundled": 5943
     },
     {
       "name": "packMeta",
       "path": "dist/index.mjs",
-      "minified": 4464,
-      "minzipped": 1398,
-      "bundled": 6478
+      "minified": 2637,
+      "minzipped": 1040,
+      "bundled": 4556
     },
     {
       "name": "processTemplateParams",
       "path": "dist/index.mjs",
-      "minified": 4106,
-      "minzipped": 1241,
-      "bundled": 5414
+      "minified": 2279,
+      "minzipped": 876,
+      "bundled": 3492
     },
     {
       "name": "resolvePackedMetaObjectValue",
       "path": "dist/index.mjs",
-      "minified": 4186,
-      "minzipped": 1206,
-      "bundled": 5770
+      "minified": 2359,
+      "minzipped": 852,
+      "bundled": 3848
     },
     {
       "name": "normaliseProps",
       "path": "dist/index.mjs",
-      "minified": 4003,
-      "minzipped": 1159,
-      "bundled": 5256
+      "minified": 2176,
+      "minzipped": 800,
+      "bundled": 3334
     },
     {
       "name": "tagDedupeKey",
       "path": "dist/index.mjs",
-      "minified": 3823,
-      "minzipped": 1090,
-      "bundled": 4893
+      "minified": 1996,
+      "minzipped": 755,
+      "bundled": 2971
     },
     {
       "name": "tagWeight",
       "path": "dist/index.mjs",
-      "minified": 3761,
-      "minzipped": 1076,
-      "bundled": 4921
+      "minified": 1971,
+      "minzipped": 737,
+      "bundled": 3060
     },
     {
       "name": "hashTag",
       "path": "dist/index.mjs",
-      "minified": 3724,
-      "minzipped": 1062,
-      "bundled": 4634
+      "minified": 1897,
+      "minzipped": 725,
+      "bundled": 2712
     },
     {
       "name": "hashCode",
       "path": "dist/index.mjs",
-      "minified": 3568,
-      "minzipped": 1004,
-      "bundled": 4418
+      "minified": 1741,
+      "minzipped": 643,
+      "bundled": 2496
     },
     {
       "name": "normaliseClassProp",
       "path": "dist/index.mjs",
-      "minified": 3603,
-      "minzipped": 969,
-      "bundled": 4474
+      "minified": 1776,
+      "minzipped": 630,
+      "bundled": 2552
     },
     {
       "name": "ValidHeadTags",
       "path": "dist/index.mjs",
-      "minified": 3536,
-      "minzipped": 946,
-      "bundled": 4395
+      "minified": 1709,
+      "minzipped": 603,
+      "bundled": 2473
     },
     {
       "name": "composableNames",
       "path": "dist/index.mjs",
-      "minified": 3530,
-      "minzipped": 940,
-      "bundled": 4381
+      "minified": 1703,
+      "minzipped": 599,
+      "bundled": 2459
     },
     {
       "name": "TagConfigKeys",
       "path": "dist/index.mjs",
-      "minified": 3523,
-      "minzipped": 939,
-      "bundled": 4353
+      "minified": 1696,
+      "minzipped": 593,
+      "bundled": 2431
     },
     {
       "name": "UniqueTags",
       "path": "dist/index.mjs",
-      "minified": 3494,
-      "minzipped": 926,
-      "bundled": 4318
-    },
-    {
-      "name": "SortModifiers",
-      "path": "dist/index.mjs",
-      "minified": 3482,
-      "minzipped": 924,
-      "bundled": 4314
-    },
-    {
-      "name": "TagsWithInnerContent",
-      "path": "dist/index.mjs",
-      "minified": 3474,
-      "minzipped": 924,
-      "bundled": 4317
+      "minified": 1667,
+      "minzipped": 585,
+      "bundled": 2396
     },
     {
       "name": "resolveTitleTemplate",
       "path": "dist/index.mjs",
-      "minified": 3485,
-      "minzipped": 924,
-      "bundled": 4417
-    },
-    {
-      "name": "HasElementTags",
-      "path": "dist/index.mjs",
-      "minified": 3471,
-      "minzipped": 920,
-      "bundled": 4317
+      "minified": 1658,
+      "minzipped": 584,
+      "bundled": 2495
     },
     {
       "name": "TAG_ALIASES",
       "path": "dist/index.mjs",
-      "minified": 3455,
-      "minzipped": 916,
-      "bundled": 4285
-    },
-    {
-      "name": "asArray",
-      "path": "dist/index.mjs",
-      "minified": 3462,
-      "minzipped": 916,
-      "bundled": 4299
+      "minified": 1628,
+      "minzipped": 582,
+      "bundled": 2363
     },
     {
       "name": "resolveMetaKeyType",
       "path": "dist/index.mjs",
-      "minified": 3461,
-      "minzipped": 913,
-      "bundled": 4318
+      "minified": 1686,
+      "minzipped": 581,
+      "bundled": 2507
     },
     {
-      "name": "resolveMetaKeyValue",
+      "name": "SortModifiers",
       "path": "dist/index.mjs",
-      "minified": 3460,
-      "minzipped": 910,
-      "bundled": 4330
+      "minified": 1655,
+      "minzipped": 580,
+      "bundled": 2392
     },
     {
-      "name": "SelfClosingTags",
+      "name": "HasElementTags",
       "path": "dist/index.mjs",
-      "minified": 3443,
-      "minzipped": 909,
-      "bundled": 4274
+      "minified": 1644,
+      "minzipped": 578,
+      "bundled": 2395
     },
     {
       "name": "TAG_WEIGHTS",
       "path": "dist/index.mjs",
-      "minified": 3444,
-      "minzipped": 909,
-      "bundled": 4270
+      "minified": 1617,
+      "minzipped": 576,
+      "bundled": 2348
+    },
+    {
+      "name": "TagsWithInnerContent",
+      "path": "dist/index.mjs",
+      "minified": 1647,
+      "minzipped": 576,
+      "bundled": 2395
+    },
+    {
+      "name": "asArray",
+      "path": "dist/index.mjs",
+      "minified": 1635,
+      "minzipped": 574,
+      "bundled": 2377
+    },
+    {
+      "name": "resolveMetaKeyValue",
+      "path": "dist/index.mjs",
+      "minified": 1633,
+      "minzipped": 569,
+      "bundled": 2408
     },
     {
       "name": "IsBrowser",
       "path": "dist/index.mjs",
-      "minified": 3447,
-      "minzipped": 905,
-      "bundled": 4267
+      "minified": 1620,
+      "minzipped": 565,
+      "bundled": 2345
     },
     {
-      "name": "TagEntityBits",
+      "name": "SelfClosingTags",
       "path": "dist/index.mjs",
-      "minified": 3427,
-      "minzipped": 900,
-      "bundled": 4248
+      "minified": 1616,
+      "minzipped": 564,
+      "bundled": 2352
     },
     {
       "name": "defineHeadPlugin",
       "path": "dist/index.mjs",
-      "minified": 3441,
-      "minzipped": 899,
-      "bundled": 4282
+      "minified": 1614,
+      "minzipped": 561,
+      "bundled": 2360
+    },
+    {
+      "name": "TagEntityBits",
+      "path": "dist/index.mjs",
+      "minified": 1600,
+      "minzipped": 559,
+      "bundled": 2326
     }
   ]
 }

--- a/packages/shared/export-size-report.json
+++ b/packages/shared/export-size-report.json
@@ -15,9 +15,9 @@
     {
       "name": "unpackMeta",
       "path": "dist/index.mjs",
-      "minified": 3826,
-      "minzipped": 1374,
-      "bundled": 6843
+      "minified": 3870,
+      "minzipped": 1389,
+      "bundled": 6909
     },
     {
       "name": "normaliseEntryTags",

--- a/packages/shared/src/meta.ts
+++ b/packages/shared/src/meta.ts
@@ -190,10 +190,8 @@ export function unpackMeta<T extends MetaFlatInput>(input: T): Required<Head>['m
   // need to handle array input of the object
   const primitives: Record<string, any> = {}
   Object.entries(input).forEach(([key, value]) => {
-    if (!value)
-      return
     if (!Array.isArray(value)) {
-      if (typeof value === 'object') {
+      if (typeof value === 'object' && value) {
         if (ObjectArrayEntries.includes(fixKeyCase(key) as keyof MetaFlatInput)) {
           extras.push(...handleObjectEntry(key, value))
           return
@@ -231,7 +229,11 @@ export function unpackMeta<T extends MetaFlatInput>(input: T): Required<Head>['m
     },
   }) as BaseMeta[]
   // remove keys with defined but empty content
-  return [...extras, ...meta] as unknown as Required<Head>['meta']
+  return [...extras, ...meta].map((m) => {
+    if (m.content === '_null')
+      m.content = null
+    return m
+  }) as unknown as Required<Head>['meta']
 }
 
 /**

--- a/packages/shared/src/meta.ts
+++ b/packages/shared/src/meta.ts
@@ -20,16 +20,10 @@ const MetaPackingSchema: Record<string, PackingDefinition> = {
       },
     },
   },
-  articleAuthor: p('article:author'),
   articleExpirationTime: p('article:expiration_time'),
   articleModifiedTime: p('article:modified_time'),
   articlePublishedTime: p('article:published_time'),
-  articleSection: p('article:section'),
-  articleTag: p('article:tag'),
-  bookAuthor: p('book:author'),
-  bookIsbn: p('book:isbn'),
   bookReleaseDate: p('book:release_date'),
-  bookTag: p('book:tag'),
   charset: {
     metaKey: 'charset',
   },
@@ -53,32 +47,13 @@ const MetaPackingSchema: Record<string, PackingDefinition> = {
   msapplicationTileColor: k('msapplication-TileColor'),
   msapplicationTileImage: k('msapplication-TileImage'),
   ogAudioSecureUrl: p('og:audio:secure_url'),
-  ogAudioType: p('og:audio:type'),
   ogAudioUrl: p('og:audio'),
-  ogDescription: p('og:description'),
-  ogDeterminer: p('og:determiner'),
-  ogImage: p('og:image'),
-  ogImageAlt: p('og:image:alt'),
-  ogImageHeight: p('og:image:height'),
   ogImageSecureUrl: p('og:image:secure_url'),
-  ogImageType: p('og:image:type'),
   ogImageUrl: p('og:image'),
-  ogImageWidth: p('og:image:width'),
-  ogLocale: p('og:locale'),
-  ogLocaleAlternate: p('og:locale:alternate'),
   ogSiteName: p('og:site_name'),
-  ogTitle: p('og:title'),
-  ogType: p('og:type'),
-  ogUrl: p('og:url'),
-  ogVideo: p('og:video'),
-  ogVideoAlt: p('og:video:alt'),
-  ogVideoHeight: p('og:video:height'),
   ogVideoSecureUrl: p('og:video:secure_url'),
-  ogVideoType: p('og:video:type'),
   ogVideoUrl: p('og:video'),
-  ogVideoWidth: p('og:video:width'),
   profileFirstName: p('profile:first_name'),
-  profileGender: p('profile:gender'),
   profileLastName: p('profile:last_name'),
   profileUsername: p('profile:username'),
   refresh: {
@@ -103,45 +78,22 @@ const MetaPackingSchema: Record<string, PackingDefinition> = {
       },
     },
   },
-  twitterAppIdGoogleplay: k('twitter:app:id:googleplay'),
-  twitterAppIdIpad: k('twitter:app:id:ipad'),
-  twitterAppIdIphone: k('twitter:app:id:iphone'),
-  twitterAppNameGoogleplay: k('twitter:app:name:googleplay'),
-  twitterAppNameIpad: k('twitter:app:name:ipad'),
-  twitterAppNameIphone: k('twitter:app:name:iphone'),
-  twitterAppUrlGoogleplay: k('twitter:app:url:googleplay'),
-  twitterAppUrlIpad: k('twitter:app:url:ipad'),
-  twitterAppUrlIphone: k('twitter:app:url:iphone'),
-  twitterCard: k('twitter:card'),
-  twitterCreator: k('twitter:creator'),
-  twitterCreatorId: k('twitter:creator:id'),
-  twitterData1: k('twitter:data1'),
-  twitterData2: k('twitter:data2'),
-  twitterDescription: k('twitter:description'),
-  twitterImage: k('twitter:image'),
-  twitterImageAlt: k('twitter:image:alt'),
-  /*************************************************/
-  // not part of Twitter's card specification anymore
-  twitterImageHeight: k('twitter:image:height'),
-  twitterImageType: k('twitter:image:type'),
-  twitterImageUrl: k('twitter:image'),
-  twitterImageWidth: k('twitter:image:width'),
-  /**************************************************/
-  twitterLabel1: k('twitter:label1'),
-  twitterLabel2: k('twitter:label2'),
-  twitterPlayer: k('twitter:player'),
-  twitterPlayerHeight: k('twitter:player:height'),
-  twitterPlayerStream: k('twitter:player:stream'),
-  twitterPlayerWidth: k('twitter:player:width'),
-  twitterSite: k('twitter:site'),
-  twitterSiteId: k('twitter:site:id'),
-  twitterTitle: k('twitter:title'),
   xUaCompatible: {
     metaKey: 'http-equiv',
   },
 } as const
 
+const openGraphNamespaces = [
+  'og',
+  'book',
+  'article',
+  'profile',
+]
+
 export function resolveMetaKeyType(key: string): keyof BaseMeta {
+  const fKey = fixKeyCase(key).split(':')[0]
+  if (openGraphNamespaces.includes(fKey))
+    return 'property'
   return MetaPackingSchema[key]?.metaKey || 'name'
 }
 
@@ -150,7 +102,11 @@ export function resolveMetaKeyValue(key: string): string {
 }
 
 function fixKeyCase(key: string) {
-  return key.replace(/([A-Z])/g, '-$1').toLowerCase()
+  const updated = key.replace(/([A-Z])/g, '-$1').toLowerCase()
+  const fKey = updated.split('-')[0]
+  if (openGraphNamespaces.includes(fKey) || fKey === 'twitter')
+    return key.replace(/([A-Z])/g, ':$1').toLowerCase()
+  return updated
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
@@ -191,66 +147,38 @@ export function resolvePackedMetaObjectValue(value: string, key: string): string
   )
 }
 
-const SimpleArrayUnpackMetas: (keyof MetaFlatInput)[] = ['themeColor']
+const ObjectArrayEntries = ['og:image', 'og:video', 'og:audio', 'twitter:image']
 
-function getMeta(key: string, value?: string) {
-  const meta: BaseMeta = {}
-  const metaKeyType = resolveMetaKeyType(key)
-
-  if (metaKeyType === 'charset') {
-    meta[metaKeyType] = value
-  }
-  else {
-    // @ts-expect-error not sure
-    meta[metaKeyType] = resolveMetaKeyValue(key)
-    meta.content = value
-  }
-
-  return meta
+function sanitize(input: Record<string, any>) {
+  const out: Record<string, any> = {}
+  Object.entries(input).forEach(([k, v]) => {
+    if (String(v) !== 'false' && k)
+      out[k] = v
+  })
+  return out
 }
 
-function flattenMetaObjects(input: MetaFlatInput, prefix: string = '') {
-  const extras: BaseMeta[] = []
-  for (const [k, v] of Object.entries(input)) {
-    const key = k as keyof MetaFlatInput
-    const value = v as MetaFlatInput
-    const fullkey = `${prefix}${prefix === '' ? key : key.charAt(0).toUpperCase() + key.slice(1)}`
-    const unpacker = MetaPackingSchema[key]?.unpack
-
-    if (unpacker) {
-      extras.push(getMeta(fullkey, unpackToString(value as Record<string, any>, unpacker)))
-      delete input[key]
-      continue
-    }
-
-    if (!value) {
-      extras.push(getMeta(fullkey, value))
-      delete input[key]
-      continue
-    }
-
-    if (typeof value === 'object') {
-      const children = Array.isArray(value) ? value : [value]
-
-      for (const child of children) {
-        if (!child)
-          extras.push(getMeta(fullkey, child))
-        else if (typeof child === 'object')
-          extras.push(...flattenMetaObjects(child, fullkey))
-        else
-          extras.push(getMeta(fullkey, child))
-      }
-
-      delete input[key]
-    }
-    else {
-      extras.push(getMeta(fullkey, value))
-      if (typeof input === 'object')
-        delete input[key]
-    }
+function handleObjectEntry(key: string, v: Record<string, any>) {
+  // filter out falsy values
+  const value: Record<string, any> = sanitize(v)
+  const fKey = fixKeyCase(key)
+  const attr = resolveMetaKeyType(fKey)
+  if (ObjectArrayEntries.includes(fKey as keyof MetaFlatInput)) {
+    const input: MetaFlatInput = {}
+    // we need to prefix the keys with og:
+    Object.entries(value).forEach(([k, v]) => {
+      // @ts-expect-error untyped
+      input[`${key}${k === 'url' ? '' : `${k.charAt(0).toUpperCase()}${k.slice(1)}`}`] = v
+    })
+    const unpacked = unpackMeta(input)
+      // sort by property name
+      .sort((a, b) =>
+        // @ts-expect-error untyped
+        (a[attr]?.length || 0) - (b[attr]?.length || 0),
+      ) as BaseMeta[]
+    return unpacked
   }
-
-  return extras
+  return [{ [attr]: fKey, ...value }] as BaseMeta[]
 }
 
 /**
@@ -259,39 +187,30 @@ function flattenMetaObjects(input: MetaFlatInput, prefix: string = '') {
  */
 export function unpackMeta<T extends MetaFlatInput>(input: T): Required<Head>['meta'] {
   const extras: BaseMeta[] = []
-
-  SimpleArrayUnpackMetas.forEach((meta: keyof T) => {
-    if (input[meta] && typeof input[meta] !== 'string') {
-      // maybe it's an array, convert to array
-      const val = (Array.isArray(input[meta]) ? input[meta] : [input[meta]]) as (Record<string, string>)[]
-      // for each array entry
-      delete input[meta]
-      val.forEach((entry) => {
-        extras.push({
-          name: fixKeyCase(meta as string),
-          ...entry,
-        })
-      })
+  // need to handle array input of the object
+  const primitives: Record<string, any> = {}
+  Object.entries(input).forEach(([key, value]) => {
+    if (!value)
+      return
+    if (!Array.isArray(value)) {
+      if (typeof value === 'object') {
+        if (ObjectArrayEntries.includes(fixKeyCase(key) as keyof MetaFlatInput)) {
+          extras.push(...handleObjectEntry(key, value))
+          return
+        }
+        primitives[key] = sanitize(value)
+      }
+      else {
+        primitives[key] = value
+      }
+      return
     }
+    value.forEach((v) => {
+      extras.push(...(typeof v === 'string' ? unpackMeta({ [key]: v }) as BaseMeta[] : handleObjectEntry(key, v)))
+    })
   })
 
-  extras.push(
-    // need to sort the entry and make sure the `og:image` is first
-    ...flattenMetaObjects(input).sort((a, b) => {
-      if (a.property?.startsWith('og:image')) {
-        if (b.property?.startsWith('og:image'))
-          return 0
-        else
-          return -1
-      }
-
-      if (b.property?.startsWith('og:image'))
-        return 1
-
-      return 0
-    }))
-
-  const meta = unpackToArray((input), {
+  const meta = unpackToArray((primitives), {
     key({ key }) {
       return resolveMetaKeyType(key) as string
     },

--- a/packages/ssr/export-size-report.json
+++ b/packages/ssr/export-size-report.json
@@ -15,23 +15,23 @@
     {
       "name": "renderSSRHead",
       "path": "dist/index.mjs",
-      "minified": 1665,
-      "minzipped": 692,
-      "bundled": 2769
+      "minified": 1509,
+      "minzipped": 631,
+      "bundled": 2561
     },
     {
       "name": "ssrRenderTags",
       "path": "dist/index.mjs",
-      "minified": 1309,
-      "minzipped": 565,
-      "bundled": 2181
+      "minified": 1153,
+      "minzipped": 515,
+      "bundled": 1973
     },
     {
       "name": "tagToString",
       "path": "dist/index.mjs",
-      "minified": 908,
-      "minzipped": 416,
-      "bundled": 1548
+      "minified": 752,
+      "minzipped": 371,
+      "bundled": 1340
     },
     {
       "name": "propsToString",
@@ -46,13 +46,6 @@
       "minified": 249,
       "minzipped": 136,
       "bundled": 504
-    },
-    {
-      "name": "escapeJson",
-      "path": "dist/index.mjs",
-      "minified": 86,
-      "minzipped": 85,
-      "bundled": 188
     }
   ]
 }

--- a/packages/unhead/export-size-report.json
+++ b/packages/unhead/export-size-report.json
@@ -17,100 +17,100 @@
     {
       "name": "createHead",
       "path": "dist/index.mjs",
-      "minified": 5569,
-      "minzipped": 2067,
-      "bundled": 11611
+      "minified": 5664,
+      "minzipped": 2083,
+      "bundled": 11731
     },
     {
       "name": "createServerHead",
       "path": "dist/index.mjs",
-      "minified": 5528,
-      "minzipped": 2053,
-      "bundled": 11577
+      "minified": 5623,
+      "minzipped": 2081,
+      "bundled": 11697
     },
     {
       "name": "createHeadCore",
       "path": "dist/index.mjs",
-      "minified": 5495,
-      "minzipped": 2042,
-      "bundled": 11468
+      "minified": 5590,
+      "minzipped": 2065,
+      "bundled": 11588
     },
     {
       "name": "CapoPlugin",
       "path": "dist/index.mjs",
-      "minified": 5048,
-      "minzipped": 1805,
-      "bundled": 10465
+      "minified": 5185,
+      "minzipped": 1840,
+      "bundled": 10690
     },
     {
       "name": "useServerSeoMeta",
       "path": "dist/index.mjs",
-      "minified": 4482,
-      "minzipped": 1653,
-      "bundled": 9398
+      "minified": 4577,
+      "minzipped": 1670,
+      "bundled": 9518
     },
     {
       "name": "useSeoMeta",
       "path": "dist/index.mjs",
-      "minified": 4429,
-      "minzipped": 1641,
-      "bundled": 9270
+      "minified": 4524,
+      "minzipped": 1655,
+      "bundled": 9390
     },
     {
       "name": "useServerHeadSafe",
       "path": "dist/index.mjs",
-      "minified": 4441,
-      "minzipped": 1630,
-      "bundled": 9342
+      "minified": 4536,
+      "minzipped": 1654,
+      "bundled": 9462
     },
     {
       "name": "useHeadSafe",
       "path": "dist/index.mjs",
-      "minified": 4389,
-      "minzipped": 1624,
-      "bundled": 9223
+      "minified": 4484,
+      "minzipped": 1650,
+      "bundled": 9343
     },
     {
       "name": "useServerHead",
       "path": "dist/index.mjs",
-      "minified": 4363,
-      "minzipped": 1611,
-      "bundled": 9196
+      "minified": 4458,
+      "minzipped": 1629,
+      "bundled": 9316
     },
     {
       "name": "useHead",
       "path": "dist/index.mjs",
-      "minified": 4311,
-      "minzipped": 1588,
-      "bundled": 9085
+      "minified": 4406,
+      "minzipped": 1611,
+      "bundled": 9205
     },
     {
       "name": "unheadComposablesImports",
       "path": "dist/index.mjs",
-      "minified": 4288,
-      "minzipped": 1582,
-      "bundled": 9002
+      "minified": 4383,
+      "minzipped": 1608,
+      "bundled": 9122
     },
     {
       "name": "composableNames",
       "path": "dist/index.mjs",
-      "minified": 4258,
-      "minzipped": 1565,
-      "bundled": 8901
-    },
-    {
-      "name": "HashHydrationPlugin",
-      "path": "dist/index.mjs",
-      "minified": 4263,
-      "minzipped": 1564,
-      "bundled": 8970
+      "minified": 4353,
+      "minzipped": 1591,
+      "bundled": 9021
     },
     {
       "name": "getActiveHead",
       "path": "dist/index.mjs",
-      "minified": 4261,
-      "minzipped": 1564,
-      "bundled": 8964
+      "minified": 4356,
+      "minzipped": 1590,
+      "bundled": 9084
+    },
+    {
+      "name": "HashHydrationPlugin",
+      "path": "dist/index.mjs",
+      "minified": 4358,
+      "minzipped": 1586,
+      "bundled": 9090
     }
   ]
 }

--- a/packages/vue/export-size-report.json
+++ b/packages/vue/export-size-report.json
@@ -18,93 +18,93 @@
     {
       "name": "VueHeadMixin",
       "path": "dist/index.mjs",
-      "minified": 1786,
-      "minzipped": 820,
-      "bundled": 3648
+      "minified": 1803,
+      "minzipped": 826,
+      "bundled": 3722
     },
     {
       "name": "useServerSeoMeta",
       "path": "dist/index.mjs",
-      "minified": 1755,
-      "minzipped": 807,
-      "bundled": 3549
+      "minified": 1772,
+      "minzipped": 819,
+      "bundled": 3623
     },
     {
       "name": "useSeoMeta",
       "path": "dist/index.mjs",
-      "minified": 1702,
-      "minzipped": 784,
-      "bundled": 3431
+      "minified": 1719,
+      "minzipped": 801,
+      "bundled": 3505
     },
     {
       "name": "useServerHeadSafe",
       "path": "dist/index.mjs",
-      "minified": 1638,
-      "minzipped": 762,
-      "bundled": 3323
+      "minified": 1655,
+      "minzipped": 771,
+      "bundled": 3397
     },
     {
       "name": "useHeadSafe",
       "path": "dist/index.mjs",
-      "minified": 1586,
-      "minzipped": 754,
-      "bundled": 3204
+      "minified": 1603,
+      "minzipped": 752,
+      "bundled": 3278
     },
     {
       "name": "useHead",
       "path": "dist/index.mjs",
-      "minified": 1512,
-      "minzipped": 716,
-      "bundled": 3082
+      "minified": 1529,
+      "minzipped": 746,
+      "bundled": 3156
     },
     {
       "name": "useServerHead",
       "path": "dist/index.mjs",
       "minified": 1212,
-      "minzipped": 574,
-      "bundled": 2463
+      "minzipped": 575,
+      "bundled": 2326
     },
     {
       "name": "injectHead",
       "path": "dist/index.mjs",
       "minified": 1116,
-      "minzipped": 535,
-      "bundled": 2271
+      "minzipped": 534,
+      "bundled": 2134
     },
     {
       "name": "createHead",
       "path": "dist/index.mjs",
       "minified": 976,
-      "minzipped": 481,
-      "bundled": 2231
+      "minzipped": 482,
+      "bundled": 2094
     },
     {
       "name": "createServerHead",
       "path": "dist/index.mjs",
       "minified": 907,
-      "minzipped": 445,
-      "bundled": 2151
+      "minzipped": 441,
+      "bundled": 2014
     },
     {
       "name": "Vue2ProvideUnheadPlugin",
       "path": "dist/index.mjs",
       "minified": 855,
-      "minzipped": 434,
-      "bundled": 2229
+      "minzipped": 436,
+      "bundled": 2092
     },
     {
       "name": "setHeadInjectionHandler",
       "path": "dist/index.mjs",
       "minified": 872,
-      "minzipped": 425,
-      "bundled": 2000
+      "minzipped": 426,
+      "bundled": 1863
     },
     {
       "name": "resolveUnrefHeadInput",
       "path": "dist/index.mjs",
       "minified": 673,
-      "minzipped": 357,
-      "bundled": 1686
+      "minzipped": 360,
+      "bundled": 1549
     },
     {
       "name": "HashHydrationPlugin",

--- a/test/unhead/ssr/ssr.test.ts
+++ b/test/unhead/ssr/ssr.test.ts
@@ -123,13 +123,13 @@ describe('ssr', () => {
         "bodyTagsOpen": "",
         "headTags": "<meta charset=\\"utf-8\\">
       <title>page name - site</title>
-      <meta property=\\"og:image\\" content=\\"https://example.com/image.png\\">
-      <meta property=\\"og:image:width\\" content=\\"800\\">
-      <meta property=\\"og:image:height\\" content=\\"600\\">
-      <meta property=\\"og:image:alt\\" content=\\"My amazing image\\">
-      <meta name=\\"description\\" content=\\"test\\">
       <meta property=\\"og:locale:alternate\\" content=\\"fr\\">
       <meta property=\\"og:locale:alternate\\" content=\\"zh\\">
+      <meta property=\\"og:image\\" content=\\"https://example.com/image.png\\">
+      <meta property=\\"og:image:alt\\" content=\\"My amazing image\\">
+      <meta property=\\"og:image:width\\" content=\\"800\\">
+      <meta property=\\"og:image:height\\" content=\\"600\\">
+      <meta name=\\"description\\" content=\\"test\\">
       <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">",
         "htmlAttrs": "",
       }
@@ -153,10 +153,10 @@ describe('ssr', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<meta property=\\"og:image\\" content=\\"https://example.com/image.png\\">
-      <meta name=\\"description\\" content=\\"This is my amazing site, let me tell you all about it.\\">
+        "headTags": "<meta name=\\"description\\" content=\\"This is my amazing site, let me tell you all about it.\\">
       <meta property=\\"og:description\\" content=\\"This is my amazing site, let me tell you all about it.\\">
       <meta property=\\"og:title\\" content=\\"My Amazing Site\\">
+      <meta property=\\"og:image\\" content=\\"https://example.com/image.png\\">
       <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">",
         "htmlAttrs": "",
       }

--- a/test/unhead/useSeoMeta.test.ts
+++ b/test/unhead/useSeoMeta.test.ts
@@ -102,6 +102,7 @@ describe('useSeoMeta', () => {
       description: null,
     })
 
+    // TODO this is wrong, it needs to _remove_ the description
     expect(await renderSSRHead(head)).toMatchInlineSnapshot(`
       {
         "bodyAttrs": "",

--- a/test/unhead/useSeoMeta.test.ts
+++ b/test/unhead/useSeoMeta.test.ts
@@ -107,7 +107,44 @@ describe('useSeoMeta', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "",
+        "headTags": "<meta name=\\"description\\" content=\\"test\\">",
+        "htmlAttrs": "",
+      }
+    `)
+  })
+
+  it('string object', async () => {
+    const head = createHead()
+    useSeoMeta({
+      robots: 'noindex, nofollow',
+    })
+    expect(await renderSSRHead(head)).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<meta name=\\"robots\\" content=\\"noindex, nofollow\\">",
+        "htmlAttrs": "",
+      }
+    `)
+  })
+
+  it('robots falsy', async () => {
+    const head = createHead()
+    useSeoMeta({
+      robots: {
+        index: true,
+        nofollow: false,
+        noindex: false,
+        maxSnippet: -1,
+      },
+    })
+    expect(await renderSSRHead(head)).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<meta name=\\"robots\\" content=\\"index, max-snippet:-1\\">",
         "htmlAttrs": "",
       }
     `)
@@ -192,14 +229,14 @@ describe('useSeoMeta', () => {
       ogDescription: 'Description',
       ogDeterminer: 'auto',
       ogImage: [{
-        alt: 'Alt',
+        alt: 'First',
         height: 1337,
         secureUrl: 'https://example.com',
         type: 'image/gif',
         url: 'https://example.com',
         width: 1337,
       }],
-      ogImageAlt: 'Alt',
+      ogImageAlt: 'Second',
       ogImageHeight: 1337,
       ogImageSecureUrl: 'https://example.com',
       ogImageType: 'image/gif',
@@ -299,38 +336,41 @@ describe('useSeoMeta', () => {
       <meta charset=\\"utf-8\\">
       <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
       <title>Title</title>
-      <meta property=\\"og:image:alt\\" content=\\"Alt\\">
+      <meta property=\\"article:author\\" content=\\"https://example.com/some.html\\">
+      <meta property=\\"article:author\\" content=\\"https://example.com/one.html\\">
+      <meta property=\\"article:tag\\" content=\\"Apple\\">
+      <meta property=\\"article:tag\\" content=\\"Steve Jobs\\">
+      <meta property=\\"book:author\\" content=\\"https://example.com/some.html\\">
+      <meta property=\\"book:author\\" content=\\"https://example.com/one.html\\">
+      <meta property=\\"book:tag\\" content=\\"Apple\\">
+      <meta property=\\"book:tag\\" content=\\"Steve Jobs\\">
+      <meta property=\\"og:audio\\" content=\\"https://example.com\\">
+      <meta property=\\"og:audio:type\\" content=\\"audio/mpeg\\">
+      <meta property=\\"og:audio:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image:alt\\" content=\\"First\\">
+      <meta property=\\"og:image:type\\" content=\\"image/gif\\">
+      <meta property=\\"og:image:width\\" content=\\"1337\\">
       <meta property=\\"og:image:height\\" content=\\"1337\\">
       <meta property=\\"og:image:secure_url\\" content=\\"https://example.com\\">
-      <meta property=\\"og:image:type\\" content=\\"image/gif\\">
-      <meta property=\\"og:image\\" content=\\"https://example.com\\">
-      <meta property=\\"og:image:width\\" content=\\"1337\\">
-      <meta property=\\"og:image:alt\\" content=\\"Alt\\">
-      <meta property=\\"og:image:height\\" content=\\"1337\\">
-      <meta property=\\"og:image:secure_url\\" content=\\"https://example.com\\">
-      <meta property=\\"og:image:type\\" content=\\"image/gif\\">
-      <meta property=\\"og:image\\" content=\\"https://example.com\\">
-      <meta property=\\"og:image:width\\" content=\\"1337\\">
+      <meta property=\\"og:video\\" content=\\"https://example.com\\">
+      <meta property=\\"og:video:alt\\" content=\\"Alt\\">
+      <meta property=\\"og:video:type\\" content=\\"application/x-shockwave-flash\\">
+      <meta property=\\"og:video:width\\" content=\\"1337\\">
+      <meta property=\\"og:video:height\\" content=\\"1337\\">
+      <meta property=\\"og:video:secure_url\\" content=\\"https://example.com\\">
       <meta name=\\"apple-itunes-app\\" content=\\"app-id=id, app-argument=https://example.com\\">
       <meta name=\\"apple-mobile-web-app-capable\\" content=\\"yes\\">
       <meta name=\\"apple-mobile-web-app-status-bar-style\\" content=\\"black\\">
       <meta name=\\"apple-mobile-web-app-title\\" content=\\"Title\\">
       <meta name=\\"application-name\\" content=\\"Name\\">
-      <meta property=\\"article:author\\" content=\\"https://example.com/some.html\\">
-      <meta property=\\"article:author\\" content=\\"https://example.com/one.html\\">
       <meta property=\\"article:expiration_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
       <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
       <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
       <meta property=\\"article:section\\" content=\\"Technology\\">
-      <meta property=\\"article:tag\\" content=\\"Apple\\">
-      <meta property=\\"article:tag\\" content=\\"Steve Jobs\\">
       <meta name=\\"author\\" content=\\"Name\\">
-      <meta property=\\"book:author\\" content=\\"https://example.com/some.html\\">
-      <meta property=\\"book:author\\" content=\\"https://example.com/one.html\\">
       <meta property=\\"book:isbn\\" content=\\"978-3-16-148410-0\\">
       <meta property=\\"book:release_date\\" content=\\"1970-01-01T00:00:00.000Z\\">
-      <meta property=\\"book:tag\\" content=\\"Apple\\">
-      <meta property=\\"book:tag\\" content=\\"Steve Jobs\\">
       <meta name=\\"color-scheme\\" content=\\"normal\\">
       <meta http-equiv=\\"content-type\\" content=\\"text/html; charset=utf-8\\">
       <meta name=\\"creator\\" content=\\"Name\\">
@@ -349,23 +389,20 @@ describe('useSeoMeta', () => {
       <meta property=\\"og:audio:secure_url\\" content=\\"https://example.com\\">
       <meta property=\\"og:audio:type\\" content=\\"audio/mpeg\\">
       <meta property=\\"og:audio\\" content=\\"https://example.com\\">
-      <meta property=\\"og:audio:secure_url\\" content=\\"https://example.com\\">
-      <meta property=\\"og:audio:type\\" content=\\"audio/mpeg\\">
-      <meta property=\\"og:audio\\" content=\\"https://example.com\\">
       <meta property=\\"og:description\\" content=\\"Description\\">
       <meta property=\\"og:determiner\\" content=\\"auto\\">
+      <meta property=\\"og:image:alt\\" content=\\"Second\\">
+      <meta property=\\"og:image:height\\" content=\\"1337\\">
+      <meta property=\\"og:image:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image:type\\" content=\\"image/gif\\">
+      <meta property=\\"og:image\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image:width\\" content=\\"1337\\">
       <meta property=\\"og:locale\\" content=\\"en-US\\">
       <meta property=\\"og:locale:alternate\\" content=\\"de-DE\\">
       <meta property=\\"og:site_name\\" content=\\"Name\\">
       <meta property=\\"og:title\\" content=\\"Title\\">
       <meta property=\\"og:type\\" content=\\"article\\">
       <meta property=\\"og:url\\" content=\\"https://example.com\\">
-      <meta property=\\"og:video:alt\\" content=\\"Alt\\">
-      <meta property=\\"og:video:height\\" content=\\"1337\\">
-      <meta property=\\"og:video:secure_url\\" content=\\"https://example.com\\">
-      <meta property=\\"og:video:type\\" content=\\"application/x-shockwave-flash\\">
-      <meta property=\\"og:video\\" content=\\"https://example.com\\">
-      <meta property=\\"og:video:width\\" content=\\"1337\\">
       <meta property=\\"og:video:alt\\" content=\\"Alt\\">
       <meta property=\\"og:video:height\\" content=\\"1337\\">
       <meta property=\\"og:video:secure_url\\" content=\\"https://example.com\\">
@@ -412,6 +449,148 @@ describe('useSeoMeta', () => {
       <meta name=\\"twitter:site:id\\" content=\\"id\\">
       <meta name=\\"twitter:title\\" content=\\"Title\\">
       <meta http-equiv=\\"x-ua-compatible\\" content=\\"IE=edge\\">",
+        "htmlAttrs": "",
+      }
+    `)
+  })
+
+  it('arrayable meta tags', async () => {
+    const head = createHead()
+    useSeoMeta({
+      ogAudio: [{
+        secureUrl: 'https://example.com',
+        type: 'audio/mpeg',
+        url: 'https://example.com',
+      }],
+      ogImage: [{
+        alt: 'First',
+        height: 1337,
+        secureUrl: 'https://first.com',
+        type: 'image/gif',
+        url: 'https://first.com',
+        width: 1337,
+      },
+      {
+        alt: 'Second',
+        height: 1337,
+        secureUrl: 'https://second.com',
+        type: 'image/gif',
+        url: 'https://second.com',
+        width: 1337,
+      }],
+      ogVideo: [{
+        alt: 'Alt',
+        height: 1337,
+        secureUrl: 'https://example.com',
+        type: 'application/x-shockwave-flash',
+        url: 'https://example.com',
+        width: 1337,
+      }],
+      twitterImage: [
+        {
+          url: 'https://example.com',
+          alt: 'Alt',
+          width: 1337,
+          height: 1337,
+          type: 'image/gif',
+        },
+      ],
+    })
+
+    expect(await renderSSRHead(head)).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<meta property=\\"og:audio\\" content=\\"https://example.com\\">
+      <meta property=\\"og:audio:type\\" content=\\"audio/mpeg\\">
+      <meta property=\\"og:audio:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image\\" content=\\"https://first.com\\">
+      <meta property=\\"og:image:alt\\" content=\\"First\\">
+      <meta property=\\"og:image:type\\" content=\\"image/gif\\">
+      <meta property=\\"og:image:width\\" content=\\"1337\\">
+      <meta property=\\"og:image:height\\" content=\\"1337\\">
+      <meta property=\\"og:image:secure_url\\" content=\\"https://first.com\\">
+      <meta property=\\"og:image\\" content=\\"https://second.com\\">
+      <meta property=\\"og:image:alt\\" content=\\"Second\\">
+      <meta property=\\"og:image:type\\" content=\\"image/gif\\">
+      <meta property=\\"og:image:width\\" content=\\"1337\\">
+      <meta property=\\"og:image:height\\" content=\\"1337\\">
+      <meta property=\\"og:image:secure_url\\" content=\\"https://second.com\\">
+      <meta property=\\"og:video\\" content=\\"https://example.com\\">
+      <meta property=\\"og:video:alt\\" content=\\"Alt\\">
+      <meta property=\\"og:video:type\\" content=\\"application/x-shockwave-flash\\">
+      <meta property=\\"og:video:width\\" content=\\"1337\\">
+      <meta property=\\"og:video:height\\" content=\\"1337\\">
+      <meta property=\\"og:video:secure_url\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:image\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:image:alt\\" content=\\"Alt\\">
+      <meta name=\\"twitter:image:type\\" content=\\"image/gif\\">
+      <meta name=\\"twitter:image:width\\" content=\\"1337\\">
+      <meta name=\\"twitter:image:height\\" content=\\"1337\\">",
+        "htmlAttrs": "",
+      }
+    `)
+  })
+
+  it('object meta tags', async () => {
+    const head = createHead()
+    useSeoMeta({
+      ogAudio: {
+        secureUrl: 'https://example.com',
+        type: 'audio/mpeg',
+        url: 'https://example.com',
+      },
+      ogImage: {
+        alt: 'First',
+        height: 1337,
+        secureUrl: 'https://first.com',
+        type: 'image/gif',
+        url: 'https://first.com',
+        width: 1337,
+      },
+      ogVideo: {
+        alt: 'Alt',
+        height: 1337,
+        secureUrl: 'https://example.com',
+        type: 'application/x-shockwave-flash',
+        url: 'https://example.com',
+        width: 1337,
+      },
+      twitterImage: {
+        url: 'https://example.com',
+        alt: 'Alt',
+        width: 1337,
+        height: 1337,
+        type: 'image/gif',
+      },
+    })
+
+    expect(await renderSSRHead(head)).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<meta property=\\"og:audio\\" content=\\"https://example.com\\">
+      <meta property=\\"og:audio:type\\" content=\\"audio/mpeg\\">
+      <meta property=\\"og:audio:secure_url\\" content=\\"https://example.com\\">
+      <meta property=\\"og:image\\" content=\\"https://first.com\\">
+      <meta property=\\"og:image:alt\\" content=\\"First\\">
+      <meta property=\\"og:image:type\\" content=\\"image/gif\\">
+      <meta property=\\"og:image:width\\" content=\\"1337\\">
+      <meta property=\\"og:image:height\\" content=\\"1337\\">
+      <meta property=\\"og:image:secure_url\\" content=\\"https://first.com\\">
+      <meta property=\\"og:video\\" content=\\"https://example.com\\">
+      <meta property=\\"og:video:alt\\" content=\\"Alt\\">
+      <meta property=\\"og:video:type\\" content=\\"application/x-shockwave-flash\\">
+      <meta property=\\"og:video:width\\" content=\\"1337\\">
+      <meta property=\\"og:video:height\\" content=\\"1337\\">
+      <meta property=\\"og:video:secure_url\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:image\\" content=\\"https://example.com\\">
+      <meta name=\\"twitter:image:alt\\" content=\\"Alt\\">
+      <meta name=\\"twitter:image:type\\" content=\\"image/gif\\">
+      <meta name=\\"twitter:image:width\\" content=\\"1337\\">
+      <meta name=\\"twitter:image:height\\" content=\\"1337\\">",
         "htmlAttrs": "",
       }
     `)

--- a/test/unhead/useSeoMeta.test.ts
+++ b/test/unhead/useSeoMeta.test.ts
@@ -102,13 +102,12 @@ describe('useSeoMeta', () => {
       description: null,
     })
 
-    // TODO this is wrong, it needs to _remove_ the description
     expect(await renderSSRHead(head)).toMatchInlineSnapshot(`
       {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<meta name=\\"description\\" content=\\"test\\">",
+        "headTags": "",
         "htmlAttrs": "",
       }
     `)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Using a string with `robots` is failing pretty badly at the moment.

```ts
useSeoMeta({
  robots: process.env.NODE_ENV !== 'production' ? 'noindex, nofollow' : 'index, follow',
})
```

```html
<meta name="robots" content="0:n, 1:o, 2:i, 3:n, 4:d, 5:e, 6:x, 7:,, 8: , 9:n, 10:o, 11:f, 12:o, 13:l, 14:l, 15:o, 16:w">
```

- Also, it's wrongly adding falsy attributes in 

```ts
  useSeoMeta({
      robots: {
        index: true,
        nofollow: false,
        noindex: false,
        maxSnippet: -1,
      },
    })
```

```html
<meta name="robots" content="index, nofollow, noindex, max-snippet:-1">
```

- It's stripping `null` values

```ts
    useSeoMeta({
      description: 'test',
    })

    useSeoMeta({
      description: null,
    })
```

```html
<meta name="description" content="test" />
```

This also fixes the build output growing quite a bit, this drops it around 20% minzipped

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
