### PR TITLE
fix: unhead version compatibility resilience

### DIFF
--- a/packages/vue/src/autoImports.ts
+++ b/packages/vue/src/autoImports.ts
@@ -5,5 +5,5 @@ const coreComposableNames = [
 ]
 
 export const unheadVueComposablesImports = {
-  '@unhead/vue': [].concat(coreComposableNames, composableNames),
+  '@unhead/vue': [...coreComposableNames, ...(composableNames || [])],
 }

--- a/packages/vue/src/autoImports.ts
+++ b/packages/vue/src/autoImports.ts
@@ -5,5 +5,5 @@ const coreComposableNames = [
 ]
 
 export const unheadVueComposablesImports = {
-  '@unhead/vue': [...coreComposableNames, ...composableNames],
+  '@unhead/vue': [].concat(coreComposableNames, composableNames),
 }


### PR DESCRIPTION
This solves an issue when serving unhead together with nuxt 3 from a monorepo. 

### 🔗 Linked issue

See https://github.com/nuxt/nuxt/issues/23026 for details.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->


<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
