### PR TITLE
feat(unhead): plugin `key` for JIT hooks 

### DIFF
--- a/packages/schema-org/src/runtime.ts
+++ b/packages/schema-org/src/runtime.ts
@@ -158,6 +158,7 @@ export function useSchemaOrg(input?: any): any {
       {
         type: 'application/ld+json',
         key: 'schema-org-graph',
+        // @ts-expect-error untyped
         nodes: input,
       },
     ],

--- a/packages/schema/src/head.ts
+++ b/packages/schema/src/head.ts
@@ -55,7 +55,8 @@ export interface HeadEntry<Input> {
 
 export type HeadPluginOptions = Omit<CreateHeadOptions, 'plugins'> & { mode?: RuntimeMode }
 
-export type HeadPlugin = HeadPluginOptions | ((head: Unhead) => HeadPluginOptions)
+export type HeadPluginInput = HeadPluginOptions & { key?: string } | ((head: Unhead) => HeadPluginOptions & { key?: string })
+export type HeadPlugin = HeadPluginOptions & { key?: string }
 
 /**
  * An active head entry provides an API to manipulate it.
@@ -78,7 +79,7 @@ export interface ActiveHeadEntry<Input> {
 export interface CreateHeadOptions {
   domDelayFn?: (fn: () => void) => void
   document?: Document
-  plugins?: HeadPlugin[]
+  plugins?: HeadPluginInput[]
   hooks?: NestedHooks<HeadHooks>
 }
 
@@ -89,6 +90,10 @@ export interface HeadEntryOptions extends TagPosition, TagPriority, ProcessesTem
 }
 
 export interface Unhead<Input extends {} = Head> {
+  /**
+   * Registered plugins.
+   */
+  plugins: HeadPlugin[]
   /**
    * The active head entries.
    */
@@ -112,7 +117,7 @@ export interface Unhead<Input extends {} = Head> {
   /**
    * Use a head plugin, loads the plugins hooks.
    */
-  use: (plugin: HeadPlugin) => void
+  use: (plugin: HeadPluginInput) => void
   /**
    * Is it a server-side render context.
    */

--- a/packages/shared/src/defineHeadPlugin.ts
+++ b/packages/shared/src/defineHeadPlugin.ts
@@ -1,5 +1,5 @@
-import type { HeadPlugin } from '@unhead/schema'
+import type { HeadPluginInput } from '@unhead/schema'
 
-export function defineHeadPlugin(plugin: HeadPlugin): HeadPlugin {
+export function defineHeadPlugin(plugin: HeadPluginInput): HeadPluginInput {
   return plugin
 }

--- a/packages/unhead/export-size-report.json
+++ b/packages/unhead/export-size-report.json
@@ -15,25 +15,25 @@
   },
   "exports": [
     {
-      "name": "createServerHead",
-      "path": "dist/index.mjs",
-      "minified": 5513,
-      "minzipped": 2111,
-      "bundled": 11426
-    },
-    {
       "name": "createHead",
       "path": "dist/index.mjs",
-      "minified": 5554,
-      "minzipped": 2108,
-      "bundled": 11460
+      "minified": 5587,
+      "minzipped": 2129,
+      "bundled": 11571
+    },
+    {
+      "name": "createServerHead",
+      "path": "dist/index.mjs",
+      "minified": 5546,
+      "minzipped": 2125,
+      "bundled": 11537
     },
     {
       "name": "createHeadCore",
       "path": "dist/index.mjs",
-      "minified": 5480,
-      "minzipped": 2083,
-      "bundled": 11317
+      "minified": 5513,
+      "minzipped": 2100,
+      "bundled": 11428
     },
     {
       "name": "CapoPlugin",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allow plugins to be deduped with an opt-in key. This allows composables to self-register plugins without registering duplicate hooks.

This is especially useful for the schema.org plugin, it allows us to treeshaking the plugin out if the composables are also removed.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
