### PR TITLE
fix: ensure tag oldProps[key] is a string

### DIFF
--- a/packages/unhead/src/plugins/dedupe.ts
+++ b/packages/unhead/src/plugins/dedupe.ts
@@ -38,7 +38,7 @@ export default defineHeadPlugin({
             ;['class', 'style'].forEach((key) => {
               if (tag.props[key] && oldProps[key]) {
                 // ensure style merge doesn't result in invalid css
-                if (key === 'style' && !oldProps[key].endsWith(';'))
+                if (key === 'style' && typeof oldProps[key] === 'string' && !oldProps[key].endsWith(';'))
                   oldProps[key] += ';'
 
                 tag.props[key] = `${oldProps[key]} ${tag.props[key]}`


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Nuxt 3.7 (but this certainly applies to other versions).
With routes:
```
/
/xxx
/[network] (parameter value)
[...]
```
When you come from `/` or `/xxx` to `/[network]`, regardless of direction, then `oldProps[key]` is `true` instead of a `string`. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
