### PR TITLE
fix(schema-org): allow `@id` override

### DIFF
--- a/packages/schema-org/src/core/resolve.ts
+++ b/packages/schema-org/src/core/resolve.ts
@@ -107,7 +107,7 @@ export function resolveNodeId<T extends Thing>(node: T, ctx: SchemaOrgGraph, res
 
   const rootId = Array.isArray(resolver.idPrefix) ? resolver.idPrefix?.[1] : undefined
   // transform ['host', PrimaryWebPageId] to https://host.com/#webpage
-  if (resolveAsRoot && rootId) {
+  if (!node['@id'] && resolveAsRoot && rootId) {
     // allow overriding root ids
     node['@id'] = prefixId(ctx.meta[prefix], rootId)
   }

--- a/packages/schema-org/src/nodes/LocalBusiness/index.test.ts
+++ b/packages/schema-org/src/nodes/LocalBusiness/index.test.ts
@@ -80,4 +80,46 @@ describe('defineLocalBusiness', () => {
       `)
     })
   })
+
+  it('can have custom id', async () => {
+    await useSetup(async () => {
+      useSchemaOrg([
+        defineLocalBusiness({
+          '@type': 'Dentist',
+          'name': 'test',
+          'address': {
+            addressCountry: 'Australia',
+            postalCode: '2000',
+            streetAddress: '123 st',
+          },
+          '@id': 'https://example.com/place/123#identity',
+          'url': 'https://www.test.com',
+        }),
+      ])
+
+      const graphNodes = await injectSchemaOrg()
+
+      expect(graphNodes).toMatchInlineSnapshot(`
+        [
+          {
+            "@id": "https://example.com/place/123#identity",
+            "@type": [
+              "Organization",
+              "LocalBusiness",
+              "Dentist",
+            ],
+            "address": {
+              "@type": "PostalAddress",
+              "addressCountry": "Australia",
+              "postalCode": "2000",
+              "streetAddress": "123 st",
+            },
+            "currenciesAccepted": "AUD",
+            "name": "test",
+            "url": "https://www.test.com",
+          },
+        ]
+      `)
+    })
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#269 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Don't set an automatic `@id` if there's one specified in the input
Resolves: #269 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
