### PR TITLE
feat(ssr): `omitLineBreaks` option

### DIFF
--- a/docs/content/1.setup/2.ssr/0.installation.md
+++ b/docs/content/1.setup/2.ssr/0.installation.md
@@ -51,6 +51,32 @@ export interface SSRHeadPayload {
 }
 ```
 
+### Options
+
+When using `renderSSRHead`, you can pass an optional `options` object to customize the output.
+
+```ts
+export interface RenderSSRHeadOptions {
+  omitLineBreaks?: boolean
+}
+```
+
+#### omitLineBreaks
+
+- Type: `boolean`
+- Default: `false`
+
+Set `omitLineBreaks` to `true` if you prefer to render the head tags without line breaks.
+
+Example usage:
+
+```ts
+const options = { omitLineBreaks: true }
+const payload = await renderSSRHead(head, options)
+```
+
+This will render the head tags as a single line, omitting any line breaks that would normally be included.
+
 ## 2. Update your app template
 
 You will need to update your app template to add in the templates for

--- a/packages/schema/src/hooks.ts
+++ b/packages/schema/src/hooks.ts
@@ -12,7 +12,7 @@ export interface SSRHeadPayload {
   bodyAttrs: string
 }
 
-export interface SSRHeadOptions {
+export interface RenderSSRHeadOptions {
   omitLineBreaks?: boolean
 }
 

--- a/packages/schema/src/hooks.ts
+++ b/packages/schema/src/hooks.ts
@@ -12,6 +12,10 @@ export interface SSRHeadPayload {
   bodyAttrs: string
 }
 
+export interface SSRHeadOptions {
+  omitLineBreaks?: boolean
+}
+
 export type UseScriptStatus = 'awaitingLoad' | 'loading' | 'loaded' | 'error' | 'removed'
 
 export interface ScriptInstance<T> {

--- a/packages/ssr/src/renderSSRHead.ts
+++ b/packages/ssr/src/renderSSRHead.ts
@@ -1,7 +1,7 @@
-import type { SSRHeadPayload, SSRRenderContext, ShouldRenderContext, Unhead } from '@unhead/schema'
+import type { SSRHeadOptions, SSRHeadPayload, SSRRenderContext, ShouldRenderContext, Unhead } from '@unhead/schema'
 import { ssrRenderTags } from './util'
 
-export async function renderSSRHead<T extends {}>(head: Unhead<T>) {
+export async function renderSSRHead<T extends {}>(head: Unhead<T>, options?: SSRHeadOptions) {
   const beforeRenderCtx: ShouldRenderContext = { shouldRender: true }
   await head.hooks.callHook('ssr:beforeRender', beforeRenderCtx)
   if (!beforeRenderCtx.shouldRender) {
@@ -15,7 +15,7 @@ export async function renderSSRHead<T extends {}>(head: Unhead<T>) {
   }
   const ctx = { tags: await head.resolveTags() }
   await head.hooks.callHook('ssr:render', ctx)
-  const html: SSRHeadPayload = ssrRenderTags(ctx.tags)
+  const html: SSRHeadPayload = ssrRenderTags(ctx.tags, options)
   const renderCtx: SSRRenderContext = { tags: ctx.tags, html }
   await head.hooks.callHook('ssr:rendered', renderCtx)
   return renderCtx.html

--- a/packages/ssr/src/renderSSRHead.ts
+++ b/packages/ssr/src/renderSSRHead.ts
@@ -1,7 +1,7 @@
-import type { SSRHeadOptions, SSRHeadPayload, SSRRenderContext, ShouldRenderContext, Unhead } from '@unhead/schema'
+import type { RenderSSRHeadOptions, SSRHeadPayload, SSRRenderContext, ShouldRenderContext, Unhead } from '@unhead/schema'
 import { ssrRenderTags } from './util'
 
-export async function renderSSRHead<T extends {}>(head: Unhead<T>, options?: SSRHeadOptions) {
+export async function renderSSRHead<T extends {}>(head: Unhead<T>, options?: RenderSSRHeadOptions) {
   const beforeRenderCtx: ShouldRenderContext = { shouldRender: true }
   await head.hooks.callHook('ssr:beforeRender', beforeRenderCtx)
   if (!beforeRenderCtx.shouldRender) {

--- a/packages/ssr/src/util/ssrRenderTags.ts
+++ b/packages/ssr/src/util/ssrRenderTags.ts
@@ -1,7 +1,7 @@
-import type { HeadTag, SSRHeadOptions } from '@unhead/schema'
+import type { HeadTag, RenderSSRHeadOptions } from '@unhead/schema'
 import { propsToString, tagToString } from '.'
 
-export function ssrRenderTags<T extends HeadTag>(tags: T[], options?: SSRHeadOptions) {
+export function ssrRenderTags<T extends HeadTag>(tags: T[], options?: RenderSSRHeadOptions) {
   const schema: {
     tags: Record<'head' | 'bodyClose' | 'bodyOpen', string[]>
     htmlAttrs: HeadTag['props']

--- a/packages/ssr/src/util/ssrRenderTags.ts
+++ b/packages/ssr/src/util/ssrRenderTags.ts
@@ -1,7 +1,7 @@
-import type { HeadTag } from '@unhead/schema'
+import type { HeadTag, SSRHeadOptions } from '@unhead/schema'
 import { propsToString, tagToString } from '.'
 
-export function ssrRenderTags<T extends HeadTag>(tags: T[]) {
+export function ssrRenderTags<T extends HeadTag>(tags: T[], options?: SSRHeadOptions) {
   const schema: {
     tags: Record<'head' | 'bodyClose' | 'bodyOpen', string[]>
     htmlAttrs: HeadTag['props']
@@ -16,10 +16,12 @@ export function ssrRenderTags<T extends HeadTag>(tags: T[]) {
     schema.tags[tag.tagPosition || 'head'].push(tagToString(tag))
   }
 
+  const lineBreaks = !options?.omitLineBreaks ? '\n' : ''
+
   return {
-    headTags: schema.tags.head.join(''),
-    bodyTags: schema.tags.bodyClose.join(''),
-    bodyTagsOpen: schema.tags.bodyOpen.join(''),
+    headTags: schema.tags.head.join(lineBreaks),
+    bodyTags: schema.tags.bodyClose.join(lineBreaks),
+    bodyTagsOpen: schema.tags.bodyOpen.join(lineBreaks),
     htmlAttrs: propsToString(schema.htmlAttrs),
     bodyAttrs: propsToString(schema.bodyAttrs),
   }

--- a/packages/ssr/src/util/ssrRenderTags.ts
+++ b/packages/ssr/src/util/ssrRenderTags.ts
@@ -17,9 +17,9 @@ export function ssrRenderTags<T extends HeadTag>(tags: T[]) {
   }
 
   return {
-    headTags: schema.tags.head.join('\n'),
-    bodyTags: schema.tags.bodyClose.join('\n'),
-    bodyTagsOpen: schema.tags.bodyOpen.join('\n'),
+    headTags: schema.tags.head.join(''),
+    bodyTags: schema.tags.bodyClose.join(''),
+    bodyTagsOpen: schema.tags.bodyOpen.join(''),
     htmlAttrs: propsToString(schema.htmlAttrs),
     bodyAttrs: propsToString(schema.bodyAttrs),
   }

--- a/test/unhead/ssr/ssr.test.ts
+++ b/test/unhead/ssr/ssr.test.ts
@@ -95,6 +95,33 @@ describe('ssr', () => {
     `)
   })
 
+  it('remove break lines', async () => {
+    const head = createHead()
+
+    head.push({
+      script: [
+        {
+          src: 'https://cdn.example.com/script-1.js',
+        },
+        {
+          src: 'https://cdn.example.com/script-2.js',
+        },
+      ],
+    })
+
+    const ctx = await renderSSRHead(head, { omitLineBreaks: true })
+
+    expect(ctx).toMatchInlineSnapshot(`
+    {
+      "bodyAttrs": "",
+      "bodyTags": "",
+      "bodyTagsOpen": "",
+      "headTags": "<script src="https://cdn.example.com/script-1.js"></script><script src="https://cdn.example.com/script-2.js"></script>",
+      "htmlAttrs": "",
+    }
+  `)
+  })
+
   it('useSeoMeta', async () => {
     const head = createHead()
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/24888

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I'm working to minimize the size of a Nuxt-rendered HTML archive, and I've observed that tags inside the `<head>` include `\n`, potentially adding a few extra kilobytes for larger sites.

I'm uncertain about the purpose of these line breaks - perhaps for enhanced readability? When I removed the newlines, my project size decreased by 1kb. It's a small reduction, but could this be significant for large-scale users?

Should you deem this PR more detrimental than beneficial, or have other reservations, please feel free to close it. Thank you.

---

After discussion, I have introduced `options.omitLineBreaks` to configure the retention of line breaks. This approach preserves the ability to easily debug page source, while also empowering developers to compress the content within `<head>` into a single line.

**`options.omitLineBreaks` is `false` or `undefined`**

```html
<head><meta charset="utf-8">
<meta name="viewport" content="width=device-width, initial-scale=1">
<link rel="preload" as="fetch" crossorigin="anonymous" href="/_payload.json">
<link rel="modulepreload" as="script" crossorigin href="/_nuxt/entry.lirqHv3X.js">
<link rel="prefetch" as="script" crossorigin href="/_nuxt/error-404.tbGoJl1q.js">
<link rel="prefetch" as="script" crossorigin href="/_nuxt/vue.f36acd1f.eXCIzdvm.js">
<link rel="prefetch" as="script" crossorigin href="/_nuxt/error-500.9n_HQChl.js">
<script type="module" src="/_nuxt/entry.lirqHv3X.js" crossorigin></script></head>
```

**`options.omitLineBreaks` is `true`**

```html
<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="preload" as="fetch" crossorigin="anonymous" href="/_payload.json"><link rel="modulepreload" as="script" crossorigin href="/_nuxt/entry.lirqHv3X.js"><link rel="prefetch" as="script" crossorigin href="/_nuxt/error-404.tbGoJl1q.js"><link rel="prefetch" as="script" crossorigin href="/_nuxt/vue.f36acd1f.eXCIzdvm.js"><link rel="prefetch" as="script" crossorigin href="/_nuxt/error-500.9n_HQChl.js"><script type="module" src="/_nuxt/entry.lirqHv3X.js" crossorigin></script></head>
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
