### PR TITLE
fix: useScript missing script API's return in proxy

### DIFF
--- a/packages/unhead/src/composables/useScript.ts
+++ b/packages/unhead/src/composables/useScript.ts
@@ -172,7 +172,7 @@ export function useScript<T>(input: UseScriptInput, _options?: UseScriptOptions<
           return script.waitForLoad().then(
             (api) => {
               // @ts-expect-error untyped
-              api[fn](...args)
+              return api[fn](...args)
             },
           )
         }

--- a/packages/unhead/src/composables/useScript.ts
+++ b/packages/unhead/src/composables/useScript.ts
@@ -69,6 +69,7 @@ export function useScript<T>(input: UseScriptInput, _options?: UseScriptOptions<
           resolve(options.use())
         function watchForScriptLoaded({ script }: { script: ScriptInstance<T> }) {
           if (script.id === id && script.status === 'loaded') {
+            script.loaded = true
             resolve(options.use?.() as T)
             head!.hooks.removeHook('script:updated', watchForScriptLoaded)
           }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Calling the script library via `use` option has no return value

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
