### PR TITLE
fix: `useSeoMeta` type

### DIFF
--- a/packages/vue/src/types/schema.ts
+++ b/packages/vue/src/types/schema.ts
@@ -1,6 +1,6 @@
 import type { BaseBodyAttr, BaseHtmlAttr, BodyEvents, DataKeys, DefinedValueOrEmptyObject, EntryAugmentation, HeadEntryOptions, MaybeArray, MaybeFunctionEntries, MergeHead, MetaFlatInput, SchemaAugmentations, Unhead, Base as _Base, Link as _Link, Meta as _Meta, Noscript as _Noscript, Script as _Script, Style as _Style, Title as _Title, TitleTemplate as _TitleTemplate } from '@unhead/schema'
 import type { Plugin, Ref } from 'vue'
-import type { MaybeComputedRef, MaybeComputedRefEntries } from './util'
+import type { MaybeComputedRef, MaybeComputedRefEntries, MaybeComputedRefEntriesOnly } from './util'
 
 export interface HtmlAttr extends Omit<BaseHtmlAttr, 'class'> {
   /**
@@ -104,5 +104,5 @@ export interface ReactiveHead<E extends MergeHead = MergeHead> {
 
 export type UseHeadOptions = Omit<HeadEntryOptions, 'head'> & { head?: VueHeadClient<any> }
 export type UseHeadInput<T extends MergeHead = {}> = MaybeComputedRef<ReactiveHead<T>>
-export type UseSeoMetaInput = MaybeComputedRefEntries<MetaFlatInput> & { title?: ReactiveHead['title'], titleTemplate?: ReactiveHead['titleTemplate'] }
+export type UseSeoMetaInput = MaybeComputedRefEntriesOnly<MetaFlatInput> & { title?: ReactiveHead['title'], titleTemplate?: ReactiveHead['titleTemplate'] }
 export type VueHeadClient<T extends MergeHead> = Unhead<MaybeComputedRef<ReactiveHead<T>>> & Plugin


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently `useSeoMeta` accepts `UseSeoMetaInput` type

<details>

<summary> UseSeoMetaInput can be both `T` and `() => T` </summary>

```ts
type UseSeoMetaInput = MaybeComputedRefEntries<MetaFlatInput> & {
  title?: ReactiveHead["title"];
  titleTemplate?: ReactiveHead["titleTemplate"];
};

type MaybeComputedRefEntries<T> =
  | MaybeComputedRef<T>
  | {
      [key in keyof T]?: MaybeComputedRefOrPromise<T[key]>;
    };

type MaybeComputedRef<T> = T | MaybeReadonlyRef<T> | Ref<T>;

type MaybeReadonlyRef<T> = (() => T) | ComputedRef<T>;
```

</details>

Because of this, typescript thinks both examples below are valid:

```ts
// computed that returns MetaFlatInput
useSeoMeta(() => {
  console.log("seo meta called");

  return {
    description: "description",
  };
});



const description = computed(() => {
  console.log("seo meta called");

  return "description";
});

// MetaFlatInput with computed properties
useSeoMeta({
  description,
});
```

[After 1.8](https://github.com/unjs/unhead/commit/3e30432c2fd978d4a193acd6431ae4418eb35120#diff-879ea8c81daca86f0d5bf9d9ecd0db0261c982d1cc5bd49ade532186c6189e84) computed that returns `MetaFlatInput` no longer works

Update `UseSeoMetaInput` type to reflect that


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
  [current documentation](https://unhead.unjs.io/usage/composables/use-seo-meta) is up to date
