### PR TITLE
docs: fix priority alias values

### DIFF
--- a/docs/content/1.usage/2.guides/2.sorting.md
+++ b/docs/content/1.usage/2.guides/2.sorting.md
@@ -35,8 +35,8 @@ You can set custom priorities for tags using the `tagPriority` attribute.
 Providing a number will set the priority to that number. The lower the number, the higher the priority.
 
 You can also make use of a string alias that adjusts the priority by a relative amount:
-- `critical` - **-20**
-- `high` - **-90**
+- `critical` - **-80**
+- `high` - **-10**
 - `low` - **20**
 
 Lastly you can set the priority based on the position of another tag using `before:` or `after:`. This is useful when you need to ensure a tag is rendered before or after another tag.


### PR DESCRIPTION
### 🔗 Linked issue

Minor typo fix; no issue opened.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)

### 📚 Description

Update the documentation of `tagPriority` string alias values to agree with those assigned in `packages/shared/src/sort.ts`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
