### PR TITLE
fix(schema-org): correct invalid ThumbnailUrl in Video tag

### DIFF
--- a/docs/content/schema-org/10.schema/video.md
+++ b/docs/content/schema-org/10.schema/video.md
@@ -25,6 +25,12 @@
 
   Can be provided using route meta on the `description` key, see [defaults](#defaults).
 
+- **thumbnail** `ImageObject`
+
+  An image of the video thumbnail.
+
+  Can be provided using route meta on the `image` key, see [defaults](#defaults).
+
 - **thumbnailUrl** `string`
 
   An image of the video thumbnail.

--- a/packages/schema-org/src/nodes/Video/index.ts
+++ b/packages/schema-org/src/nodes/Video/index.ts
@@ -21,7 +21,11 @@ export interface VideoSimple extends Thing {
   /**
    * A reference-by-ID to an imageObject.
    */
-  thumbnailUrl?: NodeRelation<ImageObject>
+  thumbnail?: NodeRelation<ImageObject>
+  /**
+   * A thumbnail image relevant to the Video.
+   */
+  thumbnailUrl?: string
   /**
    * The date the video was published, in ISO 8601 format (e.g., 2020-01-20).
    */
@@ -105,15 +109,15 @@ export const videoResolver = defineSchemaOrgResolver<VideoObject>({
     if (!video.description)
       video.description = 'No description'
 
-    if (video.thumbnailUrl)
-      video.thumbnailUrl = resolveRelation(video.thumbnailUrl, ctx, imageResolver)
+    if (video.thumbnail)
+      video.thumbnail = resolveRelation(video.thumbnail, ctx, imageResolver)
 
     return video
   },
   resolveRootNode(video, { find }) {
-    if (video.image && !video.thumbnailUrl) {
+    if (video.image && !video.thumbnail) {
       const firstImage = asArray(video.image)[0] as ImageObject
-      setIfEmpty(video, 'thumbnailUrl', find<ImageObject>(firstImage['@id'] as Id)?.url)
+      setIfEmpty(video, 'thumbnail', find<ImageObject>(firstImage['@id'] as Id)?.url)
     }
   },
 })


### PR DESCRIPTION
### Context

This pull request addresses an issue with the Schema.org markup for VideoObject in the provided Nuxt application. Specifically, it resolves the error where **thumbnailUrl** was incorrectly set as an ImageObject rather than a string URL. This error was causing issues during Google's indexing of the video pages.

### Changes Made:

- Updated **thumbnailUrl** in the **VideoObject** to be a valid string URL.
- Added thumbnail to the VideoObject which is a **ImageObject** 
- Ensured all other Schema.org properties conform to the expected types.

Resolves : #369 