### PR TITLE
Allow charset in safe variants

### DIFF
--- a/packages/schema/src/safeSchema.ts
+++ b/packages/schema/src/safeSchema.ts
@@ -11,7 +11,7 @@ import type {
 
 export type SafeBodyAttr = Pick<BodyAttr, 'id' | 'class'> & DataKeys
 export type SafeHtmlAttr = Pick<HtmlAttr, 'id' | 'class' | 'lang' | 'dir'> & DataKeys
-export type SafeMeta = Pick<_Meta, 'id' | 'name' | 'property' | 'content'> & DataKeys
+export type SafeMeta = Pick<_Meta, 'id' | 'name' | 'property' | 'content' | 'charset'> & DataKeys
 export type SafeLink = Pick<Link, 'color' | 'crossorigin' | 'fetchpriority' | 'href' | 'hreflang' | 'imagesizes' | 'imagesrcset' | 'integrity' | 'media'
   | 'referrerpolicy' | 'sizes' | 'id'> & {
     rel?: Omit<Link['rel'], 'stylesheet' | 'canonical' | 'modulepreload' | 'prerender' | 'preload' | 'prefetch'>

--- a/test/unhead/ssr/useHeadSafe.test.ts
+++ b/test/unhead/ssr/useHeadSafe.test.ts
@@ -53,4 +53,53 @@ describe('dom useHeadSafe', () => {
       }
     `)
   })
+
+  it('meta charset allows safe', async () => {
+    const head = createHead()
+
+    useHeadSafe({
+      meta: [
+        {
+          charset: 'utf-8',
+        },
+      ],
+    })
+
+    const ctx = await renderSSRHead(head)
+    expect(ctx).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<meta charset="utf-8">",
+        "htmlAttrs": "",
+      }
+    `)
+
+  });
+
+  it('meta charset is actually safe', async () => {
+    const head = createHead()
+
+    useHeadSafe({
+      meta: [
+        {
+          charset: 'utf-8"><script>alert("pwned?")</script>',
+        },
+      ],
+    })
+
+    const ctx = await renderSSRHead(head)
+    expect(ctx).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<meta charset="utf-8&quot;><script>alert(&quot;pwned?&quot;)</script>">",
+        "htmlAttrs": "",
+      }
+    `)
+
+  });
+
 })


### PR DESCRIPTION
Added 'charset' to allowed safe meta tags

resolves #372 

As always, thanks for developing and maintaining this package. My SEO metrics and I appreciate it.
