### PR TITLE
feat(scripts): deprecate implicit proxy and `$script`

### DIFF
--- a/docs/content/1.usage/2.composables/4.use-script.md
+++ b/docs/content/1.usage/2.composables/4.use-script.md
@@ -376,16 +376,6 @@ doSomething()
 
 The `useScript` composable returns the script instance that you can use to interact with the script.
 
-```ts
-  proxy: AsAsyncFunctionValues<T>
-  instance?: T
-  id: string
-  status: UseScriptStatus
-  entry?: ActiveHeadEntry<any>
-  load: () => Promise<T>
-  remove: () => boolean
-```
-
 ### id
 
 The unique ID of the script instance.

--- a/docs/content/1.usage/2.composables/4.use-script.md
+++ b/docs/content/1.usage/2.composables/4.use-script.md
@@ -50,7 +50,7 @@ use the API effectively.
 The `useScript` composable aims to solve these issues and more with the goal of making third-party scripts a breeze to use.
 
 ```ts
-const { gtag } = useScript<GoogleTag>('https://www.google-analytics.com/analytics.js', {
+const googleAnalytics = useScript<GoogleTag>('https://www.google-analytics.com/analytics.js', {
   beforeInit() {
     // Google Analytics Setup
     window.dataLayer = window.dataLayer || []
@@ -62,6 +62,7 @@ const { gtag } = useScript<GoogleTag>('https://www.google-analytics.com/analytic
     return { gtag: window.gtag }
   }
 })
+const { gtag } = googleAnalytics.proxy
 // fully typed, usable in SSR and when lazy loaded
 gtag('event', 'page_view', {
   page_title: 'Home',
@@ -75,52 +76,6 @@ interface GoogleTag {
 ```
 
 ## Usage
-
-### Your First Script
-
-The simplest usage of the `useScript` composable is to load a script and use the API it provides. To do
-so you need a URL to the script and a function that resolves the API `use()`.
-
-```ts
-const instance = useScript('https://example.com/my-awesome-script.js', {
-  // The `use` function will only called client-side, it's used to resolve the API
-  use() {
-    return window.myAwesomeScript
-  }
-})
-```
-
-Done, but accessing the API should provide type safety. To do so, you can use the `useScript` composable with a generic type.
-
-```ts
-interface MyAwesomeScript {
-  myFunction: ((arg: string) => void)
-}
-const { myFunction } = useScript<MyAwesomeScript>('https://example.com/my-awesome-script.js', {
-  use() {
-    return window.myAwesomeScript
-  }
-})
-
-// fully typed, usable in SSR and when lazy loaded
-myFunction('hello')
-```
-
-Because `useScript` returns a Proxy API, you can call the script functions before it's loaded. This will noop for SSR and be stubbable.
-
-This also lets you load in the script lazily while still being able to use the API immediately.
-
-```ts
-const { myFunction } = useScript<MyAwesomeScript>('https://example.com/my-awesome-script.js', {
-  trigger: 'manual',
-  use() {
-    return window.myAwesomeScript
-  }
-})
-
-// only client-side it will be called when the script is finished loaded
-myFunction('hello')
-```
 
 ### `referrerpolicy` and `crossorigin`
 
@@ -169,7 +124,7 @@ The `trigger` option is used to control when the script is loaded by the browser
 
 It can be one of the following:
 - `undefined` | `client`: Script tag will be inserted as the `useScript` is hydrated on the client side. The script will be usable once the network request is complete.
-- `manual`: Load the script manually using the `$script.load` method. Only runs on the client.
+- `manual`: Load the script manually using the `load()` function. Only runs on the client.
 - `Promise`: Load the script when the promise resolves. This allows you to load the script after a certain time or event,
 for example on the `requestIdleCallback` hook. Only runs on the client.
 - `Function`: Load the script when the function is called. Only runs on the client.
@@ -180,15 +135,15 @@ When you're using a `trigger` that isn't `server`, the script will not exist wit
 ::code-group
 
 ```ts [Manual]
-const { $script } = useScript('https://example.com/script.js', {
+const { load } = useScript('https://example.com/script.js', {
   trigger: 'manual'
 })
 // ...
-$script.load()
+load()
 ```
 
 ```ts [Promise]
-const { $script } = useScript('https://example.com/script.js', {
+useScript('https://example.com/script.js', {
   trigger: new Promise((resolve) => {
     setTimeout(resolve, 10000) // load after 10 seconds
   })
@@ -196,7 +151,7 @@ const { $script } = useScript('https://example.com/script.js', {
 ```
 
 ```ts [Idle]
-const { $script } = useScript('https://example.com/script.js', {
+useScript('https://example.com/script.js', {
   trigger: typeof window !== 'undefined' ? window.requestIdleCallback : 'manual'
 })
 ```
@@ -205,106 +160,123 @@ const { $script } = useScript('https://example.com/script.js', {
 
 ### Waiting for Script Load
 
-Sometimes you'll want to directly use the script instead of relying on the proxy. For this you can use the `$script` object as a Promise.
+Sometimes you'll want to directly use the script instead of relying on the proxy. For this you can use the script instance as a Promise.
+
+Using the script instance as a promise is preferable over calling `.load()` when you don't want to accidentally bypass
+the configuration trigger.
 
 ```ts
-const { $script } = useScript<MyAwesomeScript>('https://example.com/my-awesome-script.js', {
+const myScript = useScript<MyAwesomeScript>('https://example.com/my-awesome-script.js', {
   use() {
     return window.myAwesomeScript
   },
 })
 // Note: Do not do this if you have a `manual` trigger
-$script.then((myAwesomeScript) => {
+myScript.then((myAwesomeScript) => {
   // accesses the script directly, proxy is not used
   myAwesomeScript.myFunction('hello')
 })
-// OR - will block rendering until script is available
-const myAwesomeScript = await $script
-myAwesomeScript.myFunction('hello')
 ```
 
-When you have a manual trigger awaiting the promise will never resolve unless you `load()` the $script.
+When you have a manual trigger awaiting the promise will never resolve unless you `load()` the script.
 
 ```ts
-const { $script } = useScript<MyAwesomeScript>('https://example.com/my-awesome-script.js', {
-  use() {
-    return window.myAwesomeScript
-  },
+const myScript = useScript<MyAwesomeScript>('/script.js', {
   trigger: 'manual'
 })
-
-// Warning: Will never resolve!
-await $script
-
-// Make sure you call load if you're going to await with a manual trigger
-$script.load()
+myScript.then(() => {
+  // will never fire unless you call myScript.load()
+})
 ```
 
 ### Removing a Script
 
-When you're done with a script, you can remove it from the document using the `$script.remove()` method.
+When you're done with a script, you can remove it from the document using the `remove()` function.
 
 ```ts
-const { $script } = useScript<MyAwesomeScript>('https://example.com/my-awesome-script.js')
+const myScript = useScript('/script.js')
 
-$script.remove()
+myScript.remove()
 ```
 
-The `remove()` function will return a boolean indicating if the script was removed.
+The `remove()` function will return a boolean indicating if the script was removed in the case where the
+script has already been removed.
 
-### Handling Script Loading Failure
+### Script Loading Errors
 
-Sometimes scripts just won't load, this can be due to network issues, the script being blocked, etc.
+Sometimes scripts just won't load, this can be due to network issues, browser extensions blocking the script
+or many other reasons.
 
-To handle this, you can catch exceptions thrown from `$script`.
+As the script instance is a native promise, you can use the `.catch()` function.
 
 ```ts
-const { $script } = useScript<MyAwesomeScript>('https://example.com/my-awesome-script.js', {
-  use() {
-    return window.myAwesomeScript
-  },
-})
-
-$script.catch((err) => {
-  console.error('Failed to load script', err)
-})
+const myScript = useScript('/script.js')
+  .catch((err) => {
+    console.error('Failed to load script', err)
+  })
 ```
 
-Otherwise, you always check the status of the script using `$script.status`.
+Otherwise, you always check the status of the script using `status`.
 
-```ts
-const { $script } = useScript<MyAwesomeScript>('https://example.com/my-awesome-script.js', {
-  use() {
-    return window.myAwesomeScript
-  },
-})
-$script.status // 'awaitingLoad' | 'loading' | 'loaded' | 'error'
+::code-block
+
+```ts [Vanilla]
+const myScript = useScript('/script.js')
+myScript.status // 'awaitingLoad' | 'loading' | 'loaded' | 'error'
 ```
 
-### SSR Stubbing
+```ts [Vue]
+const myScript = useScript('/script.js')
+myScript.status // Ref<'awaitingLoad' | 'loading' | 'loaded' | 'error'>
+```
 
-In cases where you want to use the script API on the server, you can use the `stub` option. This lets
-you call your script functions and handle them in a way that makes sense for your server.
+::
 
-For example, we can stub the `gtag` function to send events on the server to Google Analytics. Meaning
-you have a single API to use for both server and client to achieve the same result.
+### Proxy API
+
+A `proxy` object is accessible on the script instance which provides a consistent interface for calling script functions
+regardless of the script being loaded.
+
+This can be useful in instances where you don't care when the function is called, just that it is when the script is loaded.
 
 ```ts
-const { gtag } = useScript<GoogleTag>('https://www.google-analytics.com/analytics.js', {
+const myScript = useScript<{ event: ((arg: string) => boolean) }>('/analytics.js', {
+  use() { return window.myAwesomeScript }
+})
+// send an event if or when the script is loaded
+myScript.proxy.event('foo') // Promise<boolean>
+````
+
+Using the proxy API will noop in SSR, is stubbable and is future-proofed to support loading scripts through web workers.
+
+The proxy accessors are converted to async functions, meaning if you need the return of the data you can await the function.
+
+```ts
+const myScript = useScript< { myFunction: ((arg: string) => boolean) }>('/script.js', {
+  use() { return window.myAwesomeScript }
+})
+// myFunction becomes (arg: string) => Promise<boolean>
+myScript.proxy.myFunction('hello').then((val) => {
+  // val is boolean
+})
+````
+
+### Stubbing
+
+In cases where you're using the Proxy API, you may want to replace some of the functionality.
+
+For example, in a server context, we probably want to polyfill some returns so our scrits remains functional.
+
+In the case of Google Analytics, we may stub the `dataLayer` so that it can be used as an array on the server.
+
+```ts
+const googleAnalytics = useScript<GoogleTag>('https://www.google-analytics.com/analytics.js', {
   use() {
-    return { gtag: window.gtag }
+    return { dataLayer: window.dataLayer }
   },
-  stub() {
-    if (process.server) {
-      return (fn: 'event', opt: string, opt2: { [key: string]: string }) => {
-        // send fetch to ga
-        return fetch('https://www.google-analytics.com/analytics.js', {
-          method: 'POST',
-          body: JSON.stringify({ event: opt, ...op2 })
-        })
-      }
-    }
-  }
+  stub({ fn }) {
+    return fn === 'dataLayer' && typeof window === 'undefined' ? [] : undefined
+  },
 })
 ```
 
@@ -346,14 +318,15 @@ useScript({
 A function that resolves the scripts API. This is only called client-side.
 
 ```ts
-const { trackPageview } = useScript<FathomApi>({
+const fathom = useScript<FathomApi>({
   // fathom analytics
   src: 'https://cdn.usefathom.com/script.js',
 }, {
   use: () => window.fathom
 })
-// just works
-trackPageview({ url: 'https://example.com' })
+fathom.then((api) => {
+  // api is equal to window.fathom
+})
 ```
 
 #### `trigger`
@@ -380,7 +353,7 @@ This is particularly useful when the API you want to use is a primitive and you 
 pushing to `dataLayer` when using Google Tag Manager.
 
 ```ts
-const { sendEvent, doSomething } = useScript<MyScriptApi>({
+const myScript = useScript<MyScriptApi>({
   src: 'https://example.com/script.js',
 }, {
   use: () => window.myScript,
@@ -390,6 +363,7 @@ const { sendEvent, doSomething } = useScript<MyScriptApi>({
       return (opt: string) => fetch('https://api.example.com/event', { method: 'POST', body: opt })
   }
 })
+const { sendEvent, doSomething } = myScript.proxy
 // on server, will send a fetch to https://api.example.com/event
 // on client it falls back to the real API
 sendEvent('event')
@@ -398,44 +372,75 @@ sendEvent('event')
 doSomething()
 ```
 
-### Return Value
+## Script Instance API
 
-The `useScript` composable returns a Proxy API that you can use to interact with the script.
-
-Any requests to the API will be proxied to the real script when it's loaded.
-
-#### $script
-
-The `$script` property is a special property that gives you access to the underlying script instance.
-
-It is a Promise and the script API in one. This means you can await the script to load and use the API directly.
+The `useScript` composable returns the script instance that you can use to interact with the script.
 
 ```ts
-const { $script } = useScript({
-  // ...
-})
-
-$script
-  .then() // script is loaded
-  .catch() // script failed to load
+  proxy: AsAsyncFunctionValues<T>
+  instance?: T
+  id: string
+  status: UseScriptStatus
+  entry?: ActiveHeadEntry<any>
+  load: () => Promise<T>
+  remove: () => boolean
 ```
 
-- `status`
+### id
+
+The unique ID of the script instance.
+
+### status
 
 The status of the script. Can be one of the following: `'awaitingLoad' | 'loading' | 'loaded' | 'error'`
 
-- `load`
+In Vue, this is a `Ref`.
+
+### load()
 
 Trigger the script to load. This is useful when using the `manual` loading strategy.
 
 ```ts
-const { $script } = useScript({
-  // ...
-}, {
+const { load } = useScript('/script.js', {
   trigger: 'manual'
 })
 // ...
-$script.load()
+load()
+```
+
+### remove()
+
+Remove the script from the document.
+
+#### proxy
+
+The proxy API for calling the script functions.
+
+```ts
+const myScript = useScript<MyScriptApi>('/script.js', {
+  use() { return window.myScript }
+})
+myScript.proxy.myFunction('hello')
+```
+
+#### instance
+
+Internal value providing the `use()` function, this will be the result. This is passed when resolving the script using `then()` or `load()`.
+
+```ts
+const myScript = useScript<MyScriptApi>('/script.js', {
+  use() { return window.myScript }
+})
+myScript.instance // window.myScript
+```
+
+### entry
+
+The internal head entry for the script. This is useful for debugging and tracking the script.
+
+```ts
+const myScript = useScript('/script.js')
+myScript.entry // ReturnType<typeof useHead>
 ```
 
 ## Examples

--- a/examples/vite-ssr-vue/src/pages/fathom.vue
+++ b/examples/vite-ssr-vue/src/pages/fathom.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { onMounted } from 'vue'
 import { useScript } from '@unhead/vue'
 
 export interface FathomAnalyticsApi {
@@ -8,13 +9,13 @@ export interface FathomAnalyticsApi {
   isTrackingEnabled: () => boolean
   send: (type: string, data: unknown) => void
   setSite: (siteId: string) => void
-  sideId: string
+  siteId: string
   trackPageview: (ctx?: { url: string, referrer?: string }) => void
   trackGoal: (goalId: string, cents: number) => void
   trackEvent: (eventName: string, value: { _value: number }) => void
 }
 
-const { trackPageview, blockTrackingForMe } = useScript<FathomAnalyticsApi>({
+const { trackPageview, blockTrackingForMe, siteId } = useScript<FathomAnalyticsApi>({
   src: 'https://cdn.usefathom.com/script.js',
   ['data-site']: 'KGILBQDV',
 }, {
@@ -27,6 +28,9 @@ blockTrackingForMe()
 trackPageview({
   url: '/test',
   referrer: '',
+})
+onMounted(async () => {
+  console.log(siteId, await siteId())
 })
 </script>
 <template>

--- a/examples/vite-ssr-vue/src/pages/gtag.vue
+++ b/examples/vite-ssr-vue/src/pages/gtag.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
 import { useScript } from '@unhead/vue'
 
-const { dataLayer, $script } = useScript<{ dataLayer: any[] }>({
+const gtag = useScript<{ dataLayer: any[] }>({
   src: 'https://www.googletagmanager.com/gtm.js?id=GTM-MNJD4B',
 }, {
-  stub({ fn }) {
-    return fn === 'dataLayer' && typeof window === 'undefined' ? [] : undefined
-  },
   beforeInit() {
     if (typeof window !== 'undefined') {
       window.dataLayer = window.dataLayer || []
@@ -20,13 +17,17 @@ const { dataLayer, $script } = useScript<{ dataLayer: any[] }>({
   },
   trigger: typeof window !== 'undefined' ? window.requestIdleCallback : 'manual'
 })
+const { $script } = gtag
+const dataLayer = gtag.proxy
+
+const status = gtag.status
 
 dataLayer.push({
   event: 'page_view',
   page_path: '/stripe',
 })
 
-$script.then((res) => {
+gtag.then((res) => {
   console.log('ready!', res)
 })
 
@@ -39,7 +40,7 @@ useHead({
 <div>
   <h1>gtm</h1>
   <div>
-    script status: {{ $script.status }}
+    script status: {{ status }}
   </div>
   <div>
     data layer:

--- a/packages/schema/src/script.ts
+++ b/packages/schema/src/script.ts
@@ -8,8 +8,15 @@ export type UseScriptStatus = 'awaitingLoad' | 'loading' | 'loaded' | 'error' | 
  */
 export type UseScriptInput = string | (Omit<Script, 'src'> & { src: string })
 export type UseScriptResolvedInput = Omit<Script, 'src'> & { src: string }
+type BaseScriptApi = Record<symbol | string, any>
 
-export interface ScriptInstance<T> {
+export type AsAsyncFunctionValues<T extends BaseScriptApi> = {
+  [key in keyof T]: T[key] extends (...args: infer A) => infer R ? (...args: A) => Promise<R> : () => Promise<T[key]>
+}
+
+export interface ScriptInstance<T extends BaseScriptApi> {
+  proxy: AsAsyncFunctionValues<T>
+  instance?: T
   id: string
   status: UseScriptStatus
   entry?: ActiveHeadEntry<any>
@@ -17,7 +24,7 @@ export interface ScriptInstance<T> {
   remove: () => boolean
 }
 
-export interface UseScriptOptions<T> extends HeadEntryOptions {
+export interface UseScriptOptions<T extends BaseScriptApi> extends HeadEntryOptions {
   /**
    * Resolve the script instance from the window.
    */

--- a/packages/schema/src/script.ts
+++ b/packages/schema/src/script.ts
@@ -11,7 +11,11 @@ export type UseScriptResolvedInput = Omit<Script, 'src'> & { src: string }
 type BaseScriptApi = Record<symbol | string, any>
 
 export type AsAsyncFunctionValues<T extends BaseScriptApi> = {
-  [key in keyof T]: T[key] extends (...args: infer A) => infer R ? (...args: A) => Promise<R> : () => Promise<T[key]>
+  [key in keyof T]:
+  // arays return literals
+  T[key] extends any[] ? T[key] :
+    T[key] extends object ? AsAsyncFunctionValues<T[key]> :
+      T[key] extends (...args: infer A) => infer R ? (...args: A) => Promise<R> : () => Promise<T[key]>
 }
 
 export interface ScriptInstance<T extends BaseScriptApi> {

--- a/packages/unhead/src/composables/useScript.ts
+++ b/packages/unhead/src/composables/useScript.ts
@@ -140,9 +140,11 @@ export function useScript<T extends Record<symbol | string, any>>(_input: UseScr
       },
       async apply(_, _this, args) {
         // we are faking, just return, avoid promise handles
-        if (_[ScriptProxyTarget])
+        if (head.ssr && _[ScriptProxyTarget])
           return
+        let instance: any
         const access = (fn?: T) => {
+          instance = fn || instance
           for (let i = 0; i < accessors.length; i++) {
             const k = accessors[i]
             fn = fn?.[k]
@@ -150,7 +152,7 @@ export function useScript<T extends Record<symbol | string, any>>(_input: UseScr
           return fn
         }
         const fn = access(script.instance) || access(await loadPromise)
-        return typeof fn === 'function' ? Reflect.apply(fn, _this, args) : fn
+        return typeof fn === 'function' ? Reflect.apply(fn, instance, args) : fn
       },
     })
   }
@@ -170,10 +172,6 @@ export function useScript<T extends Record<symbol | string, any>>(_input: UseScr
       if (target)
         return Reflect.get(target, k, target)
       return false
-    },
-    set(_, k, v) {
-      // just do the set on script
-      return Reflect.set(script, k, v)
     },
   })
 }

--- a/packages/unhead/src/composables/useScript.ts
+++ b/packages/unhead/src/composables/useScript.ts
@@ -149,7 +149,7 @@ export function useScript<T extends Record<symbol | string, any>>(_input: UseScr
           }
           return fn
         }
-        let fn = access(script.instance) || access(await loadPromise)
+        const fn = access(script.instance) || access(await loadPromise)
         return typeof fn === 'function' ? Reflect.apply(fn, _this, args) : fn
       },
     })

--- a/packages/unhead/src/composables/useScript.ts
+++ b/packages/unhead/src/composables/useScript.ts
@@ -109,7 +109,7 @@ export function useScript<T extends Record<symbol | string, any>>(_input: UseScr
         }
         // status should get updated from script events
         script.entry = head.push({
-          script: [{ ...defaults, ...input, key: id }],
+          script: [{ ...defaults, ...input, key: `script.${id}` }],
         }, options)
       }
       return loadPromise

--- a/packages/unhead/src/composables/useScript.ts
+++ b/packages/unhead/src/composables/useScript.ts
@@ -129,6 +129,7 @@ export function useScript<T extends Record<symbol | string, any>>(_input: UseScr
   const proxyChain = (instance: any, accessor?: string | symbol, accessors?: (string | symbol)[]) => {
     return new Proxy((!accessor ? instance : instance?.[accessor]) || sharedTarget, {
       get(_, k, r) {
+        head.hooks.callHook('script:instance-fn', { script, fn: k, exists: k in _ })
         if (!accessor) {
           const stub = options.stub?.({ script, fn: k })
           if (stub)

--- a/packages/vue/src/composables/useScript.ts
+++ b/packages/vue/src/composables/useScript.ts
@@ -1,4 +1,5 @@
 import type {
+  AsAsyncFunctionValues,
   UseScriptInput as BaseUseScriptInput,
   DataKeys,
   SchemaAugmentations,
@@ -19,12 +20,18 @@ export interface VueScriptInstance<T extends Record<symbol | string, any>> exten
 
 export type UseScriptInput = string | (MaybeComputedRefEntriesOnly<Omit<ScriptBase & DataKeys & SchemaAugmentations['script'], 'src'>> & { src: string })
 
-export type UseScriptContext<T extends Record<symbol | string, any>> = (Promise<T> & VueScriptInstance<T>) & {
-  $script: Promise<T> & VueScriptInstance<T>
-}
+export type UseScriptContext<T extends Record<symbol | string, any>> =
+  (Promise<T> & VueScriptInstance<T>)
+  & AsAsyncFunctionValues<T>
+  & {
+  /**
+   * @deprecated Use top-level functions instead.
+   */
+    $script: Promise<T> & VueScriptInstance<T>
+  }
 
 export function useScript<T extends Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptContext<T> {
-  const input = typeof _input === 'string' ? { src: _input } : _input
+  const input = (typeof _input === 'string' ? { src: _input } : _input) as ScriptBase
   const head = injectHead()
   const options = _options || {}
   // @ts-expect-error untyped

--- a/packages/vue/src/composables/useScript.ts
+++ b/packages/vue/src/composables/useScript.ts
@@ -13,43 +13,40 @@ import { getCurrentInstance, onMounted, ref } from 'vue'
 import type { MaybeComputedRefEntriesOnly } from '../types'
 import { injectHead } from './injectHead'
 
-export interface VueScriptInstance<T> extends Omit<ScriptInstance<T>, 'status'> {
+export interface VueScriptInstance<T extends Record<symbol | string, any>> extends Omit<ScriptInstance<T>, 'status'> {
   status: Ref<UseScriptStatus>
 }
 
 export type UseScriptInput = string | (MaybeComputedRefEntriesOnly<Omit<ScriptBase & DataKeys & SchemaAugmentations['script'], 'src'>> & { src: string })
 
-export function useScript<T extends Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): T & { $script: VueScriptInstance<T> & Promise<T> } {
+export type UseScriptContext<T extends Record<symbol | string, any>> = (Promise<T> & VueScriptInstance<T>) & {
+  $script: Promise<T> & VueScriptInstance<T>
+}
+
+export function useScript<T extends Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptContext<T> {
   const input = typeof _input === 'string' ? { src: _input } : _input
   const head = injectHead()
   const options = _options || {}
   // @ts-expect-error untyped
   options.head = head
   options.eventContext = getCurrentInstance()
-  const status = ref('awaitingLoad')
-
-  const stubOptions = options.stub
-  options.stub = ({ script, fn }) => {
-    // @ts-expect-error untyped
-    script.status = status
-    // need to add reactive properties
-    if (fn === '$script')
-      return script
-    return stubOptions?.({ script, fn })
-  }
-  let instance: T & { $script: VueScriptInstance<T> & Promise<T> }
+  const status = ref<UseScriptStatus>('awaitingLoad')
+  let script: UseScriptContext<T>
   // sync the status, need to register before useScript
-  const _ = head.hooks.hook('script:updated', ({ script }) => {
-    if (instance && script.id === instance.$script.id) {
-      status.value = script.status
+  const _ = head.hooks.hook('script:updated', ({ script: s }) => {
+    if (script && s.id === script.id) {
+      status.value = s.status
       // clean up
-      script.status === 'removed' && _()
+      if (s.status === 'removed') {
+        _()
+      }
     }
   })
   const scope = getCurrentInstance()
   if (scope && !options.trigger)
     options.trigger = onMounted
-  instance = _useScript(input as BaseUseScriptInput, options) as any as T & { $script: VueScriptInstance<T> & Promise<T> }
+  script = _useScript(input as BaseUseScriptInput, options) as any as UseScriptContext<T>
   // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
-  return instance
+  script.status = status
+  return script
 }

--- a/test/unhead/dom/useScript.test.ts
+++ b/test/unhead/dom/useScript.test.ts
@@ -19,7 +19,7 @@ describe('dom useScript', () => {
     expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
 
-      <script data-onload="" data-onerror="" defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" data-hid="1292051"></script></head>
+      <script data-onload="" data-onerror="" defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" data-hid="c5c65b0"></script></head>
       <body>
 
       <div>

--- a/test/unhead/dom/useScript.test.ts
+++ b/test/unhead/dom/useScript.test.ts
@@ -8,12 +8,18 @@ describe('dom useScript', () => {
 
     const instance = useScript<{ test: (foo: string) => void }>({
       src: 'https://cdn.example.com/script.js',
+    }, {
+      use() {
+        return {
+          test: (foo: string) => {},
+        }
+      },
     })
 
     expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
 
-      <script data-onload="" data-onerror="" defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" data-hid="c5c65b0"></script></head>
+      <script data-onload="" data-onerror="" defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" data-hid="1292051"></script></head>
       <body>
 
       <div>
@@ -37,5 +43,20 @@ describe('dom useScript', () => {
     instance.test('hello-world')
     await hookPromise
     expect(calledFn).toBe('test')
+  })
+  it('proxy', async () => {
+    const head = useDOMHead()
+
+    const instance = useScript<{ test: (foo: string) => string }>({
+      src: 'https://cdn.example.com/script.js',
+    }, {
+      use() {
+        return {
+          test: (foo: string) => foo,
+        }
+      },
+    })
+
+    expect(await instance.proxy.test('hello-world')).toEqual('hello-world')
   })
 })

--- a/test/unhead/ssr/useScript.test.ts
+++ b/test/unhead/ssr/useScript.test.ts
@@ -36,7 +36,7 @@ describe('ssr useScript', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="1292051"></script>",
+        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="c5c65b0"></script>",
         "htmlAttrs": "",
       }
     `)
@@ -57,7 +57,7 @@ describe('ssr useScript', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="1292051"></script>",
+        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="c5c65b0"></script>",
         "htmlAttrs": "",
       }
     `)
@@ -93,7 +93,7 @@ describe('ssr useScript', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://www.googletagmanager.com/gtm.js?id=GTM-MNJD4B" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="2d9f307"></script>",
+        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://www.googletagmanager.com/gtm.js?id=GTM-MNJD4B" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="2e8fc9"></script>",
         "htmlAttrs": "",
       }
     `)

--- a/test/unhead/ssr/useScript.test.ts
+++ b/test/unhead/ssr/useScript.test.ts
@@ -36,7 +36,7 @@ describe('dom useScript', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="c5c65b0"></script>",
+        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="1292051"></script>",
         "htmlAttrs": "",
       }
     `)

--- a/test/unhead/ssr/useScript.test.ts
+++ b/test/unhead/ssr/useScript.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'vitest'
 import { createHead, useScript } from 'unhead'
 import { renderSSRHead } from '@unhead/ssr'
 
-describe('dom useScript', () => {
+describe('ssr useScript', () => {
   it('default', async () => {
     const head = createHead()
 
@@ -37,6 +37,63 @@ describe('dom useScript', () => {
         "bodyTags": "",
         "bodyTagsOpen": "",
         "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="1292051"></script>",
+        "htmlAttrs": "",
+      }
+    `)
+  })
+  it('await ', async () => {
+    const head = createHead()
+
+    // mock a promise, test that it isn't resolved in 1 second
+    const script = useScript<{ foo: 'bar' }>({
+      src: 'https://cdn.example.com/script.js',
+    }, {
+      trigger: 'server',
+    })
+
+    const ctx = await renderSSRHead(head)
+    expect(ctx).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="1292051"></script>",
+        "htmlAttrs": "",
+      }
+    `)
+  })
+  it('google ', async () => {
+    const head = createHead()
+
+    const gtag = useScript<{ dataLayer: any[] }>({
+      src: 'https://www.googletagmanager.com/gtm.js?id=GTM-MNJD4B',
+    }, {
+      beforeInit() {
+        if (typeof window !== 'undefined') {
+          window.dataLayer = window.dataLayer || []
+          window.dataLayer.push({ 'gtm.start': new Date().getTime(), 'event': 'gtm.js' })
+        }
+      },
+      use() {
+        return {
+          dataLayer: window.dataLayer,
+        }
+      },
+      trigger: 'server',
+    })
+
+    // just checkign types and no exceptions are thrown
+    gtag.proxy.dataLayer.push({
+      event: 'page.load',
+    })
+
+    const ctx = await renderSSRHead(head)
+    expect(ctx).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://www.googletagmanager.com/gtm.js?id=GTM-MNJD4B" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true" data-hid="2d9f307"></script>",
         "htmlAttrs": "",
       }
     `)


### PR DESCRIPTION
## Background

I'm considering one major API change before the official Nuxt Scripts announcement regarding the proxy API, this will be backwards compatible.

The proxy API provides a good DX for end users IMO and it allows good future-proofing when loading scripts using alternative strategies such as web workers.

However, it introduces behaviour that is hard to predict, and there's no way to know what will happen when you call the function universally across all scripts.

For users who don't consider how the code can work, it would be easy to assume they are interacting with the loaded script. When it fails they may have a difficult time debugging as they'll only have a proxy to inspect.

For something like Google Analytics this isn't a big issue, see:

```ts
const { gtag } = useScript(...)
// script is not loaded
gtag() // gtag is an async function with a void return
// script is loaded
gtag() // gtag is a regular function with a void return
```

However, when users try and use the proxy API where there is a return, it can be super fiddly

```ts
const { loadUser } = useScript(...)
// script is not loaded
const { firstName } = await loadUser() // loadUser is an async function with a user return - we have to alter the underlying API
// script is loaded
const { firstName } = loadUser() // loadUser is a regular function with a user return - just works
```

So we're deprecating this behavior completely and only supporting the previous behavior by accessing the `proxy` value.

```ts
const { proxy }= useScript(...)
const { loadUser } = myScript.proxy
// an async function is returned for all properties and will always behave the same regardless of load state
const { firstName } = await loadUser()
```

We can see this implemented using `gtag` as:

```ts
const { proxy } = useScript(...)
// script is not loaded
proxy.gtag() // gtag is an async function with a void return
// script is loaded
proxy.gtag() // gtag is an async function with a void return
```

We can easily type this functionality so the user will always know what's going on.

This also allows us to simplify `useScript`, we can now return the `$script` instance directly as is as there are no other data returned on the function.

```ts
const script = useScript({
 // ...
})
script.then(() => {})
//
script.load(() => {})
// 
script.status // loaded
```

## Technical Details

## ⚠️ Deprecations

- `$script`, you should now access the previous script instance functions at the top level.
- Proxy functions, you should now access them from the `proxy` object.

### Features

- Proxy functions now have proper types.
- Can nest calls within the proxy, for example `dataLayer.push()` now works without stubbing.
- New `instance` on the script instance which holds the reference to the `use()` output.
- New `proxy` on the script instance.
- Allow access to properties within the third-party script through the proxy API by wrapping them in an async function call.