### PR TITLE
feat(scripts): safer lifecycle hooks `onLoaded`, `onError`

### DIFF
--- a/docs/content/1.usage/2.composables/4.use-script.md
+++ b/docs/content/1.usage/2.composables/4.use-script.md
@@ -135,15 +135,17 @@ When you're using a `trigger` that isn't `server`, the script will not exist wit
 ::code-group
 
 ```ts [Manual]
-const { load } = useScript('https://example.com/script.js', {
+const { load } = useScript('/script.js', {
   trigger: 'manual'
 })
 // ...
-load()
+load((instance) => {
+  // use the script instance
+})
 ```
 
 ```ts [Promise]
-useScript('https://example.com/script.js', {
+useScript('/script.js', {
   trigger: new Promise((resolve) => {
     setTimeout(resolve, 10000) // load after 10 seconds
   })
@@ -151,7 +153,7 @@ useScript('https://example.com/script.js', {
 ```
 
 ```ts [Idle]
-useScript('https://example.com/script.js', {
+useScript('/script.js', {
   trigger: typeof window !== 'undefined' ? window.requestIdleCallback : 'manual'
 })
 ```
@@ -160,33 +162,63 @@ useScript('https://example.com/script.js', {
 
 ### Waiting for Script Load
 
-To use the underlying API exposed by a script, we need to either use the [Proxy API](#proxy-api) or register a hook for when
-the script loads.
+To use the underlying API exposed by a script, it's recommended to use the `onLoaded` function, which accepts
+a callback function once the script is loaded.
 
-To do this we can use `then()` which accepts a function callback.
+::code-block
 
-```ts
-const myScript = useScript<{ myFunction: (s: string) => void }>('/script.js', {
-  use() {
-    return window.myAwesomeScript
-  },
-})
-myScript.then((myAwesomeScript) => {
-  // accesses the script directly, proxy is not used
-  myAwesomeScript.myFunction('hello')
+```ts [Vanilla]
+const { onLoaded } = useScript('/script.js')
+onLoaded(() => {
+  // script ready!
 })
 ```
+
+```ts [Vue]
+const { onLoaded } = useScript('/script.js')
+onLoaded(() => {
+  // script ready!
+})
+```
+
+::
 
 If you have registered your script using a `manual` trigger, then you can call `load()` with the same syntax.
 
 ```ts
-const myScript = useScript<{ myFunction: (s: string) => void }>('/script.js', {
+const { load } = useScript('/script.js', {
   trigger: 'manual'
 })
-myScript.then(() => {
-  // will never fire unless you call myScript.load()
+load((instance) => {
+  // runs once the script loads
 })
 ```
+
+The `onLoaded` function returns a function that you can use to dispose of the callback. For reactive integrations
+such as Vue, this will automatically bind to the scope lifecycle.
+
+::code-block
+
+```ts [Vanilla]
+const { onLoaded } = useScript('/script.js')
+const dispose = onLoaded(() => {
+  // script ready!
+})
+// ...
+dispose() // nevermind!
+```
+
+```ts [Vue]
+const { onLoaded } = useScript('/script.js')
+
+onLoaded(() => {
+  // this will never be called once the scope unmounts
+})
+```
+
+::
+
+If you'd like to always run the code regardless of lifecycle events, you may consider the [Proxy API](#proxy-api) instead.
 
 ### Removing a Script
 
@@ -210,7 +242,7 @@ As the script instance is a native promise, you can use the `.catch()` function.
 
 ```ts
 const myScript = useScript('/script.js')
-  .catch((err) => {
+  .onError((err) => {
     console.error('Failed to load script', err)
   })
 ```
@@ -391,7 +423,7 @@ The status of the script. Can be one of the following: `'awaitingLoad' | 'loadin
 
 In Vue, this is a `Ref`.
 
-### then(callback: Function)
+### onLoaded(cb: (instance: ReturnType<typeof use>) => void | Promise<void>): () => void
 
 A function that is called when the script is loaded. This is useful when you want to access the script directly.
 
@@ -402,7 +434,18 @@ myScript.onLoaded(() => {
 })
 ```
 
-### load(callback?: Function)
+### then(cb: (instance: ReturnType<typeof use>) => void | Promise<void>)
+
+A function that is called when the script is loaded. This is useful when you want to access the script directly.
+
+```ts
+const myScript = useScript('/script.js')
+myScript.onLoaded(() => {
+  // ready
+})
+```
+
+### load(callback?: (instance: ReturnType<typeof use>) => void | Promise<void>): Promise<ReturnType<typeof use>>
 
 Trigger the script to load. This is useful when using the `manual` loading strategy.
 

--- a/examples/vite-ssr-vue/src/App.vue
+++ b/examples/vite-ssr-vue/src/App.vue
@@ -17,6 +17,9 @@
     </RouterLink>|
     <RouterLink to="/js-confetti">
       JS Confetti
+    </RouterLink>|
+    <RouterLink to="/manual-script">
+      Manual
     </RouterLink>
     <RouterView v-slot="{ Component }">
       <Suspense>

--- a/examples/vite-ssr-vue/src/pages/manual-script.vue
+++ b/examples/vite-ssr-vue/src/pages/manual-script.vue
@@ -1,14 +1,14 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onUnmounted } from 'vue'
 import { useScript } from '@unhead/vue'
 
 const isScriptLoaded = ref(false)
 
-const { $script } = useScript({
+const { $script, onLoaded } = useScript({
   key: 'stripe',
   src: 'https://js.stripe.com/v3/',
   onload() {
-    console.log('script loaded')
+    console.log('script onload input')
     isScriptLoaded.value = true
   },
   onerror() {
@@ -18,7 +18,16 @@ const { $script } = useScript({
   trigger: 'manual',
 })
 
-console.log($script.status)
+onLoaded(() => {
+  console.log('on loaded callback')
+})
+$script.then(() => {
+  console.log('script promise callback')
+})
+
+onUnmounted(() => {
+  $script.load()
+})
 
 useHead({
   title: () => $script.status.value,

--- a/packages/schema/src/script.ts
+++ b/packages/schema/src/script.ts
@@ -26,6 +26,16 @@ export interface ScriptInstance<T extends BaseScriptApi> {
   entry?: ActiveHeadEntry<any>
   load: () => Promise<T>
   remove: () => boolean
+  // cbs
+  onLoaded: (fn: (instance: T) => void | Promise<void>) => void
+  onError: (fn: (err?: Error) => void | Promise<void>) => void
+  /**
+   * @internal
+   */
+  _cbs: {
+    loaded: ((instance: T) => void | Promise<void>)[]
+    error: ((err?: Error) => void | Promise<void>)[]
+  }
 }
 
 export interface UseScriptOptions<T extends BaseScriptApi> extends HeadEntryOptions {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Currently we can wait for a script to load like so

```ts
const script = useScript('/script.js')
script.then(() => {
  // script loaded!
})
```

This provides a simple promise-based interface that is concise and fairly easy to work with, however, this has several issues:
- Promise handles stay open if the script won't be called
- Awaiting the script may brick the page if called at the wrong time
- No way to de-register the callback
- Bypasses any contextual lifecycle hooks such as Vue's component mounting

To address this we move to a lifecycle register setup, where callbacks are provided to `onLoaded` and `onError`.

```ts
const script = useScript('/script.js')
// ✅ no promise handles left open, can't await as it's not a promise
const deregister = script.onLoaded(() => {
  // script loaded!
  // ✅ we can have this automatically hook into lifecycle events like Vue mounting
})
// ...
deregister() // ✅ we can deregister the callback
```

