### PR TITLE
fix(scripts): support re-registering the load trigger

### DIFF
--- a/packages/schema/src/script.ts
+++ b/packages/schema/src/script.ts
@@ -26,6 +26,7 @@ export interface ScriptInstance<T extends BaseScriptApi> {
   entry?: ActiveHeadEntry<any>
   load: () => Promise<T>
   remove: () => boolean
+  updateTrigger: (trigger: UseScriptOptions['trigger']) => void
   // cbs
   onLoaded: (fn: (instance: T) => void | Promise<void>) => void
   onError: (fn: (err?: Error) => void | Promise<void>) => void

--- a/test/unhead/e2e/scripts.test.ts
+++ b/test/unhead/e2e/scripts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'vitest'
-import { createHead, useHead } from 'unhead'
+import { createHead, useHead, useScript } from 'unhead'
 import { renderSSRHead } from '@unhead/ssr'
 import { renderDOMHead } from '@unhead/dom'
 import { useDom } from '../../fixtures'
@@ -52,5 +52,25 @@ describe('unhead e2e scripts', () => {
 
       </body></html>"
     `)
+  })
+
+  it('expect to update trigger', async () => {
+    const promise = new Promise<void>(() => {})
+    const script = useScript({
+      src: 'https://cdn.example.com/script.js',
+    }, {
+      trigger: promise,
+    })
+
+    const newPromise = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve()
+      }, 25)
+    })
+    expect(script.status).toBe('awaitingLoad')
+    script.updateTrigger(newPromise)
+    expect(script.status).toBe('awaitingLoad')
+    await newPromise
+    expect(script.status).toBe('loading')
   })
 })


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Hey :wave: this PR will provide a fix for https://github.com/nuxt/scripts/issues/222 and https://github.com/nuxt/scripts/issues/212

The issue is that since nuxt-scripts reuse the script instance if it exists, the trigger isn't updated because it keep the old trigger promise => The new promise is not used.

This PR adds an `updateTrigger` function to abort the previous trigger and set the new trigger Promise.

Maybe could we add a new trigger promise instead of replacing it ?

nuxt-script PR to test this https://github.com/nuxt/scripts/pull/231
