### PR TITLE
fix(scripts): lifecycle events for triggers

### DIFF
--- a/examples/vite-ssr-vue/src/pages/timer-script.vue
+++ b/examples/vite-ssr-vue/src/pages/timer-script.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { useScript } from '@unhead/vue'
+
+const { status, onLoaded } = useScript({
+  src: 'https://timeout.script',
+}, {
+  // leaving the page will stop the trigger from activating
+  trigger: new Promise((resolve) => {
+    setTimeout(() => {
+      resolve()
+    }, 2000)
+  }),
+})
+</script>
+
+<template>
+  <div>
+    <h1>timer-script</h1>
+    <div>
+      script status: {{ status }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+h1,
+a {
+  color: green;
+}
+</style>

--- a/packages/schema/src/script.ts
+++ b/packages/schema/src/script.ts
@@ -33,6 +33,10 @@ export interface ScriptInstance<T extends BaseScriptApi> {
   /**
    * @internal
    */
+  _triggerAbortController?: AbortController
+  /**
+   * @internal
+   */
   _cbs: {
     loaded: null | ((instance: T) => void | Promise<void>)[]
     error: null | ((err?: Error) => void | Promise<void>)[]

--- a/packages/unhead/src/composables/useScript.ts
+++ b/packages/unhead/src/composables/useScript.ts
@@ -142,16 +142,8 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     updateTrigger(trigger: UseScriptOptions['trigger']) {
       // cancel previous trigger
       script._triggerAbortController?.abort()
-      if (head.ssr) {
-        if (trigger === 'server') {
-          script.load()
-        }
-      }
-      else if (trigger === 'client' || typeof trigger === 'undefined') {
+      if (((typeof trigger === 'undefined' || trigger === 'client') && !head.ssr) || trigger === 'server') {
         script.load()
-      }
-      else if (typeof trigger === 'function') {
-        trigger(script.load)
       }
       else if (trigger instanceof Promise) {
         script._triggerAbortController = new AbortController()
@@ -163,6 +155,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         ]).then((res) => {
           res?.()
         })
+      }
+      else if (typeof trigger === 'function') {
+        trigger(script.load)
       }
     },
     _cbs,


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

https://github.com/unjs/unhead/pull/389 Continued

- Reregister the trigger on new `useScript` call
- Vue script instance will no longer be affected by the trigger if the scope unmounts
- Slight refactor of trigger code to make it easier to interpret 
