### PR TITLE
fix(scripts,vue): always expose status as a ref

### DIFF
--- a/examples/vite-ssr-vue/src/pages/js-confetti.vue
+++ b/examples/vite-ssr-vue/src/pages/js-confetti.vue
@@ -29,6 +29,7 @@ function doConfetti() {
   jsConfetti.addConfetti({ emojis: ['🌈', '⚡️', '💥', '✨', '💫', '🌸'] })
 }
 const status = jsConfetti.status
+console.log(status)
 </script>
 
 <template>

--- a/examples/vite-ssr-vue/src/pages/js-confetti.vue
+++ b/examples/vite-ssr-vue/src/pages/js-confetti.vue
@@ -28,6 +28,7 @@ function doConfetti() {
   console.log('pre doConfetti', jsConfetti, typeof jsConfetti.addConfetti, jsConfetti.addConfetti)
   jsConfetti.addConfetti({ emojis: ['🌈', '⚡️', '💥', '✨', '💫', '🌸'] })
 }
+const status = jsConfetti.status
 </script>
 
 <template>
@@ -36,4 +37,7 @@ function doConfetti() {
   >
     Add Confetti
   </button>
+<div>
+  status: {{ status }}
+</div>
 </template>

--- a/packages/unhead/src/composables/useScript.ts
+++ b/packages/unhead/src/composables/useScript.ts
@@ -219,7 +219,8 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   // remove in v2, just return the script
   const res = new Proxy(script, {
     get(_, k) {
-      const target = k in script ? script : script.proxy
+      // _ keys are reserved for internal overrides
+      const target = (k in script || String(k)[0] === '_') ? script : script.proxy
       if (k === 'then' || k === 'catch') {
         return script[k].bind(script)
       }

--- a/packages/vue/src/composables/useScript.ts
+++ b/packages/vue/src/composables/useScript.ts
@@ -85,5 +85,10 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
   // @ts-expect-error untyped
   registerVueScopeHandlers(script, scope)
-  return script as any as UseScriptContext<UseFunctionType<UseScriptOptions<T, U>, T>>
+  return new Proxy(script, {
+    get(_, key, a) {
+      // we can't override status as it will break the unhead useScript API
+      return Reflect.get(_, key === 'status' ? '_statusRef' : key, a)
+    },
+  }) as any as UseScriptContext<UseFunctionType<UseScriptOptions<T, U>, T>>
 }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

- Any data on the script object that starts with `_` is reserved for the script instance instead of the proxy. This allows us to bind the status ref directly to the instance and re-use it for the proxy accessor.
- Keep a single watcher for all script status syncing, no need to match the ids
- Always hit the `unhead` `useScript` function for re-using the instance, avoid re-implementing this logic ourselves. This will re-register the trigger for us.

