### PR TITLE
fixed typos in useSchemaOrg api docs

### DIFF
--- a/docs/content/schema-org/5.api/0.use-schema-org.md
+++ b/docs/content/schema-org/5.api/0.use-schema-org.md
@@ -45,7 +45,7 @@ interface Head<E extends MergeHead = SchemaAugmentations> {
 
 ## Options
 
-The second argument to `useSchemaOrg` is the `HeadEntryOptions`. This allow you apply options to the entry, meaning all
+The second parameter to `useSchemaOrg` is the `HeadEntryOptions`. This allows you to apply options to the entry, meaning all
 tags that exist within the `input`.
 
 ```ts
@@ -96,13 +96,14 @@ Be careful, **do not** use this function with any unknown / third party input, t
 to guarantee that the output is safe when dealing with unknown input.
 
 If you need XSS safety, sanitise your input or
-look at using the [useSeoMet
+look at using the [useSeoMeta](/usage/composables/use-seo-meta) or [useSchemaOrgSafe](/usage/composables/use-head-safe) composables instead.
 If you're having issues working around the default nodes, you should disable them.
 
-```ts [nuxt.config.ts]
+```ts
+// nuxt.config.ts
 export default defineNuxtConfig({
   schemaOrg: {
     defaults: false
   }
 })
-```a](/usage/composables/use-seo-meta) or [useSchemaOrgSafe](/usage/composables/use-head-safe) composables instead.
+```


### PR DESCRIPTION
fixed typos, grammar, wording in useSchemaOrg api docs
