### PR TITLE
fix(schema): prefer ReturnType instead of infer

### DIFF
--- a/packages/schema/src/script.ts
+++ b/packages/schema/src/script.ts
@@ -51,7 +51,9 @@ export interface ScriptInstance<T extends BaseScriptApi> {
   }
 }
 
-export type UseFunctionType<T, U> = T extends { use: infer V } ? V extends () => infer W ? W : U : U
+export type UseFunctionType<T, U> = T extends {
+  use: infer V;
+} ? V extends (...args: any) => any ? ReturnType<V> : U : U
 
 export interface UseScriptOptions<T extends BaseScriptApi = {}, U = {}> extends HeadEntryOptions {
   /**


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
may fix https://github.com/nuxt/scripts/issues/320#issuecomment-2483440942

Hey :wave: 

this PR removes inferance from `UseFunctionType`. The reason is that inferance works really badly with function overload, returning only the last overload. 

I hope this will be fixed in TS soon :/
