### PR TITLE
fix(schema-org): mark `unhead` as peer dependency

### DIFF
--- a/packages/schema-org/package.json
+++ b/packages/schema-org/package.json
@@ -54,6 +54,15 @@
     "release": "bumpp package.json --commit --push --tag",
     "lint": "eslint \"{src,test}/**/*.{ts,vue,json,yml}\" --fix"
   },
+  "peerDependencies": {
+    "@unhead/vue": "^1",
+    "unhead": "^1"
+  },
+  "peerDependenciesMeta": {
+    "@unhead/vue": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "ohash": "^1.1.4",
     "ufo": "^1.5.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10315,6 +10315,10 @@ snapshots:
     dependencies:
       acorn: 8.12.1
 
+  acorn-import-attributes@1.9.5(acorn@8.14.0):
+    dependencies:
+      acorn: 8.14.0
+
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
       acorn: 8.12.1
@@ -16130,8 +16134,8 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/wasm-edit': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.12.1
-      acorn-import-attributes: 1.9.5(acorn@8.12.1)
+      acorn: 8.14.0
+      acorn-import-attributes: 1.9.5(acorn@8.14.0)
       browserslist: 4.24.0
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.17.1


### PR DESCRIPTION
We specify that the package requires `unhead` and maybe `@unhead/vue` to work. We prefer peerDependencies to avoid version conflicts,

Fixes #418

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
