### PR TITLE
fix: export `InferSeoMetaPlugin` from `unhead/optionalPlugins`

### DIFF
--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -64,6 +64,9 @@
     "unplugin": "^2.1.2",
     "unplugin-ast": "^0.13.1"
   },
+  "peerDependencies": {
+    "unhead": "workspace:*"
+  },
   "devDependencies": {
     "@babel/types": "^7.26.3"
   }

--- a/packages/addons/src/index.ts
+++ b/packages/addons/src/index.ts
@@ -1,2 +1,3 @@
 export * from './constants'
-export * from './plugins'
+
+export { InferSeoMetaPlugin } from 'unhead/optionalPlugins'

--- a/packages/addons/src/plugins/index.ts
+++ b/packages/addons/src/plugins/index.ts
@@ -1,1 +1,0 @@
-export * from './inferSeoMetaPlugin'

--- a/packages/unhead/src/optionalPlugins/index.ts
+++ b/packages/unhead/src/optionalPlugins/index.ts
@@ -1,2 +1,3 @@
 export * from './deprecations'
+export * from './inferSeoMetaPlugin'
 export * from './promises'

--- a/packages/unhead/src/optionalPlugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/optionalPlugins/inferSeoMetaPlugin.ts
@@ -22,7 +22,7 @@ export interface InferSeoMetaPluginOptions {
   twitterCard?: false | 'summary' | 'summary_large_image' | 'app' | 'player'
 }
 
-/* @__NO_SIDE_EFFECTS__ */ export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
+export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
   return defineHeadPlugin({
     hooks: {
       entries: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       ufo:
         specifier: ^1.5.4
         version: 1.5.4
+      unhead:
+        specifier: workspace:*
+        version: link:../unhead
       unplugin:
         specifier: ^2.1.2
         version: 2.1.2

--- a/test/unhead/plugins/infer-seo-meta.test.ts
+++ b/test/unhead/plugins/infer-seo-meta.test.ts
@@ -1,7 +1,7 @@
 import { renderSSRHead } from '@unhead/ssr'
+import { InferSeoMetaPlugin } from 'unhead/optionalPlugins'
 import { createHead } from 'unhead/server'
 import { describe, it } from 'vitest'
-import { InferSeoMetaPlugin } from '../src/plugins/inferSeoMetaPlugin'
 
 describe('inferSeoMetaPlugin', () => {
   it('simple', async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Simply moving the `InferSeoMetaPlugin` as an subpath export of `unhead/optionalPlugins` to avoid the extra dependency of `@unhead/addons`.

This is non breaking as we still export from the addon module.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
