### PR TITLE
feat(ssr): transformHtmlTemplate

### DIFF
--- a/docs/0.nuxt/guides/1.components.md
+++ b/docs/0.nuxt/guides/1.components.md
@@ -1,27 +1,35 @@
 ---
-title: <Head> Component
-description: Use the <Head> component to manage your head tags.
+title: Components
+description: Use component to manage your head tags.
 navigation:
-  title: '<Head> Component'
+  title: 'Components'
 ---
 
-The Unhead Vue package exports a `<Head>`{lang="html"}  component that can be used to manage your head tags.
+## Introduction
 
-While it's recommended to use the `useHead` composable as it offers a more flexible API with full TypeScript support,
-the `<Head>`{lang="html"}  component may make more sense for your project.
+Nuxt exports several Vue components that can be used to manage your head tags.
 
-The component will takes any child elements that you would normally put in your actual `<head>`{lang="html"}  and renders them
-with Unhead.
+While it's recommended to use the `useHead()`{lang="ts"} composable as it offers a more flexible API with full TypeScript support,
+the Vue component may make more sense for your project.
+
+## Usage
+
+For full usage instructions please refer to the [Nuxt documentation](https://nuxt.com/docs/getting-started/seo-meta#components).
 
 ```vue
-<script lang="ts" setup>
-import { Head } from '@unhead/vue/components'
+<script setup lang="ts">
+const title = ref('Hello World')
 </script>
 
 <template>
-  <Head>
-    <title>My awesome site</title>
-    <meta name="description" content="My awesome site description">
-  </Head>
+  <div>
+    <Head>
+      <Title>{{ title }}</Title>
+      <Meta name="description" :content="title" />
+      <Style type="text/css" children="body { background-color: green; }" ></Style>
+    </Head>
+
+    <h1>{{ title }}</h1>
+  </div>
 </template>
 ```

--- a/docs/0.vue/1.installation.md
+++ b/docs/0.vue/1.installation.md
@@ -20,19 +20,21 @@ Using [Nuxt](https://nuxt.com/docs/getting-started/seo-meta)? Unhead is already 
 
 ### Demos
 
-- [StackBlitz - Vite - Vue SPA](https://stackblitz.com/edit/vitejs-vite-uijgqa?file=package.json)
+- [StackBlitz - Unhead - Vite + Vue SSR](https://stackblitz.com/edit/github-uesntxts)
+- [StackBlitz - Unhead - Vue SPA](https://stackblitz.com/edit/github-uesntxts)
 
 ## Setup
 
 ### 1. Add Dependency
 
-Install `@unhead/vue`{lang="bash"} dependency to your project:
+Install `@unhead/vue`{lang="bash"} dependency to your project. The `next` tag is for v2 of Unhead.
 
-:ModuleInstall{name="@unhead/vue"}
+:ModuleInstall{name="@unhead/vue@next"}
 
 #### Using Vue 2
 
-In Unhead v2, official support for Vue 2 has been dropped. If you're using Vue 2, you will need to install v1 of `@unhead/vue@^1`{lang="bash"} instead.
+In Unhead v2, official support for Vue 2 has been dropped. If you're using Vue 2, you will need to install v1 of `@unhead/vue@^1`{lang="bash"} instead
+and follow the [v1 documentation](/docs/0.vue/1.installation-v1).
 
 :ModuleInstall{name="@unhead/vue@^1"}
 
@@ -87,18 +89,16 @@ export async function render(_url: string) {
 Next we'll update our template `index.html`{lang="bash"} file. We'll be removing any head tags that should be dynamic
 and replacing them with placeholders.
 
-```html {1,3,5,7} [./index.html]
+```html {1,3,5,7} [index.html]
 <!DOCTYPE html>
-<html <!--htmlAttrs--> >
+<html>
 <head>
   <!--headTags-->
-  <!--preload-links-->
+  <!--app-head-->
 </head>
-<body <!--bodyAttrs--> >
-  <!--bodyTagsOpen-->
+<body>
   <div id="app"><!--app-html--></div>
   <script type="module" src="/src/entry-client.js"></script>
-  <!--bodyTags-->
 </body>
 </html>
 ```
@@ -106,7 +106,8 @@ and replacing them with placeholders.
 Now we need to render out the head tags _after_ vue has rendered the app and replace these
 placeholders with the actual head tags.
 
-To start with we need to modify the `render` function to return the template data.
+To start with we need to modify the `render` function to return the template data. Make
+sure you add the `renderSSRHead` import.
 
 ```ts {1,14-15} [src/entry-server.ts]
 import { createHead, renderSSRHead } from '@unhead/vue/server'
@@ -140,7 +141,9 @@ export async function createServer(
     // ...
     const [appHtml, templateData] = await render(url, manifest)
     // replace placeholders
-    let html = template.replace('<!--app-html-->', appHtml)
+    let html = template
+      .replace('<!--app-html-->', appHtml)
+      
     Object.entries(templateData).forEach(([key, value]) => {
       html = html.replace(`<!--${key}-->`{lang="html"}, value)
     })

--- a/docs/0.vue/guides/1.components.md
+++ b/docs/0.vue/guides/1.components.md
@@ -5,12 +5,16 @@ navigation:
   title: '<Head> Component'
 ---
 
+## Introduction
+
 The Unhead Vue package exports a `<Head>`{lang="html"}  component that can be used to manage your head tags.
 
-While it's recommended to use the `useHead` composable as it offers a more flexible API with full TypeScript support,
+While it's recommended to use the `useHead()`{lang="ts"} composable as it offers a more flexible API with full TypeScript support,
 the `<Head>`{lang="html"}  component may make more sense for your project.
 
-The component will takes any child elements that you would normally put in your actual `<head>`{lang="html"}  and renders them
+## Usage
+
+The component will takes any child elements that you would normally put in your actual `<head>`{lang="html"} and renders them
 with Unhead.
 
 ```vue
@@ -25,3 +29,5 @@ import { Head } from '@unhead/vue/components'
   </Head>
 </template>
 ```
+
+When the head component is unmounted, it will remove all the tags that were added.

--- a/packages/unhead/src/server/index.ts
+++ b/packages/unhead/src/server/index.ts
@@ -1,4 +1,5 @@
-export * from './createHead'
-export * from './renderSSRHead'
-export * from './util'
+export { createHead } from './createHead'
+export { renderSSRHead } from './renderSSRHead'
+export { transformHtmlTemplate } from './transformHtmlTemplate'
+export { escapeHtml, propsToString, ssrRenderTags, tagToString } from './util'
 export type { SSRHeadPayload } from '@unhead/schema'

--- a/packages/unhead/src/server/index.ts
+++ b/packages/unhead/src/server/index.ts
@@ -1,5 +1,5 @@
 export { createHead } from './createHead'
 export { renderSSRHead } from './renderSSRHead'
 export { transformHtmlTemplate } from './transformHtmlTemplate'
-export { escapeHtml, extractTagsFromHtml, propsToString, ssrRenderTags, tagToString } from './util'
+export { escapeHtml, extractUnheadInputFromHtml, propsToString, ssrRenderTags, tagToString } from './util'
 export type { SSRHeadPayload } from '@unhead/schema'

--- a/packages/unhead/src/server/index.ts
+++ b/packages/unhead/src/server/index.ts
@@ -1,5 +1,5 @@
 export { createHead } from './createHead'
 export { renderSSRHead } from './renderSSRHead'
 export { transformHtmlTemplate } from './transformHtmlTemplate'
-export { escapeHtml, propsToString, ssrRenderTags, tagToString } from './util'
+export { escapeHtml, extractTagsFromHtml, propsToString, ssrRenderTags, tagToString } from './util'
 export type { SSRHeadPayload } from '@unhead/schema'

--- a/packages/unhead/src/server/transformHtmlTemplate.ts
+++ b/packages/unhead/src/server/transformHtmlTemplate.ts
@@ -1,0 +1,15 @@
+import type { RenderSSRHeadOptions, Unhead } from '@unhead/schema'
+import { renderSSRHead } from './renderSSRHead'
+import { extractTagsFromHtml } from './util/extractTagsFromHtml'
+
+export async function transformHtmlTemplate(head: Unhead<any>, html: string, options?: RenderSSRHeadOptions) {
+  const { html: parsedHtml, input } = extractTagsFromHtml(html)
+  head.push(input)
+  const headHtml = await renderSSRHead(head, options)
+  return parsedHtml
+    .replace('<html>', `<html${headHtml.htmlAttrs}>`)
+    .replace('<body>', `<body>${headHtml.bodyTagsOpen ? `\n${headHtml.bodyTagsOpen}` : ``}`)
+    .replace('<body>', `<body${headHtml.bodyAttrs}>`)
+    .replace('</head>', `${headHtml.headTags}</head>`)
+    .replace('</body>', `${headHtml.bodyTags}</body>`)
+}

--- a/packages/unhead/src/server/transformHtmlTemplate.ts
+++ b/packages/unhead/src/server/transformHtmlTemplate.ts
@@ -1,9 +1,9 @@
 import type { RenderSSRHeadOptions, Unhead } from '@unhead/schema'
 import { renderSSRHead } from './renderSSRHead'
-import { extractTagsFromHtml } from './util/extractTagsFromHtml'
+import { extractUnheadInputFromHtml } from './util/extractUnheadInputFromHtml'
 
 export async function transformHtmlTemplate(head: Unhead<any>, html: string, options?: RenderSSRHeadOptions) {
-  const { html: parsedHtml, input } = extractTagsFromHtml(html)
+  const { html: parsedHtml, input } = extractUnheadInputFromHtml(html)
   head.push(input)
   const headHtml = await renderSSRHead(head, options)
   return parsedHtml

--- a/packages/unhead/src/server/util/extractTagsFromHtml.ts
+++ b/packages/unhead/src/server/util/extractTagsFromHtml.ts
@@ -1,0 +1,52 @@
+function extractAttributes(tag: string) {
+  const attrs = tag.match(/([a-z-]+)="([^"]*)"/g)
+  return attrs?.reduce((acc, attr) => {
+    const [key, ...valueParts] = attr.split('=')
+    // join value parts to support '=' within the quoted values
+    const val = valueParts.join('=').slice(1, -1)
+    return { ...acc, [key]: val, tagPriority: 'low' }
+  }, {})
+}
+
+export function extractTagsFromHtml(html: string) {
+  const input = {}
+  // i should be able to give it a string of html and it should convert it to input for useHead()
+  // parse htmlAttrs, bodyAttrs
+  input.htmlAttrs = extractAttributes(html.match(/<html[^>]*>/)?.[0] || '')
+
+  html = html.replace(/<html[^>]*>/, '<html>')
+  input.bodyAttrs = extractAttributes(html.match(/<body[^>]*>/)?.[0] || '')
+  html = html.replace(/<body[^>]*>/, '<body>')
+  // parse headTags, need to split on /> and seperate each tag
+  const innerHead = html.match(/<head[^>]*>([\s\S]*)<\/head>/)?.[1]
+  // replace ['meta', 'link', 'base'] tags first because they're unique in that they don't have a closing tag
+  innerHead?.match(/<meta[^>]*>|<link[^>]*>|<base[^>]*>/g).forEach((s) => {
+    html = html.replace(s, '')
+    const tag = s.split(' ')[0].slice(1)
+    input[tag] = input[tag] || []
+    input[tag].push(extractAttributes(s))
+  })
+  innerHead?.match(/<title[^>]*>[\s\S]*?<\/title>|<script[^>]*>[\s\S]*?<\/script>|<style[^>]*>[\s\S]*?<\/style>/g)
+    .map(tag => tag.trim())
+    .filter(Boolean)
+    .forEach((tag) => {
+      html = html.replace(tag, '')
+      const type = tag.match(/<([a-z-]+)/)?.[1]
+      const res = {
+        tagPriority: 'low',
+        [type !== 'script' ? 'textContent' : 'innerHTML']: tag.match(/>([\s\S]*)</)?.[1],
+        ...extractAttributes(tag),
+      }
+      if (type === 'title') {
+        input.title = res
+      }
+      else {
+        input[type] = input[type] || []
+        input[type].push(res)
+      }
+    })
+  // remove duplicate new lines from html, could be 2, 5 or 20 in a row
+  html = html.replace(/(\n\s*)+/g, '\n')
+  // we leave any body tags as the order is out of our control
+  return { html, input }
+}

--- a/packages/unhead/src/server/util/extractUnheadInputFromHtml.ts
+++ b/packages/unhead/src/server/util/extractUnheadInputFromHtml.ts
@@ -23,7 +23,7 @@ function extractAttributes(tag: string) {
   }, {}) || {}
 }
 
-export function extractTagsFromHtml(html: string) {
+export function extractUnheadInputFromHtml(html: string) {
   const input: UseHeadInput<any> = {}
   input.htmlAttrs = extractAttributes(html.match(HtmlTag)?.[0] || '')
   html = html.replace(HtmlTag, '<html>')

--- a/packages/unhead/src/server/util/index.ts
+++ b/packages/unhead/src/server/util/index.ts
@@ -1,4 +1,4 @@
-export { extractTagsFromHtml } from './extractTagsFromHtml'
+export { extractUnheadInputFromHtml } from './extractUnheadInputFromHtml'
 export { propsToString } from './propsToString'
 export { ssrRenderTags } from './ssrRenderTags'
 export { escapeHtml, tagToString } from './tagToString'

--- a/packages/unhead/src/server/util/index.ts
+++ b/packages/unhead/src/server/util/index.ts
@@ -1,3 +1,4 @@
-export * from './propsToString'
-export * from './ssrRenderTags'
-export * from './tagToString'
+export { extractTagsFromHtml } from './extractTagsFromHtml'
+export { propsToString } from './propsToString'
+export { ssrRenderTags } from './ssrRenderTags'
+export { escapeHtml, tagToString } from './tagToString'

--- a/packages/unhead/test/unit/server/ssr.test.ts
+++ b/packages/unhead/test/unit/server/ssr.test.ts
@@ -291,7 +291,7 @@ describe('ssr', () => {
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>new title</title>
       <link rel="stylesheet" href="style.css">
-      <script src="script.js" type="module"></script></head>
+      <script src="script.js" async type="module"></script></head>
       <body style="background-color: blue; accent-color: red">
       <div>hello</div>
       <script src="ssr.test.ts"></script>

--- a/packages/unhead/test/unit/server/ssr.test.ts
+++ b/packages/unhead/test/unit/server/ssr.test.ts
@@ -1,7 +1,6 @@
 import { useHead, useSeoMeta } from 'unhead'
 import { renderSSRHead } from 'unhead/server'
 import { transformHtmlTemplate } from 'unhead/server/transformHtmlTemplate'
-import { extractTagsFromHtml } from 'unhead/server/util/extractTagsFromHtml'
 import { describe, it } from 'vitest'
 import { basicSchema } from '../../fixtures'
 import { createServerHeadWithContext } from '../../util'

--- a/packages/unhead/test/unit/server/ssr.test.ts
+++ b/packages/unhead/test/unit/server/ssr.test.ts
@@ -303,4 +303,50 @@ describe('ssr', () => {
       "
     `)
   })
+  it('random template #2', async () => {
+    const html = `
+    <!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Test description">
+  <link rel="stylesheet" href="styles.css">
+  <link rel="icon" href="favicon.ico">
+  <base href="/">
+  <title>Test Document</title>
+  <style>body { font-family: Arial, sans-serif; }</style>
+  <script src="script.js" async></script>
+  <script>console.log('Inline script');</script>
+  <!-- Resource Hints -->
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" href="script.js" as="script">
+  <link rel="dns-prefetch" href="//example.com">
+  <link rel="preconnect" href="//example.com">
+  <link rel="prefetch" href="another-script.js">
+</head>
+<body style="background-color: #f0f0f0;">
+  <div id="content">Hello, world!</div>
+  <script src="another-script.js"></script>
+</body>
+</html>`
+    const head = createServerHeadWithContext()
+    const processedHtml = await transformHtmlTemplate(head, html)
+    expect(processedHtml).toContain('<meta charset="UTF-8">')
+    expect(processedHtml).toContain('<meta name="viewport" content="width=device-width, initial-scale=1.0">')
+    expect(processedHtml).toContain('<meta name="description" content="Test description">')
+    expect(processedHtml).toContain('<link rel="stylesheet" href="styles.css">')
+    expect(processedHtml).toContain('<link rel="icon" href="favicon.ico">')
+    expect(processedHtml).toContain('<base href="/">')
+    expect(processedHtml).toContain('<title>Test Document</title>')
+    expect(processedHtml).toContain('<style>body { font-family: Arial, sans-serif; }</style>')
+    expect(processedHtml).toContain('<script src="script.js" async></script>')
+    expect(processedHtml).toContain('<script>console.log(\'Inline script\');</script>')
+    expect(processedHtml).toContain('<link rel="preload" href="styles.css" as="style">')
+    expect(processedHtml).toContain('<link rel="preload" href="script.js" as="script">')
+    expect(processedHtml).toContain('<link rel="dns-prefetch" href="//example.com">')
+    expect(processedHtml).toContain('<link rel="preconnect" href="//example.com">')
+    expect(processedHtml).toContain('<link rel="prefetch" href="another-script.js">')
+    expect(processedHtml).toContain('<script src="another-script.js"></script>')
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In Unhead v1 we had end users manually add in placeholder tokens that get replaced when we SSR out the template.

```html
<! -- example -->
<head <-- unhead.headAttrs --> >
  <!-- unhead.headTags -->
</head>
```

As we move towards supporting more frameworks the conditions that are available to replace the HTML template get more complicated. To improve the developer experience around the implementation of Unhead we need an easier way to inject the templates Unhead generates.

Supporting more frameworks also means issues with templates having specific tags already in that we need to work with. Previously we just ignored these or had the end framework add these to Unhead explicitly. As we're now concerned with rendering tags in the optimal performance way it is important we can parse these tags into Unhead so that can be moved (or overwritten if needed).

```html
<head>
  <link rel="preload" href="/framework-specific-js-file.js">
</head>
```

To solve both of these issues we introduce the `transformHtmlTemplate()` function:

```ts
import { createHead, transformHtmlTemplate } from 'unhead/server'

const unhead = createHead()

unhead.push({
  title: 'hello world'
  meta: [{ name: 'description', content: 'foo' }]
})

const HTML = transformHtmlTemplate(unhead, `<!doctype html>
    <html lang="en">
    <head>
      <meta charset="UTF-8" />
    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Vite + Vue + TS</title>
    <!--app-head-->
    </head>
    <body>
    <div id="app"><!--app-html--></div>
      <script type="module" src="/src/entry-client.ts"></script>
      </body>
      </html>`)

// title is hello world
// description is foo
```

This also exports an `extractUnheadInputFromHtml` function that may be useful in some cases.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
