### PR TITLE
feat: default important head tags

### DIFF
--- a/docs/0.react/1.installation.md
+++ b/docs/0.react/1.installation.md
@@ -116,9 +116,36 @@ app.use('*all', async (req, res) => {
 
 Done! Your app should now be rendering head tags on the server and client.
 
-In Unhead React we have both a `<Head>`{lang="html"} component and a `useHead()`{lang="ts"} hook for managing head tags.
+To improve your apps stability, Unhead will now insert important default tags for you.
 
-Decicing which to use will be up to you:
+- `<meta charset="utf-8">`
+- `<meta name="viewport" content="width=device-width, initial-scale=1">`
+- `<html lang="en">`
+
+You may need to change these for your app requirements, for example you may want to change the default language. Adding
+tags in your server entry means you won't add any weight to your client bundle.
+
+```ts {2,6-8} [src/entry-server.ts]
+import { createHead } from '@unhead/react/server'
+
+export function render(_url: string) {
+  const head = createHead({
+    // change default initial lang
+    init: [
+      { 
+        htmlAttrs: { lang: 'en' },
+        title: 'Default title',
+        titleTemplate: '%s %separator My Site',
+      },
+    ]
+  })
+  const html = `<!-- your html -->`
+  return { html, head }
+}
+```
+
+For adding tags in your components, you can either use the `<Head>`{lang="html"} component and the `useHead()`{lang="ts"} hook.
+
 - `useHead()`{lang="ts"}: Type safety, more flexible and can access lower level primitives.
 - `<Head>`{lang="html"}: More declarative and easier to read.
 
@@ -145,36 +172,6 @@ export default function App() {
   )
 }
 ```
-
-If you'd like to add any default tags to your app, doing so in your server entry means you won't add any weight
-to your client bundle.
-
-```tsx {4,11-14} [src/entry-server.tsx]
-import { useSeoMeta } from '@unhead/react'
-import { createHead, UnheadProvider } from '@unhead/react/server'
-import { StrictMode } from 'react'
-import { renderToString } from 'react-dom/server'
-import App from './App'
-
-export function render(_url: string) {
-  const head = createHead()
-  useSeoMeta({
-    title: 'My Awesome Site',
-    description: 'My awesome site description',
-  }, head)
-  const html = renderToString(
-    <StrictMode>
-      <UnheadProvider value={head}>
-        <App />
-      </UnheadProvider>
-    </StrictMode>,
-  )
-  return { html, head }
-}
-```
-
-You'll notice we're passing the `head` instance here, this is because we're outside the React app context, you can learn more
-on the [Async Context](/docs/React/guides/managing-context) guide.
 
 ### 5. Optional: Auto-Imports
 

--- a/docs/0.typescript/1.installation.md
+++ b/docs/0.typescript/1.installation.md
@@ -96,6 +96,36 @@ app.use('*all', async (req, res) => {
 
 Done! Your app should now be rendering head tags on the server and client.
 
+
+To improve your apps stability, Unhead will now insert important default tags for you.
+
+- `<meta charset="utf-8">`
+- `<meta name="viewport" content="width=device-width, initial-scale=1">`
+- `<html lang="en">`
+
+You may need to change these for your app requirements, for example you may want to change the default language. Adding
+tags in your server entry means you won't add any weight to your client bundle.
+
+```ts {2,6-8} [main.ts]
+import { createHead } from 'unhead/server'
+import typescriptLogo from './typescript.svg'
+
+export function render(_url: string) {
+  const head = createHead({
+    // change default initial lang
+    init: [
+      {
+        title: 'Default title',
+        titleTemplate: '%s | My Site',
+        htmlAttrs: { lang: 'fr' }
+      },
+    ]
+  })
+  const html = `<!-- your html -->`
+  return { html, head }
+}
+```
+
 Here is an example of how you can use `useHead` in your app for a counter:
 
 ```ts [counter.ts]

--- a/docs/0.vue/1.installation.md
+++ b/docs/0.vue/1.installation.md
@@ -119,7 +119,37 @@ app.use('*all', async (req, res) => {
 
 Done! Your app should now be rendering head tags on the server and client.
 
-```vue
+To improve your apps stability, Unhead will now insert important default tags for you. 
+
+- `<meta charset="utf-8">`
+- `<meta name="viewport" content="width=device-width, initial-scale=1">`
+- `<html lang="en">`
+
+You may need to change these for your app requirements, for example you may want to change the default language. Adding
+tags in your server entry means you won't add any weight to your client bundle.
+
+```ts {7-12} [src/entry-server.ts]
+import { createHead } from '@unhead/vue/server'
+
+export async function render(_url: string) {
+  // ...
+  const head = createHead({
+    init: [
+      // change default initial lang
+      { 
+        title: 'Default title',
+        titleTemplate: '%s | My Site',
+        htmlAttrs: { lang: 'fr' }
+      },
+    ]
+  })
+  // ...
+}
+```
+
+Feel free to play around with adding tags to your apps. Here's an example of adding some styles to the body. 
+
+```vue [src/App.vue]
 <script setup lang="ts">
 import { useHead } from '@unhead/vue'
 
@@ -130,34 +160,6 @@ useHead({
 })
 </script>
 ```
-
-If you'd like to add any default tags to your app, doing so in your server entry means you won't add any weight
-to your client bundle.
-
-```ts {4,11-14} [src/entry-server.ts]
-import { useSeoMeta } from '@unhead/vue'
-import { createHead } from '@unhead/vue/server'
-import { renderToString } from 'vue/server-renderer'
-import { createApp } from './main'
-
-export async function render(_url: string) {
-  const { app } = createApp()
-  const head = createHead()
-  app.use(head)
-  // no client-side hydration needed
-  useSeoMeta({
-    title: 'My Awesome Site',
-    description: 'My awesome site description',
-  }, { head })
-  const ctx = {}
-  const html = await renderToString(app, ctx)
-
-  return { html, head }
-}
-```
-
-You'll notice we're passing the `head` instance here, this is because we're outside the Vue app context, you can learn more
-on the [Async Context](/docs/vue/guides/managing-context) guide.
 
 ### 5. Optional: Auto-Imports
 

--- a/docs/1.guides/0.titles.md
+++ b/docs/1.guides/0.titles.md
@@ -90,7 +90,7 @@ Creating your own title like this is simple using `useHead()`{lang="ts"} with a 
 ```ts twoslash [input.vue]
 useHead({
   title: 'Home',
-  titleTemplate: '%s %seperator MySite'
+  titleTemplate: '%s %separator MySite'
 })
 ```
 
@@ -110,10 +110,10 @@ You may ask why we don't just use a function for the title template, and while t
 
 Instead, it's recommended to use the params. Out-of-the-box, Unhead provides:
 
-| Token | Description                                     |
-|-------|-------------------------------------------------|
-| `%s` | The current page title.                         |
-| `%seperator` | The separator, defaults to a pipe character \|. |
+| Token        | Description                                     |
+|--------------|-------------------------------------------------|
+| `%s`         | The current page title.                         |
+| `%separator` | The separator, defaults to a pipe character \|. |
 
 The `%separator` token is smart - it only appears between content and automatically removes itself when the title is empty or when multiple separators would appear.
 
@@ -124,7 +124,7 @@ Define custom template params to maintain consistent formatting:
 ```ts twoslash [input.vue]
 useHead({
   title: 'Home',
-  titleTemplate: '%s %seperator %siteName',
+  titleTemplate: '%s %separator %siteName',
   templateParams: {
     seperator: '—',
     siteName: 'MySite'
@@ -201,12 +201,12 @@ Remembering how to use the meta tags can be annoying, so we can use the [`useSeo
 
 ```ts [input.vue]
 useSeoMeta({
-  titleTemplate: '%s %seperator Health Tips',
+  titleTemplate: '%s %separator Health Tips',
   title: 'Why you should eat more broccoli',
   // og title is not effected by titleTemplate, we can use template params here if we need
-  ogTitle: 'Hey! Health Tips %seperator 10 reasons to eat more broccoli.',
+  ogTitle: 'Hey! Health Tips %separator 10 reasons to eat more broccoli.',
   // explicit twitter title is only needed when we want to display something just for X
-  twitterTitle: 'Hey X! Health Tips %seperator 10 reasons to eat more broccoli.',
+  twitterTitle: 'Hey X! Health Tips %separator 10 reasons to eat more broccoli.',
 })
 ```
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -7,7 +7,12 @@ navigation:
 
 ## Introduction
 
-The goal of Unhead v2 was to remove deprecations and remove the implicit context implementation.
+While Unhead has always been framework agnostic, the majority of adoption was by the Vue ecosystem. 
+
+With the release of Unhead v2, we now have first-class support for other frameworks. However, this guide will focus on
+the changes that affect Vue and TypeScript users.
+
+The high-level of Unhead v2 was to remove deprecations and remove the implicit context implementation.
 
 ### Legacy Support
 
@@ -399,5 +404,37 @@ You can opt-out of Capo.js sorting by providing the option.
 ```ts
 createHead({
   disableCapoSorting: true,
+})
+```
+
+## Default SSR Tags
+
+🚦 Impact Level: Low
+
+When SSR Unhead will now insert important default tags for you:
+- `<meta charset="utf-8">`
+- `<meta name="viewport" content="width=device-width, initial-scale=1">`
+- `<html lang="en">`
+
+If you were previously relying on these being left empty, you may need to either disable them by using `disableDefaultTags` or insert tags
+to override them.
+
+```ts
+import { createHead } from '@unhead/vue/server'
+
+// disable when creating the head instance
+createHead({
+  disableDefaults: true,
+})
+```
+
+```ts
+import { useHead } from 'unhead'
+
+// override the defaults
+useHead({
+  htmlAttrs: {
+    lang: 'fr'
+  }
 })
 ```

--- a/packages/angular/src/unhead/install.ts
+++ b/packages/angular/src/unhead/install.ts
@@ -1,4 +1,4 @@
-import type { CreateHeadOptions } from '@unhead/schema'
+import type { CreateClientHeadOptions, CreateServerHeadOptions } from '@unhead/schema'
 import type { AngularUnhead } from './types/index'
 import { InjectionToken, makeEnvironmentProviders } from '@angular/core'
 import { BEFORE_APP_SERIALIZED } from '@angular/platform-server'
@@ -11,7 +11,7 @@ export const headSymbol = 'usehead'
 
 export const UnheadInjectionToken = new InjectionToken<AngularUnhead>(headSymbol)
 
-export function provideServerHead(options: Omit<CreateHeadOptions, 'domDelayFn' | 'document'> = {}) {
+export function provideServerHead(options: CreateServerHeadOptions = {}) {
   const head = _createServerHead<AngularUnhead>({
     ...options,
     plugins: [
@@ -33,7 +33,7 @@ export function provideServerHead(options: Omit<CreateHeadOptions, 'domDelayFn' 
   ])
 }
 
-export function provideClientHead(options: Omit<CreateHeadOptions, 'domOptions' | 'document'> = {}) {
+export function provideClientHead(options: CreateClientHeadOptions = {}) {
   const head = _createClientHead<AngularUnhead>({
     domOptions: {
       render: createDebouncedFn(() => renderDOMHead(head), fn => setTimeout(() => fn(), 0)),

--- a/packages/react/src/server.ts
+++ b/packages/react/src/server.ts
@@ -1,4 +1,4 @@
-import type { CreateClientHeadOptions, MergeHead } from '@unhead/schema'
+import type { CreateServerHeadOptions, MergeHead } from '@unhead/schema'
 import type { ReactNode } from 'react'
 import type { MaybeComputedRef, ReactiveHead, ReactUnhead } from './types'
 import { createElement } from 'react'
@@ -8,7 +8,7 @@ import { ReactReactivityPlugin } from './ReactReactivityPlugin'
 
 export * from 'unhead/server'
 
-export function createHead<T extends MergeHead>(options: CreateClientHeadOptions = {}): ReactUnhead<T> {
+export function createHead<T extends MergeHead>(options: CreateServerHeadOptions = {}): ReactUnhead<T> {
   return _createHead<MaybeComputedRef<ReactiveHead<T>>>({
     ...options,
     plugins: [

--- a/packages/schema-org/test/e2e/basic.test.ts
+++ b/packages/schema-org/test/e2e/basic.test.ts
@@ -8,6 +8,7 @@ import { useDom } from '../../../unhead/test/fixtures'
 describe('schema.org e2e', () => {
   it('basic hydration', async () => {
     const ssrHead = createServerHead({
+      disableDefaults: true,
       plugins: [
         SchemaOrgUnheadPlugin(),
       ],
@@ -73,6 +74,7 @@ describe('schema.org e2e', () => {
 
   it('hierarchy', async () => {
     const ssrHead = createServerHead({
+      disableDefaults: true,
       plugins: [
         SchemaOrgUnheadPlugin({
           path: '/about',
@@ -146,6 +148,7 @@ describe('schema.org e2e', () => {
 
   it('linking', async () => {
     const ssrHead = createServerHead({
+      disableDefaults: true,
       plugins: [
         SchemaOrgUnheadPlugin({
           path: '/about',
@@ -193,6 +196,7 @@ describe('schema.org e2e', () => {
 
   it('faq', async () => {
     const ssrHead = createServerHead({
+      disableDefaults: true,
       plugins: [
         SchemaOrgUnheadPlugin({
           path: '/about',
@@ -259,6 +263,7 @@ describe('schema.org e2e', () => {
 
   it('canonical', async () => {
     const ssrHead = createServerHead({
+      disableDefaults: true,
       plugins: [
         SchemaOrgUnheadPlugin(),
       ],
@@ -301,6 +306,7 @@ describe('schema.org e2e', () => {
 
   it('empty', async () => {
     const ssrHead = createServerHead({
+      disableDefaults: true,
       plugins: [
         SchemaOrgUnheadPlugin(),
       ],
@@ -317,6 +323,7 @@ describe('schema.org e2e', () => {
   })
   it('#441', async () => {
     const ssrHead = createServerHead({
+      disableDefaults: true,
       plugins: [
         SchemaOrgUnheadPlugin(),
       ],

--- a/packages/schema-org/test/e2e/no-plugin.test.ts
+++ b/packages/schema-org/test/e2e/no-plugin.test.ts
@@ -7,7 +7,9 @@ import { useDom } from '../../../unhead/test/fixtures'
 
 describe('schema.org e2e no plugin', () => {
   it('basic hydration', async () => {
-    const ssrHead = createServerHead()
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+    })
 
     useSchemaOrg(ssrHead, [
       defineWebPage({
@@ -59,7 +61,9 @@ describe('schema.org e2e no plugin', () => {
   })
 
   it('hierarchy', async () => {
-    const ssrHead = createServerHead()
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+    })
 
     useHead(ssrHead, {
       templateParams: {
@@ -134,7 +138,9 @@ describe('schema.org e2e no plugin', () => {
   })
 
   it('linking', async () => {
-    const ssrHead = createServerHead()
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+    })
 
     useHead(ssrHead, {
       templateParams: {
@@ -184,7 +190,9 @@ describe('schema.org e2e no plugin', () => {
   })
 
   it('faq', async () => {
-    const ssrHead = createServerHead()
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+    })
 
     useHead(ssrHead, {
       templateParams: {
@@ -253,7 +261,9 @@ describe('schema.org e2e no plugin', () => {
   })
 
   it('many registrations', async () => {
-    const ssrHead = createServerHead()
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+    })
     useSchemaOrg(ssrHead, [
       defineWebPage({
         name: 'One',

--- a/packages/schema-org/test/index.ts
+++ b/packages/schema-org/test/index.ts
@@ -17,6 +17,7 @@ export async function findNode<T>(unhead: Unhead<any>, id: string) {
 }
 export async function useSetup(fn: (unhead: Unhead<any>) => void, meta: Partial<MetaInput> = {}) {
   const head = createHead({
+    disableDefaults: true,
     plugins: [
       SchemaOrgUnheadPlugin({
         currency: 'AUD',

--- a/packages/schema-org/test/ssr/ids.test.ts
+++ b/packages/schema-org/test/ssr/ids.test.ts
@@ -5,7 +5,9 @@ import { describe, expect, it } from 'vitest'
 
 describe('schema.org ssr ids', () => {
   it('adds host prefix to custom id without host', async () => {
-    const ssrHead = createHead()
+    const ssrHead = createHead({
+      disableDefaults: true,
+    })
 
     useHead(ssrHead, {
       templateParams: {
@@ -27,7 +29,9 @@ describe('schema.org ssr ids', () => {
     expect(id).toMatchInlineSnapshot(`"https://example.com/#/schema/web-page/#foo"`)
   })
   it('allows ids with custom domains', async () => {
-    const ssrHead = createHead()
+    const ssrHead = createHead({
+      disableDefaults: true,
+    })
 
     useHead(ssrHead, {
       templateParams: {
@@ -49,7 +53,9 @@ describe('schema.org ssr ids', () => {
     expect(id).toMatchInlineSnapshot('"https://custom-domain.com/#foo"')
   })
   it('full relative paths', async () => {
-    const ssrHead = createHead()
+    const ssrHead = createHead({
+      disableDefaults: true,
+    })
 
     useHead(ssrHead, {
       templateParams: {
@@ -72,7 +78,9 @@ describe('schema.org ssr ids', () => {
   })
 
   it('full relative paths relations', async () => {
-    const ssrHead = createHead()
+    const ssrHead = createHead({
+      disableDefaults: true,
+    })
 
     useHead(ssrHead, {
       templateParams: {

--- a/packages/schema/src/head.ts
+++ b/packages/schema/src/head.ts
@@ -82,11 +82,29 @@ export interface CreateHeadOptions {
   plugins?: HeadPluginInput[]
   hooks?: NestedHooks<HeadHooks>
   /**
+   * Initial head input that should be added.
+   *
+   * Any tags here are added with low priority.
+   */
+  init?: (Head<any> | undefined)[]
+  /**
    * Disable the Capo.js tag sorting algorithm.
    *
    * This is added to make the v1 -> v2 migration easier allowing users to opt-out of the new sorting algorithm.
    */
   disableCapoSorting?: boolean
+}
+
+export interface CreateServerHeadOptions extends CreateHeadOptions {
+  /**
+   * Should default important tags be skipped.
+   *
+   * Adds the following tags with low priority:
+   * - <html lang="en">
+   * - <meta charset="utf-8">
+   * - <meta name="viewport" content="width=device-width, initial-scale=1">
+   */
+  disableDefaults?: boolean
 }
 
 export interface CreateClientHeadOptions extends CreateHeadOptions {

--- a/packages/scripts/test/unit/ssr.test.ts
+++ b/packages/scripts/test/unit/ssr.test.ts
@@ -3,7 +3,9 @@ import { useScript } from '../../src/useScript'
 
 describe('ssr useScript', () => {
   it('default', async () => {
-    const head = createServerHead()
+    const head = createServerHead({
+      disableDefaults: true,
+    })
 
     useScript(head, {
       src: 'https://cdn.example.com/script.js',
@@ -21,7 +23,9 @@ describe('ssr useScript', () => {
     `)
   })
   it('server', async () => {
-    const head = createServerHead()
+    const head = createServerHead({
+      disableDefaults: true,
+    })
 
     useScript(head, {
       src: 'https://cdn.example.com/script.js',
@@ -41,7 +45,9 @@ describe('ssr useScript', () => {
     `)
   })
   it('await ', async () => {
-    const head = createServerHead()
+    const head = createServerHead({
+      disableDefaults: true,
+    })
 
     // mock a promise, test that it isn't resolved in 1 second
     useScript<{ foo: 'bar' }>(head, {
@@ -62,7 +68,9 @@ describe('ssr useScript', () => {
     `)
   })
   it('google ', async () => {
-    const head = createServerHead()
+    const head = createServerHead({
+      disableDefaults: true,
+    })
     const window: any = {}
     const gtag = useScript<{ dataLayer: any[] }>(head, {
       src: 'https://www.googletagmanager.com/gtm.js?id=GTM-MNJD4B',

--- a/packages/scripts/test/unit/warmup.test.ts
+++ b/packages/scripts/test/unit/warmup.test.ts
@@ -5,7 +5,9 @@ import { useScript } from '../../src/useScript'
 
 describe('warmup', () => {
   it('server', () => {
-    const head = createServerHead()
+    const head = createServerHead({
+      disableDefaults: true,
+    })
     useScript(head, 'https://cdn.example.com/script.js', {
       head,
       trigger: 'server',
@@ -15,7 +17,9 @@ describe('warmup', () => {
     expect(entry.link).toBeUndefined()
   })
   it('default / client', () => {
-    const head = createServerHead()
+    const head = createServerHead({
+      disableDefaults: true,
+    })
     useScript(head, 'https://cdn.example.com/script.js', {
       head,
       trigger: 'client',
@@ -25,7 +29,9 @@ describe('warmup', () => {
     expect(link.rel).toEqual('preload')
   })
   it('relative: default / client', () => {
-    const head = createServerHead()
+    const head = createServerHead({
+      disableDefaults: true,
+    })
     useScript(head, '/script.js', {
       head,
       trigger: 'client',
@@ -35,7 +41,9 @@ describe('warmup', () => {
     expect(link.rel).toEqual('preload')
   })
   it('absolute: dns-prefetch', () => {
-    const head = createServerHead()
+    const head = createServerHead({
+      disableDefaults: true,
+    })
     useScript(head, 'https://cdn.example.com/script.js', {
       head,
       trigger: 'client',

--- a/packages/unhead/src/createHead.ts
+++ b/packages/unhead/src/createHead.ts
@@ -123,5 +123,10 @@ export function createHeadCore<T extends Record<string, any> = Head>(options: Cr
     ...(options?.plugins || []),
   ], ssr)
   head.hooks.callHook('init', head)
+  if (Array.isArray(options.init)) {
+    options.init
+      .filter(Boolean)
+      .forEach(e => head.push(e as T, { tagPriority: 'low' }))
+  }
   return head
 }

--- a/packages/unhead/src/server/createHead.ts
+++ b/packages/unhead/src/server/createHead.ts
@@ -8,6 +8,25 @@ export function createHead<T extends Record<string, any> = Head>(options: Create
     ...options,
     // @ts-expect-error untyped
     document: false,
+    init: [
+      options.disableDefaults
+        ? undefined
+        : {
+            htmlAttrs: {
+              lang: 'en',
+            },
+            meta: [
+              {
+                charset: 'utf-8',
+              },
+              {
+                name: 'viewport',
+                content: 'width=device-width, initial-scale=1',
+              },
+            ],
+          },
+      ...(options.init || []),
+    ],
     plugins: [
       ...(options.plugins || []),
       PayloadPlugin,

--- a/packages/unhead/src/server/createHead.ts
+++ b/packages/unhead/src/server/createHead.ts
@@ -1,9 +1,9 @@
-import type { CreateHeadOptions, Head } from '@unhead/schema'
+import type { CreateServerHeadOptions, Head } from '@unhead/schema'
 import { createHeadCore } from '../createHead'
 import { ServerEventHandlerPlugin } from './plugins/eventHandlers'
 import { PayloadPlugin } from './plugins/payload'
 
-export function createHead<T extends Record<string, any> = Head>(options: CreateHeadOptions = {}) {
+export function createHead<T extends Record<string, any> = Head>(options: CreateServerHeadOptions = {}) {
   return createHeadCore<T>({
     ...options,
     // @ts-expect-error untyped

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from 'vitest'
 describe('inferSeoMetaPlugin', () => {
   it('simple', async () => {
     const head = createHead({
+      disableDefaults: true,
       plugins: [InferSeoMetaPlugin()],
     })
 
@@ -40,6 +41,7 @@ describe('inferSeoMetaPlugin', () => {
   })
   it('conflicts', async () => {
     const head = createHead({
+      disableDefaults: true,
       plugins: [InferSeoMetaPlugin()],
     })
 
@@ -71,6 +73,7 @@ describe('inferSeoMetaPlugin', () => {
   })
   it('empty meta', async () => {
     const head = createHead({
+      disableDefaults: true,
       plugins: [InferSeoMetaPlugin()],
     })
     head.push({
@@ -90,6 +93,7 @@ describe('inferSeoMetaPlugin', () => {
   })
   it('template params', async () => {
     const head = createHead({
+      disableDefaults: true,
       plugins: [InferSeoMetaPlugin()],
     })
     head.push({
@@ -113,6 +117,7 @@ describe('inferSeoMetaPlugin', () => {
 
   it('title and then remove title', async () => {
     const head = createHead({
+      disableDefaults: true,
       plugins: [InferSeoMetaPlugin()],
     })
     const entry = head.push({
@@ -152,6 +157,7 @@ describe('inferSeoMetaPlugin', () => {
 
   it('no title and then add title', async () => {
     const head = createHead({
+      disableDefaults: true,
       plugins: [InferSeoMetaPlugin()],
     })
     head.push({
@@ -186,6 +192,7 @@ describe('inferSeoMetaPlugin', () => {
 
   it('handles title template', async () => {
     const head = createHead({
+      disableDefaults: true,
       plugins: [InferSeoMetaPlugin()],
     })
     head.push({
@@ -207,6 +214,7 @@ describe('inferSeoMetaPlugin', () => {
 
   it('null title / title template', async () => {
     const head = createHead({
+      disableDefaults: true,
       plugins: [InferSeoMetaPlugin()],
     })
     head.push({
@@ -231,6 +239,7 @@ describe('inferSeoMetaPlugin', () => {
 
   it('multiple title templates', async () => {
     const head = createHead({
+      disableDefaults: true,
       plugins: [InferSeoMetaPlugin()],
     })
 

--- a/packages/unhead/test/util.ts
+++ b/packages/unhead/test/util.ts
@@ -9,7 +9,10 @@ export function createClientHeadWithContext(options?: any) {
 }
 
 export function createServerHeadWithContext(options?: any) {
-  return createServerHead(options)
+  return createServerHead({
+    disableDefaults: true,
+    ...options,
+  })
 }
 
 // eslint-disable-next-line import/no-mutable-exports

--- a/packages/vue/src/server.ts
+++ b/packages/vue/src/server.ts
@@ -1,4 +1,4 @@
-import type { CreateHeadOptions, MergeHead } from '@unhead/schema'
+import type { CreateServerHeadOptions, MergeHead } from '@unhead/schema'
 import type { MaybeComputedRef, ReactiveHead, VueHeadClient } from '@unhead/vue'
 import { createHead as _createServerHead } from 'unhead/server'
 import { vueInstall } from './install'
@@ -7,7 +7,7 @@ import { VueReactivityPlugin } from './VueReactivityPlugin'
 export { VueHeadMixin } from './VueHeadMixin'
 export * from 'unhead/server'
 
-export function createHead<T extends MergeHead>(options: Omit<CreateHeadOptions, 'domDelayFn' | 'document'> = {}): VueHeadClient<T> {
+export function createHead<T extends MergeHead>(options: CreateServerHeadOptions = {}): VueHeadClient<T> {
   const head = _createServerHead<MaybeComputedRef<ReactiveHead<T>>>({
     ...options,
     plugins: [

--- a/packages/vue/test/unit/e2e/basic.test.ts
+++ b/packages/vue/test/unit/e2e/basic.test.ts
@@ -356,7 +356,9 @@ describe('vue e2e', () => {
   })
 
   it('title', async () => {
-    const ssrHead = createServerHead()
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+    })
 
     // i.e App.vue
     ssrHead.push({

--- a/packages/vue/test/unit/e2e/keys.test.ts
+++ b/packages/vue/test/unit/e2e/keys.test.ts
@@ -17,7 +17,9 @@ describe('vue e2e keys', () => {
     }
 
     // ssr render on the index page
-    const ssrHead = createServerHead()
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+    })
 
     ssrHead.push(IndexSchema)
 

--- a/packages/vue/test/unit/ssr/asyncSetup.test.ts
+++ b/packages/vue/test/unit/ssr/asyncSetup.test.ts
@@ -7,7 +7,9 @@ import { createSSRApp, ref } from 'vue'
 
 describe('vue ssr asyncSetup', () => {
   it('basic', async () => {
-    const head = createHead()
+    const head = createHead({
+      disableDefaults: true,
+    })
     const app = createSSRApp({
       async setup() {
         const title = ref('initial title')

--- a/packages/vue/test/unit/ssr/customAugmentation.test.ts
+++ b/packages/vue/test/unit/ssr/customAugmentation.test.ts
@@ -14,7 +14,9 @@ describe('vue ssr custom augmentation', () => {
       }
     }
 
-    const head = createHead<CustomHead>()
+    const head = createHead<CustomHead>({
+      disableDefaults: true,
+    })
     const app = createSSRApp({
       setup() {
         const title = ref('')

--- a/packages/vue/test/unit/ssr/normalise.test.ts
+++ b/packages/vue/test/unit/ssr/normalise.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from 'vitest'
 
 describe('normalise', () => {
   it('handles booleans nicely', async () => {
-    const head = createHead()
+    const head = createHead({
+      disableDefaults: true,
+    })
 
     const fn = () => {}
     fn.toString = () => {

--- a/packages/vue/test/unit/ssr/templateParams.test.ts
+++ b/packages/vue/test/unit/ssr/templateParams.test.ts
@@ -146,7 +146,9 @@ describe('ssr vue templateParams', () => {
   })
 
   it('edge case', async () => {
-    const head = createHead()
+    const head = createHead({
+      disableDefaults: true,
+    })
     head.push({
       title: '%site.tagline',
       // DEV - My page title - My cool site
@@ -180,7 +182,9 @@ describe('ssr vue templateParams', () => {
   })
 
   it('entry opt-out', async () => {
-    const head = createHead()
+    const head = createHead({
+      disableDefaults: true,
+    })
     head.push({
       title: 'Hello %name',
       templateParams: { name: 'World' },

--- a/packages/vue/test/util.ts
+++ b/packages/vue/test/util.ts
@@ -32,7 +32,10 @@ export function csrVueAppWithUnhead(dom: JSDOM, fn: () => void | Promise<void>) 
 }
 
 export async function ssrVueAppWithUnhead(fn: () => void | Promise<void>, options?: CreateHeadOptions) {
-  const head = createServerHead(options)
+  const head = createServerHead({
+    disableDefaults: true,
+    ...options,
+  })
   const app = createSSRApp({
     async setup() {
       fn()
@@ -45,7 +48,9 @@ export async function ssrVueAppWithUnhead(fn: () => void | Promise<void>, option
 }
 
 export async function ssrRenderHeadToString(fn: () => void) {
-  const head = createServerHead()
+  const head = createServerHead({
+    disableDefaults: true,
+  })
   const app = createSSRApp({
     setup() {
       fn()
@@ -59,7 +64,9 @@ export async function ssrRenderHeadToString(fn: () => void) {
 }
 
 export async function ssrRenderOptionsHead(input: any) {
-  const head = createServerHead()
+  const head = createServerHead({
+    disableDefaults: true,
+  })
   const app = createSSRApp({
     head() {
       return input


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

🚦 Impact Level: Low

When SSR Unhead will now insert important default tags for you:
- `<meta charset="utf-8">`
- `<meta name="viewport" content="width=device-width, initial-scale=1">`
- `<html lang="en">`

If you were previously relying on these being left empty, you may need to either disable them by using `disableDefaultTags` or insert tags
to override them.

```ts
import { createHead } from '@unhead/vue/server'

// disable when creating the head instance
createHead({
  disableDefaults: true,
})
```

```ts
import { useHead } from 'unhead'

// override the defaults
useHead({
  htmlAttrs: {
    lang: 'fr'
  }
})
```


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
