### PR TITLE
fix!: drop `CJS` exports

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -438,3 +438,14 @@ useHead({
   }
 })
 ```
+
+## CJS Exports Removed
+
+🚦 Impact Level: Low
+
+CommonJS exports have been removed in favor of ESM only.
+
+```diff
+-const { createHead } = require('unhead/client')
++import { createHead } from 'unhead/client'
+```

--- a/packages/addons/build.config.ts
+++ b/packages/addons/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   entries: [
     { input: 'src/index', name: 'index' },
     { input: 'src/unplugin/vite', name: 'vite' },

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -22,21 +22,17 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     },
     "./vite": {
       "types": "./dist/vite.d.ts",
-      "import": "./dist/vite.mjs",
-      "require": "./dist/vite.cjs"
+      "import": "./dist/vite.mjs"
     },
     "./webpack": {
       "types": "./dist/webpack.d.ts",
-      "import": "./dist/webpack.mjs",
-      "require": "./dist/webpack.cjs"
+      "import": "./dist/webpack.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "typesVersions": {

--- a/packages/dom/build.config.ts
+++ b/packages/dom/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   entries: [
     { input: 'src/index', name: 'index' },
   ],

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -22,11 +22,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/react/build.config.ts
+++ b/packages/react/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   externals: ['react'],
   entries: [
     { input: 'src/index', name: 'index' },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,26 +18,21 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     },
     "./server": {
       "types": "./dist/server.d.ts",
-      "import": "./dist/server.mjs",
-      "require": "./dist/server.cjs"
+      "import": "./dist/server.mjs"
     },
     "./client": {
       "types": "./dist/client.d.ts",
-      "import": "./dist/client.mjs",
-      "require": "./dist/client.cjs"
+      "import": "./dist/client.mjs"
     },
     "./types": {
       "types": "./dist/types.d.ts",
-      "import": "./dist/types.mjs",
-      "require": "./dist/types.cjs"
+      "import": "./dist/types.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "typesVersions": {

--- a/packages/schema-org/build.config.ts
+++ b/packages/schema-org/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   entries: [
     { input: 'src/index' },
     { input: 'src/vue/index', name: 'vue' },

--- a/packages/schema-org/package.json
+++ b/packages/schema-org/package.json
@@ -28,16 +28,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     },
     "./vue": {
       "types": "./dist/vue.d.ts",
-      "import": "./dist/vue.mjs",
-      "require": "./dist/vue.cjs"
+      "import": "./dist/vue.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "typesVersions": {

--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   entries: [
     { input: 'src/index', name: 'index' },
   ],

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -27,11 +27,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/scripts/build.config.ts
+++ b/packages/scripts/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   entries: [
     { input: 'src/index' },
     { input: 'src/vue/index', name: 'vue' },

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -23,16 +23,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     },
     "./vue": {
       "types": "./dist/vue.d.ts",
-      "import": "./dist/vue.mjs",
-      "require": "./dist/vue.cjs"
+      "import": "./dist/vue.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "typesVersions": {

--- a/packages/shared/build.config.ts
+++ b/packages/shared/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   entries: [
     { input: 'src/index', name: 'index' },
   ],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,11 +27,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/ssr/build.config.ts
+++ b/packages/ssr/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   entries: [
     { input: 'src/index', name: 'index' },
   ],

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -22,11 +22,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/unhead/build.config.ts
+++ b/packages/unhead/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   entries: [
     { input: 'src/index', name: 'index' },
     { input: 'src/plugins/index', name: 'plugins' },

--- a/packages/unhead/package.json
+++ b/packages/unhead/package.json
@@ -27,31 +27,25 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     },
     "./plugins": {
       "types": "./dist/plugins.d.ts",
-      "import": "./dist/plugins.mjs",
-      "require": "./dist/plugins.cjs"
+      "import": "./dist/plugins.mjs"
     },
     "./server": {
       "types": "./dist/server.d.ts",
-      "import": "./dist/server.mjs",
-      "require": "./dist/server.cjs"
+      "import": "./dist/server.mjs"
     },
     "./client": {
       "types": "./dist/client.d.ts",
-      "import": "./dist/client.mjs",
-      "require": "./dist/client.cjs"
+      "import": "./dist/client.mjs"
     },
     "./legacy": {
       "types": "./dist/legacy.d.ts",
-      "import": "./dist/legacy.mjs",
-      "require": "./dist/legacy.cjs"
+      "import": "./dist/legacy.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "optionalPlugins": {

--- a/packages/vue/build.config.ts
+++ b/packages/vue/build.config.ts
@@ -3,9 +3,6 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
   externals: ['vue'],
   entries: [
     { input: 'src/index', name: 'index' },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -23,36 +23,29 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     },
     "./components": {
       "types": "./dist/components.d.ts",
-      "import": "./dist/components.mjs",
-      "require": "./dist/components.cjs"
+      "import": "./dist/components.mjs"
     },
     "./server": {
       "types": "./dist/server.d.ts",
-      "import": "./dist/server.mjs",
-      "require": "./dist/server.cjs"
+      "import": "./dist/server.mjs"
     },
     "./client": {
       "types": "./dist/client.d.ts",
-      "import": "./dist/client.mjs",
-      "require": "./dist/client.cjs"
+      "import": "./dist/client.mjs"
     },
     "./types": {
       "types": "./dist/types.d.ts",
-      "import": "./dist/types.mjs",
-      "require": "./dist/types.cjs"
+      "import": "./dist/types.mjs"
     },
     "./legacy": {
       "types": "./dist/legacy.d.ts",
-      "import": "./dist/legacy.mjs",
-      "require": "./dist/legacy.cjs"
+      "import": "./dist/legacy.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "typesVersions": {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Inspired by https://antfu.me/posts/move-on-to-esm-only.

For v2 we no longer export CJS.

:warning: This may break for some users although not exactly sure who.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
