### PR TITLE
feat(core): whitelist styles with `useHeadSafe()`

### DIFF
--- a/docs/7.api/1.use-head-safe.md
+++ b/docs/7.api/1.use-head-safe.md
@@ -9,23 +9,23 @@ The `useHeadSafe` composable is a wrapper around the [useHead](/guide/composable
 
 There is a whitelist of allowed tags and attributes. If you try to use a tag or attribute that isn't on the whitelist, it will be ignored.
 
-The whitelist is very restrictive, as there are many vectors for XSS attacks. If you need to use a tag or attribute that isn't on the whitelist, you can use the [useHead](/guide/composables/use-head) composable instead,
+The whitelist is restrictive, as there are many vectors for XSS attacks. If you need to use a tag or attribute that isn't on the whitelist, you can use the [useHead](/guide/composables/use-head) composable instead,
 just make sure **you sanitise the input**.
 
 The whitelist is as follows:
 
 ```ts
 const WhitelistAttributes = {
-  htmlAttrs: ['id', 'class', 'lang', 'dir'],
-  bodyAttrs: ['id', 'class'],
-  meta: ['id', 'name', 'property', 'charset', 'content'],
-  noscript: ['id', 'textContent'],
-  script: ['id', 'type', 'textContent'],
-  link: ['id', 'color', 'crossorigin', 'fetchpriority', 'href', 'hreflang', 'imagesrcset', 'imagesizes', 'integrity', 'media', 'referrerpolicy', 'rel', 'sizes', 'type'],
-}
+  htmlAttrs: ['class', 'style', 'lang', 'dir'] satisfies (keyof HtmlAttributes)[],
+  bodyAttrs: ['class', 'style'] satisfies (keyof BodyAttributes)[],
+  meta: ['name', 'property', 'charset', 'content', 'media'] satisfies (keyof Meta)[],
+  noscript: ['textContent'] satisfies (Partial<keyof Noscript> | 'textContent')[],
+  style: ['media', 'textContent', 'nonce', 'title', 'blocking'] satisfies (Partial<keyof Style> | 'textContent')[],
+  script: ['type', 'textContent', 'nonce', 'blocking'] satisfies (Partial<keyof Script> | 'textContent')[],
+  link: ['color', 'crossorigin', 'fetchpriority', 'href', 'hreflang', 'imagesrcset', 'imagesizes', 'integrity', 'media', 'referrerpolicy', 'rel', 'sizes', 'type'] satisfies (keyof Link)[],
+} as const
 ```
 
-- Style tags and attributes not supported `<link rel="stylesheet" ...>`{lang="html"}, `<style>`{lang="html"}, they are a vector for XSS attacks and clickjacking.
 - Scripts of any sort are not allowed, except for JSON. `<script type="application/json">`{lang="html"}, use `textContent: myObject`.
 - http-equiv is not allowed on meta.
 - `data-*` attributes are allowed.
@@ -40,3 +40,7 @@ const thirdPartyMeta = loadMeta()
 
 useHeadSafe(thirdPartyMeta)
 ```
+
+## Styles
+
+While styles are permitted it's important to note that [clickjacking](https://en.wikipedia.org/wiki/Clickjacking) is still possible. You should ensure that your styles are safe to use.

--- a/packages/unhead/src/types/schema/bodyAttributes.ts
+++ b/packages/unhead/src/types/schema/bodyAttributes.ts
@@ -1,3 +1,5 @@
+import type { GlobalAttributes } from './attributes/global'
+
 export interface BodyEvents {
   /**
    * Script to be run after the document is printed
@@ -61,22 +63,7 @@ export interface BodyEvents {
   onunload?: string
 }
 
-export interface BaseBodyAttributes {
-  /**
-   * The class global attribute is a space-separated list of the case-sensitive classes of the element.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class
-   */
-  class?: string
-  /**
-   * The style global attribute contains CSS styling declarations to be applied to the element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/style
-   */
-  style?: string
-  /**
-   * This attribute defines the unique ID.
-   */
-  id?: string
+export interface BaseBodyAttributes extends Pick<GlobalAttributes, 'class' | 'style' | 'id'> {
 }
 
 export type BodyAttributes = BaseBodyAttributes & BodyEvents

--- a/packages/unhead/src/types/schema/htmlAttributes.ts
+++ b/packages/unhead/src/types/schema/htmlAttributes.ts
@@ -1,38 +1,6 @@
-export interface HtmlAttributes {
-  /**
-   * The lang global attribute helps define the language of an element: the language that non-editable elements are
-   * written in, or the language that the editable elements should be written in by the user.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang
-   */
-  lang?: string
-  /**
-   * The dir global attribute is an enumerated attribute that indicates the directionality of the element's text.
-   */
-  dir?: 'ltr' | 'rtl' | 'auto'
-  /**
-   * The translate global attribute is an enumerated attribute that is used to specify whether an element's
-   * translatable attribute values and its Text node children should be translated when the page is localized,
-   * or whether to leave them unchanged.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate
-   */
-  translate?: 'yes' | 'no'
-  /**
-   * The class global attribute is a space-separated list of the case-sensitive classes of the element.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class
-   */
-  class?: string
-  /**
-   * The style global attribute contains CSS styling declarations to be applied to the element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/style
-   */
-  style?: string
-  /**
-   * This attribute defines the unique ID.
-   */
-  id?: string
+import type { GlobalAttributes } from './attributes/global'
+
+export interface HtmlAttributes extends Pick<GlobalAttributes, 'lang' | 'dir' | 'translate' | 'class' | 'style' | 'id'> {
   /**
    * Open-graph protocol prefix.
    *

--- a/packages/unhead/src/types/schema/link.ts
+++ b/packages/unhead/src/types/schema/link.ts
@@ -34,7 +34,7 @@ export type LinkRelTypes = 'alternate' |
   'apple-touch-icon' |
   'apple-touch-startup-image'
 
-export interface LinkBase extends Pick<GlobalAttributes, 'nonce'>, Blocking {
+export interface LinkBase extends Pick<GlobalAttributes, 'nonce' | 'id'>, Blocking {
   /**
    * This attribute is only used when rel="preload" or rel="prefetch" has been set on the `<link>` element.
    * It specifies the type of content being loaded by the `<link>`, which is necessary for request matching,
@@ -251,10 +251,6 @@ export interface LinkBase extends Pick<GlobalAttributes, 'nonce'>, Blocking {
     'audio/3gpp' |
     'video/3gpp2' |
     'audio/3gpp2' | (string & Record<never, never>)
-  /**
-   * This attribute defines the unique ID.
-   */
-  id?: string
 }
 
 export type Link = LinkBase & HttpEventAttributes

--- a/packages/unhead/src/types/schema/meta.ts
+++ b/packages/unhead/src/types/schema/meta.ts
@@ -1,4 +1,5 @@
 import type { Stringable } from '../util'
+import type { GlobalAttributes } from './attributes/global'
 
 export type MetaNames =
   'apple-itunes-app' |
@@ -99,7 +100,7 @@ export type MetaProperties = 'article:author' |
   'profile:last_name' |
   'profile:username'
 
-export interface Meta {
+export interface Meta extends Pick<GlobalAttributes, 'id'> {
   /**
    * This attribute declares the document's character encoding.
    * If the attribute is present, its value must be an ASCII case-insensitive match for the string "utf-8",
@@ -142,10 +143,6 @@ export interface Meta {
    * Mainly used for og and twitter meta tags.
    */
   property?: MetaProperties | (string & Record<never, never>)
-  /**
-   * This attribute defines the unique ID.
-   */
-  id?: string
   /**
    * A valid media query list that can be included to set the media the `theme-color` metadata applies to.
    *

--- a/packages/unhead/src/types/schema/script.ts
+++ b/packages/unhead/src/types/schema/script.ts
@@ -4,7 +4,7 @@ import type { GlobalAttributes } from './attributes/global'
 import type { ReferrerPolicy } from './shared'
 import type { Blocking } from './struct/blocking'
 
-export interface ScriptBase extends Pick<GlobalAttributes, 'nonce'>, Blocking {
+export interface ScriptBase extends Pick<GlobalAttributes, 'nonce' | 'id'>, Blocking {
   /**
    * For classic scripts, if the async attribute is present,
    * then the classic script will be fetched in parallel to parsing and evaluated as soon as it is available.
@@ -81,11 +81,6 @@ export interface ScriptBase extends Pick<GlobalAttributes, 'nonce'>, Blocking {
     'application/ld+json' |
     'speculationrules' |
     (string & Record<never, never>)
-  /**
-   * This attribute defines the unique ID.
-   */
-  id?: string
-
   /**
    * A custom element name
    *

--- a/packages/unhead/src/types/schema/style.ts
+++ b/packages/unhead/src/types/schema/style.ts
@@ -1,6 +1,7 @@
+import type { GlobalAttributes } from './attributes/global'
 import type { Blocking } from './struct/blocking'
 
-export interface Style extends Blocking {
+export interface Style extends Pick<GlobalAttributes, 'nonce' | 'id'>, Blocking {
   /**
    * This attribute defines which media the style should be applied to.
    * Its value is a media query, which defaults to all if the attribute is missing.
@@ -22,8 +23,4 @@ export interface Style extends Blocking {
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#attr-title
    */
   title?: string
-  /**
-   * This attribute defines the unique ID.
-   */
-  id?: string
 }

--- a/packages/unhead/test/unit/client/useHeadSafe.test.ts
+++ b/packages/unhead/test/unit/client/useHeadSafe.test.ts
@@ -45,7 +45,7 @@ describe('dom useHeadSafe', () => {
     expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html lang="en" dir="ltr"><head>
 
-      <meta charset="utf-8"><link href="https://cdn.example.com/favicon.ico" rel="icon" type="image/x-icon"><script type="application/json">{"value":"alert(1)"}</script></head>
+      <meta charset="utf-8"><link href="https://cdn.example.com/style.css" rel="stylesheet"><link href="https://cdn.example.com/favicon.ico" rel="icon" type="image/x-icon"><script type="application/json">{"value":"alert(1)"}</script></head>
       <body class="dark">
 
       <div>

--- a/packages/vue/test/unit/dom/useHeadSafe.test.ts
+++ b/packages/vue/test/unit/dom/useHeadSafe.test.ts
@@ -62,7 +62,7 @@ describe('vue dom useHeadSafe', () => {
     expect(dom.serialize()).toMatchInlineSnapshot(`
       "<html lang="en" dir="ltr"><head>
 
-      <meta charset="utf-8"><link href="https://cdn.example.com/favicon.ico" rel="icon" type="image/x-icon"><link data-bar="foo" href="/valid.png" rel="icon"><link href="alert(1)" rel="icon"></head>
+      <meta charset="utf-8"><link data-bar="foo" href="https://cdn.example.com/style.css" rel="stylesheet"><style data-foo="bar">body { background: url("javascript:alert(1)") }</style><link href="https://cdn.example.com/favicon.ico" rel="icon" type="image/x-icon"><link data-bar="foo" href="/valid.png" rel="icon"><link href="alert(1)" rel="icon"></head>
       <body class="dark" data-bar="foo"><div id="app" data-v-app=""><div>hello world</div></div></body></html>"
     `)
   })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allows the use of styles with `useHeadSafe()` as modern browsers won't allow XSS injection in `style` tags.

While styles are permitted it's important to note that [clickjacking](https://en.wikipedia.org/wiki/Clickjacking) is still possible. You should ensure that your styles are safe to use.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
