### PR TITLE
fix(core,vue): deprecate server composables

### DIFF
--- a/docs/7.api/6.use-server-head.md
+++ b/docs/7.api/6.use-server-head.md
@@ -1,7 +1,10 @@
 ---
 title: useServerHead()
 description: Learn how to use server only tags.
+deprecated: true
 ---
+
+:UAlert{color="warning" variant="outline" title="Deprecated" description="The useServerHead composable is deprecated. Learn more at https://github.com/unjs/unhead/pull/505"}
 
 The `useServerHead` offers the same API as `useHead` but only works on the server.
 

--- a/packages/react/src/autoImports.ts
+++ b/packages/react/src/autoImports.ts
@@ -4,6 +4,5 @@ export const hookImports = {
     'useHead',
     'useSeoMeta',
     'useHeadSafe',
-    'useServerHead',
   ],
 }

--- a/packages/solid-js/src/autoImports.ts
+++ b/packages/solid-js/src/autoImports.ts
@@ -4,6 +4,5 @@ export const hookImports = {
     'useHead',
     'useSeoMeta',
     'useHeadSafe',
-    'useServerHead',
   ],
 }

--- a/packages/svelte/src/autoImports.ts
+++ b/packages/svelte/src/autoImports.ts
@@ -4,6 +4,5 @@ export const autoImports = {
     'useHead',
     'useSeoMeta',
     'useHeadSafe',
-    'useServerHead',
   ],
 }

--- a/packages/unhead/src/composables.ts
+++ b/packages/unhead/src/composables.ts
@@ -43,4 +43,26 @@ export function useSeoMeta<T extends Unhead<any>>(unhead: T, input: UseSeoMetaIn
   return entry
 }
 
+/**
+ * @deprecated use `useHead` instead. Advanced use cases should tree shake using import.meta.* if statements.
+ */
+export function useServerHead<T extends Unhead<any>>(unhead: T, input: Parameters<T['push']>[0] = {}, options: Omit<HeadEntryOptions, 'mode'> = {}): ReturnType<T['push']> {
+  ;(options as HeadEntryOptions).mode = 'server'
+  return unhead.push(input, options) as ReturnType<T['push']>
+}
+
+/**
+ * @deprecated use `useHeadSafe` instead. Advanced use cases should tree shake using import.meta.* if statements.
+ */
+export function useServerHeadSafe(input: HeadSafe = {}, options: UseHeadOptions = {}): ActiveHeadEntry<HeadSafe> {
+  return useHeadSafe(input, { ...options, mode: 'server' })
+}
+
+/**
+ * @deprecated use `useSeoMeta` instead. Advanced use cases should tree shake using import.meta.* if statements.
+ */
+export function useServerSeoMeta(input: UseSeoMetaInput = {}, options?: UseHeadOptions): ActiveHeadEntry<UseSeoMetaInput> {
+  return useSeoMeta(input, { ...options, mode: 'server' })
+}
+
 export { useScript } from './scripts'

--- a/packages/unhead/src/composables.ts
+++ b/packages/unhead/src/composables.ts
@@ -47,22 +47,24 @@ export function useSeoMeta<T extends Unhead<any>>(unhead: T, input: UseSeoMetaIn
  * @deprecated use `useHead` instead. Advanced use cases should tree shake using import.meta.* if statements.
  */
 export function useServerHead<T extends Unhead<any>>(unhead: T, input: Parameters<T['push']>[0] = {}, options: Omit<HeadEntryOptions, 'mode'> = {}): ReturnType<T['push']> {
-  ;(options as HeadEntryOptions).mode = 'server'
+  (options as HeadEntryOptions).mode = 'server'
   return unhead.push(input, options) as ReturnType<T['push']>
 }
 
 /**
  * @deprecated use `useHeadSafe` instead. Advanced use cases should tree shake using import.meta.* if statements.
  */
-export function useServerHeadSafe(input: HeadSafe = {}, options: UseHeadOptions = {}): ActiveHeadEntry<HeadSafe> {
-  return useHeadSafe(input, { ...options, mode: 'server' })
+export function useServerHeadSafe<T extends Unhead<any>>(unhead: T, input: HeadSafe = {}, options: Omit<HeadEntryOptions, 'mode'> = {}): ActiveHeadEntry<HeadSafe> {
+  (options as HeadEntryOptions).mode = 'server'
+  return useHeadSafe(unhead, input, { ...options, mode: 'server' })
 }
 
 /**
  * @deprecated use `useSeoMeta` instead. Advanced use cases should tree shake using import.meta.* if statements.
  */
-export function useServerSeoMeta(input: UseSeoMetaInput = {}, options?: UseHeadOptions): ActiveHeadEntry<UseSeoMetaInput> {
-  return useSeoMeta(input, { ...options, mode: 'server' })
+export function useServerSeoMeta<T extends Unhead<any>>(unhead: T, input: UseSeoMetaInput = {}, options?: Omit<HeadEntryOptions, 'mode'>): ActiveHeadEntry<UseSeoMetaInput> {
+  (options as HeadEntryOptions).mode = 'server'
+  return useSeoMeta(unhead, input, { ...options, mode: 'server' })
 }
 
 export { useScript } from './scripts'

--- a/packages/unhead/src/index.ts
+++ b/packages/unhead/src/index.ts
@@ -1,2 +1,2 @@
-export { useHead, useHeadSafe, useScript, useSeoMeta } from './composables'
+export { useHead, useHeadSafe, useScript, useSeoMeta, useServerHead, useServerHeadSafe, useServerSeoMeta } from './composables'
 export { createHeadCore } from './createHead'

--- a/packages/unhead/src/server/createHead.ts
+++ b/packages/unhead/src/server/createHead.ts
@@ -41,7 +41,7 @@ export function createHead<T = Head>(options: CreateServerHeadOptions = {}) {
         const title = ctx.tagMap.get('title') as HeadTag | undefined
         const titleTemplate = ctx.tagMap.get('titleTemplate') as HeadTag | undefined
         const templateParams = ctx.tagMap.get('templateParams') as HeadTag | undefined
-        const payload = {
+        const payload: Head = {
           title: title?.mode === 'server' ? unhead._title : undefined,
           titleTemplate: titleTemplate?.mode === 'server' ? unhead._titleTemplate : undefined,
           templateParams: templateParams?.mode === 'server' ? unhead._templateParams : undefined,

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -139,6 +139,9 @@ export interface CreateClientHeadOptions extends CreateHeadOptions {
 }
 
 export interface HeadEntryOptions extends TagPosition, TagPriority, ProcessesTemplateParams, ResolvesDuplicates {
+  /**
+   * @deprecated Tree shaking should now be handled using import.meta.* if statements.
+   */
   mode?: RuntimeMode
   head?: Unhead
   /**

--- a/packages/unhead/test/unit/e2e/e2e.test.ts
+++ b/packages/unhead/test/unit/e2e/e2e.test.ts
@@ -87,7 +87,8 @@ describe('unhead e2e', () => {
       <meta property="og:image" content="https://cdn.example.com/image.jpg">
       <meta property="og:image" content="https://cdn.example.com/image2.jpg">
       <script type="application/json">{"val":"\\u003C/script>"}</script>
-      <meta name="description" content="This is the home page">",
+      <meta name="description" content="This is the home page">
+      <script id="unhead:payload" type="application/json">{"meta":[{"charset":"utf-8"},{"property":"og:title","content":"My amazing site"},{"property":"og:description","content":"This is my amazing site"},{"property":"og:image","content":"https://cdn.example.com/image.jpg"},{"property":"og:image","content":"https://cdn.example.com/image2.jpg"}]}</script>",
         "htmlAttrs": " lang="en"",
       }
     `)
@@ -132,6 +133,7 @@ describe('unhead e2e', () => {
       <meta property="og:image" content="https://cdn.example.com/image2.jpg">
       <script type="application/json">{"val":"\\u003C/script>"}</script>
       <meta name="description" content="This is the home page">
+      <script id="unhead:payload" type="application/json">{"meta":[{"charset":"utf-8"},{"property":"og:title","content":"My amazing site"},{"property":"og:description","content":"This is my amazing site"},{"property":"og:image","content":"https://cdn.example.com/image.jpg"},{"property":"og:image","content":"https://cdn.example.com/image2.jpg"}]}</script>
       </head>
       <body>
 

--- a/packages/unhead/test/unit/e2e/e2e.test.ts
+++ b/packages/unhead/test/unit/e2e/e2e.test.ts
@@ -87,8 +87,7 @@ describe('unhead e2e', () => {
       <meta property="og:image" content="https://cdn.example.com/image.jpg">
       <meta property="og:image" content="https://cdn.example.com/image2.jpg">
       <script type="application/json">{"val":"\\u003C/script>"}</script>
-      <meta name="description" content="This is the home page">
-      <script id="unhead:payload" type="application/json">{"meta":[{"charset":"utf-8"},{"property":"og:title","content":"My amazing site"},{"property":"og:description","content":"This is my amazing site"},{"property":"og:image","content":"https://cdn.example.com/image.jpg"},{"property":"og:image","content":"https://cdn.example.com/image2.jpg"}]}</script>",
+      <meta name="description" content="This is the home page">",
         "htmlAttrs": " lang="en"",
       }
     `)
@@ -133,7 +132,6 @@ describe('unhead e2e', () => {
       <meta property="og:image" content="https://cdn.example.com/image2.jpg">
       <script type="application/json">{"val":"\\u003C/script>"}</script>
       <meta name="description" content="This is the home page">
-      <script id="unhead:payload" type="application/json">{"meta":[{"charset":"utf-8"},{"property":"og:title","content":"My amazing site"},{"property":"og:description","content":"This is my amazing site"},{"property":"og:image","content":"https://cdn.example.com/image.jpg"},{"property":"og:image","content":"https://cdn.example.com/image2.jpg"}]}</script>
       </head>
       <body>
 

--- a/packages/unhead/test/unit/e2e/useServerSeoMeta.test.ts
+++ b/packages/unhead/test/unit/e2e/useServerSeoMeta.test.ts
@@ -48,7 +48,7 @@ describe('unhead e2e useServerSeoMeta', () => {
         "headTags": "<title>title mainpage</title>
       <script>lorem ipsum generate more lorem ipsum</script>
       <meta name="description" content="description mainpage">
-      <script id="unhead:payload" type="application/json">{"title":"title mainpage","meta":[{"name":"description","content":"description mainpage"}]}</script>",
+      <script id="unhead:payload" type="application/json">{"title":"title mainpage"}</script>",
         "htmlAttrs": " lang="app.vue"",
       }
     `)
@@ -76,8 +76,8 @@ describe('unhead e2e useServerSeoMeta', () => {
       "<!DOCTYPE html><html lang="app.vue"><head>
       <title>title mainpage</title>
       <script>lorem ipsum generate more lorem ipsum</script>
-      <meta name="description" content="description mainpage">
-      <script id="unhead:payload" type="application/json">{"title":"title mainpage","meta":[{"name":"description","content":"description mainpage"}]}</script>
+      <meta name="description" content="Description from nuxt.config.ts">
+      <script id="unhead:payload" type="application/json">{"title":"title mainpage"}</script>
       </head>
       <body>
 

--- a/packages/unhead/test/unit/e2e/useServerSeoMeta.test.ts
+++ b/packages/unhead/test/unit/e2e/useServerSeoMeta.test.ts
@@ -1,0 +1,93 @@
+import { useHead, useSeoMeta } from 'unhead'
+import { renderDOMHead } from 'unhead/client'
+import { renderSSRHead } from 'unhead/server'
+import { describe, it } from 'vitest'
+import { createClientHeadWithContext, createServerHeadWithContext, useDom } from '../../util'
+
+describe('unhead e2e useServerSeoMeta', () => {
+  it('useServerSeoMeta', async () => {
+    // scenario: we are injecting root head schema which will not have a hydration step,
+    // but we are also injecting a child head schema which will have a hydration step
+    const ssrHead = createServerHeadWithContext()
+    useSeoMeta(ssrHead, {
+      title: 'title from nuxt.config.ts',
+      description: 'Description from nuxt.config.ts',
+    }, {
+      tagPriority: 'low',
+    })
+    useHead(ssrHead, {
+      htmlAttrs: { lang: 'nuxt.config' },
+      script: [
+        {
+          innerHTML: 'lorem ipsum generate more lorem ipsum',
+        },
+      ],
+    }, {
+      mode: 'server',
+    })
+    // i.e App.vue
+    useSeoMeta(ssrHead, {
+      title: 'title mainpage',
+      description: 'description mainpage',
+    }, {
+      mode: 'server',
+    })
+    useHead(ssrHead, {
+      htmlAttrs: { lang: 'app.vue' },
+    }, {
+      mode: 'server',
+    })
+
+    const data = await renderSSRHead(ssrHead)
+
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": "",
+        "bodyTags": "",
+        "bodyTagsOpen": "",
+        "headTags": "<title>title mainpage</title>
+      <script>lorem ipsum generate more lorem ipsum</script>
+      <meta name="description" content="description mainpage">
+      <script id="unhead:payload" type="application/json">{"title":"title mainpage","meta":[{"name":"description","content":"description mainpage"}]}</script>",
+        "htmlAttrs": " lang="app.vue"",
+      }
+    `)
+
+    const dom = useDom(data)
+
+    const csrHead = createClientHeadWithContext({
+      document: dom.window.document,
+    })
+    useHead(ssrHead, {
+      htmlAttrs: { lang: 'nuxt.config' },
+    }, {
+      tagPriority: 'low',
+    })
+    useSeoMeta(csrHead, {
+      title: 'Some cool reproduction repo :)',
+      description: 'Description from nuxt.config.ts',
+    }, {
+      tagPriority: 'low',
+    })
+
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html lang="app.vue"><head>
+      <title>title mainpage</title>
+      <script>lorem ipsum generate more lorem ipsum</script>
+      <meta name="description" content="description mainpage">
+      <script id="unhead:payload" type="application/json">{"title":"title mainpage","meta":[{"name":"description","content":"description mainpage"}]}</script>
+      </head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+})

--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -86,14 +86,24 @@ export function useSeoMeta(input: UseSeoMetaInput = {}, options: UseHeadOptions 
     _flatMeta: meta,
   }, options)
 }
+
+/**
+ * @deprecated use `useHead` instead.Advanced use cases should tree shake using import.meta.* if statements.
+ */
 export function useServerHead<T extends MergeHead>(input: UseHeadInput<T> = {}, options: UseHeadOptions = {}): ActiveHeadEntry<any> {
   return useHead<T>(input, { ...options, mode: 'server' })
 }
 
+/**
+ * @deprecated use `useHeadSafe` instead.Advanced use cases should tree shake using import.meta.* if statements.
+ */
 export function useServerHeadSafe(input: UseHeadSafeInput = {}, options: UseHeadOptions = {}): ActiveHeadEntry<any> {
   return useHeadSafe(input, { ...options, mode: 'server' })
 }
 
+/**
+ * @deprecated use `useSeoMeta` instead.Advanced use cases should tree shake using import.meta.* if statements.
+ */
 export function useServerSeoMeta(input: UseSeoMetaInput = {}, options?: UseHeadOptions): ActiveHeadEntry<UseSeoMetaInput> {
   return useSeoMeta(input, { ...options, mode: 'server' })
 }

--- a/packages/vue/src/legacy.ts
+++ b/packages/vue/src/legacy.ts
@@ -141,14 +141,23 @@ export function useSeoMeta(input: UseSeoMetaInput, options?: UseHeadOptions): Ac
   }
 }
 
+/**
+ * @deprecated use `useHead` instead. Advanced use cases should tree shake using import.meta.* if statements.
+ */
 export function useServerHead<T extends MergeHead>(input: UseHeadInput<T>, options: UseHeadOptions = {}): ActiveHeadEntry<any> | void {
   return useHead(input, { ...options, mode: 'server' })
 }
 
+/**
+ * @deprecated use `useHeadSafe` instead. Advanced use cases should tree shake using import.meta.* if statements.
+ */
 export function useServerHeadSafe(input: UseHeadSafeInput, options: UseHeadOptions = {}): ActiveHeadEntry<any> | void {
   return useHeadSafe(input, { ...options, mode: 'server' })
 }
 
+/**
+ * @deprecated use `useSeoMeta` instead. Advanced use cases should tree shake using import.meta.* if statements.
+ */
 export function useServerSeoMeta(input: UseSeoMetaInput, options?: UseHeadOptions): ActiveHeadEntry<any> | void {
   return useSeoMeta(input, { ...options, mode: 'server' })
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The introduction of server composables like `useServerHead`, `useServerSeoMeta`, etc. were added as a way to add head tags without effecting the client bundle.

In practice, however, these composables created confusion on which could be used and the performance benefit as well as a double up on maintenance and documentation.

- https://github.com/nuxt/nuxt/discussions/25357
- https://github.com/nuxt/nuxt/discussions/18554
- https://github.com/nuxt/nuxt/discussions/20758
- https://github.com/nuxt/nuxt/discussions/20812
- https://github.com/unjs/unhead/issues/116

When it wasn't creating confusion, it would lead to unintuitive bugs:
- https://github.com/harlan-zw/nuxt-seo/issues/389
- https://github.com/harlan-zw/nuxt-seo-utils/issues/32

One of the benefits of `useServerSeoMeta()` is that you don't need `useSeoMeta()` which is a few kbs, we can get around this by simply using the tree shaking plugin that converts it to `useHead()`

```ts
import Unhead from '@unhead/addons/vite'

// https://vite.dev/config/
export default defineConfig({
  plugins: [
    // ...
    Unhead()
  ],
})
```

Otherwise, end users are encouraged to just wrap their code in a `import.meta.server` which for seo meta will do the exact same thing.

```diff
-useServerSeoMeta({ description: 'foo' })
+if (import.meta.server) {
+  useSeoMeta({ description: 'foo' })
+}
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
