### PR TITLE
fix: delay patching until first dom render

### DIFF
--- a/packages/react/test/ReactiveTitle.test.tsx
+++ b/packages/react/test/ReactiveTitle.test.tsx
@@ -21,6 +21,8 @@ describe('unheadProvider', () => {
       getByText('Update').click()
     })
 
+    await new Promise(resolve => setTimeout(resolve, 10))
+
     expect(getByText('Updated')).toBeDefined()
     const res = await renderSSRHead(head)
     expect(res.headTags).toEqual(`<title>Updated</title>`)

--- a/packages/react/test/useSeoMeta.test.tsx
+++ b/packages/react/test/useSeoMeta.test.tsx
@@ -60,6 +60,9 @@ describe('useSeoMeta hook', () => {
     const input = getByRole('textbox') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'Updated Title' } })
 
+    // wait for second update
+    await new Promise(resolve => setTimeout(resolve, 10))
+
     const { headTags } = await renderSSRHead(head)
     expect(headTags).toContain('<title>Updated Title</title>')
   })
@@ -85,6 +88,8 @@ describe('useSeoMeta hook', () => {
         <TestComponentWithRef />
       </UnheadProvider>,
     )
+
+    await new Promise(resolve => setTimeout(resolve, 10))
 
     const { headTags } = await renderSSRHead(head)
     expect(headTags).toContain('<title>Updated Title</title>')

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -80,7 +80,7 @@ export interface ActiveHeadEntry<Input> {
    *
    * Will first clear any side effects for previous input.
    */
-  patch: (input: Input) => void
+  patch: (input: Input, force?: boolean) => void
   /**
    * Dispose the entry, removing it from the active head.
    *
@@ -91,6 +91,10 @@ export interface ActiveHeadEntry<Input> {
    * @internal
    */
   _poll: (rm?: boolean) => void
+  /**
+   * Hook side effect persisted for deduping and clean up.
+   */
+  _h?: () => void
 }
 
 export type PropResolver = (key: string, value: any, tag?: HeadTag) => any

--- a/packages/vue/test/unit/dom/classes.test.ts
+++ b/packages/vue/test/unit/dom/classes.test.ts
@@ -3,7 +3,7 @@
 import { renderDOMHead } from '@unhead/dom'
 import { useHead } from '@unhead/vue'
 import { describe, it } from 'vitest'
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useDom } from '../../../../unhead/test/fixtures'
 import { csrVueAppWithUnhead } from '../../util'
 
@@ -41,6 +41,41 @@ describe('vue dom classes', () => {
 
       </head>
       <body class="active-navbar-body"><div id="app" data-v-app=""><div>hello world</div></div></body></html>"
+    `)
+  })
+  it('toggle class', async () => {
+    const dom = useDom()
+    dom.window.document.body.className = 'loading'
+
+    const isLoaded = ref(false)
+    const head = csrVueAppWithUnhead(dom, () => {
+      useHead({
+        bodyAttrs: {
+          class: computed(() => {
+            return !isLoaded.value ? 'loading' : ''
+          }),
+        },
+      })
+      onMounted(() => {
+        isLoaded.value = true
+      })
+    })
+    await renderDOMHead(head, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<html><head>
+
+      </head>
+      <body class="loading"><div id="app" data-v-app=""><div>hello world</div></div></body></html>"
+    `)
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+    await renderDOMHead(head, { document: dom.window.document })
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<html><head>
+
+      </head>
+      <body class=""><div id="app" data-v-app=""><div>hello world</div></div></body></html>"
     `)
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

https://github.com/nuxt/nuxt/issues/26272

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We always ensure the first tag push is rendered before a patch takes place, this ensures we can remove server-side artifacts.

:warning: This may have unexpected consequences, for example it could lead to flashes from classes that aren't expected to work like this.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
