### PR TITLE
fix(schema.org): avoid appending trailing slash on `@id`'s

### DIFF
--- a/packages/schema-org/src/nodes/Article/index.test.ts
+++ b/packages/schema-org/src/nodes/Article/index.test.ts
@@ -70,7 +70,7 @@ describe('defineArticle', () => {
       expect(client).toMatchInlineSnapshot(`
         [
           {
-            "@id": "https://example.com/test/#article",
+            "@id": "https://example.com/test#article",
             "@type": "Article",
             "dateModified": "2021-11-10T10:10:10.000Z",
             "datePublished": "2021-11-10T10:10:10.000Z",
@@ -436,7 +436,7 @@ describe('defineArticle', () => {
 
       expect(client[2]).toMatchInlineSnapshot(`
         {
-          "@id": "https://kootingalpecancompany.com/pecan-tree-kootingal/#article",
+          "@id": "https://kootingalpecancompany.com/pecan-tree-kootingal#article",
           "@type": "Article",
           "articleSection": [
             "Organic pecans, activated pecans, single source, Australian organic pecans",
@@ -453,7 +453,7 @@ describe('defineArticle', () => {
           },
           "inLanguage": "en-US",
           "isPartOf": {
-            "@id": "https://kootingalpecancompany.com/pecan-tree-kootingal/#webpage",
+            "@id": "https://kootingalpecancompany.com/pecan-tree-kootingal#webpage",
           },
           "keywords": [
             "certified organic pecans",
@@ -463,7 +463,7 @@ describe('defineArticle', () => {
             "Pecan tree",
           ],
           "mainEntityOfPage": {
-            "@id": "https://kootingalpecancompany.com/pecan-tree-kootingal/#webpage",
+            "@id": "https://kootingalpecancompany.com/pecan-tree-kootingal#webpage",
           },
           "publisher": {
             "@id": "https://kootingalpecancompany.com/#identity",

--- a/packages/schema-org/src/nodes/Question/index.test.ts
+++ b/packages/schema-org/src/nodes/Question/index.test.ts
@@ -24,24 +24,24 @@ describe('defineQuestion', () => {
       expect(graphNodes).toMatchInlineSnapshot(`
         [
           {
-            "@id": "https://example.com/frequently-asked-questions/#webpage",
+            "@id": "https://example.com/frequently-asked-questions#webpage",
             "@type": [
               "WebPage",
               "FAQPage",
             ],
             "mainEntity": [
               {
-                "@id": "https://example.com/frequently-asked-questions/#/schema/question/1dbbae0",
+                "@id": "https://example.com/frequently-asked-questions#/schema/question/1dbbae0",
               },
               {
-                "@id": "https://example.com/frequently-asked-questions/#/schema/question/39eca17",
+                "@id": "https://example.com/frequently-asked-questions#/schema/question/39eca17",
               },
             ],
             "name": "FAQ",
             "url": "https://example.com/frequently-asked-questions",
           },
           {
-            "@id": "https://example.com/frequently-asked-questions/#/schema/question/1dbbae0",
+            "@id": "https://example.com/frequently-asked-questions#/schema/question/1dbbae0",
             "@type": "Question",
             "acceptedAnswer": {
               "@type": "Answer",
@@ -51,7 +51,7 @@ describe('defineQuestion', () => {
             "name": "How long is a piece of string?",
           },
           {
-            "@id": "https://example.com/frequently-asked-questions/#/schema/question/39eca17",
+            "@id": "https://example.com/frequently-asked-questions#/schema/question/39eca17",
             "@type": "Question",
             "acceptedAnswer": {
               "@type": "Answer",

--- a/packages/schema-org/src/nodes/WebPage/index.test.ts
+++ b/packages/schema-org/src/nodes/WebPage/index.test.ts
@@ -52,22 +52,22 @@ describe('defineWebPage', () => {
       expect(webPage?.name).toEqual('headline')
 
       expect(webPage).toMatchInlineSnapshot(`
-          {
-            "@id": "https://example.com/test/#webpage",
-            "@type": "WebPage",
-            "description": "description",
-            "name": "headline",
-            "potentialAction": [
-              {
-                "@type": "ReadAction",
-                "target": [
-                  "https://example.com/test",
-                ],
-              },
-            ],
-            "url": "https://example.com/test",
-          }
-        `)
+        {
+          "@id": "https://example.com/test#webpage",
+          "@type": "WebPage",
+          "description": "description",
+          "name": "headline",
+          "potentialAction": [
+            {
+              "@type": "ReadAction",
+              "target": [
+                "https://example.com/test",
+              ],
+            },
+          ],
+          "url": "https://example.com/test",
+        }
+      `)
     }, {
       path: '/test',
       title: 'headline',
@@ -155,23 +155,23 @@ describe('defineWebPage', () => {
       const webpage = await findNode<WebPage>(head, PrimaryWebPageId)
 
       expect(webpage).toMatchInlineSnapshot(`
-          {
-            "@id": "https://example.com/our-pages/about-us/#webpage",
-            "@type": [
-              "WebPage",
-              "AboutPage",
+        {
+          "@id": "https://example.com/our-pages/about-us#webpage",
+          "@type": [
+            "WebPage",
+            "AboutPage",
+          ],
+          "name": "Webpage",
+          "potentialAction": {
+            "@type": "ReadAction",
+            "target": [
+              "https://example.com/our-pages/about-us",
+              "test",
             ],
-            "name": "Webpage",
-            "potentialAction": {
-              "@type": "ReadAction",
-              "target": [
-                "https://example.com/our-pages/about-us",
-                "test",
-              ],
-            },
-            "url": "https://example.com/our-pages/about-us",
-          }
-        `)
+          },
+          "url": "https://example.com/our-pages/about-us",
+        }
+      `)
     }, {
       path: '/our-pages/about-us',
     })

--- a/packages/schema-org/src/utils/index.ts
+++ b/packages/schema-org/src/utils/index.ts
@@ -87,7 +87,7 @@ export function prefixId(url: string, id: Id | string) {
     return id as Id
   if (!id.includes('#'))
     id = `#${id}`
-  return withBase(id, url) as Id
+  return `${url || ''}${id}` as Id
 }
 
 export function trimLength(val: string | undefined, length: number) {

--- a/packages/schema-org/test/e2e/basic.test.ts
+++ b/packages/schema-org/test/e2e/basic.test.ts
@@ -103,7 +103,7 @@ describe('schema.org e2e', () => {
         "@context": "https://schema.org",
         "@graph": [
           {
-            "@id": "/about/#webpage",
+            "@id": "/about#webpage",
             "name": "About",
             "url": "/about",
             "@type": [
@@ -132,7 +132,7 @@ describe('schema.org e2e', () => {
         "@context": "https://schema.org",
         "@graph": [
           {
-            "@id": "/about/#webpage",
+            "@id": "/about#webpage",
             "name": "About",
             "url": "/about",
             "@type": [
@@ -178,18 +178,18 @@ describe('schema.org e2e', () => {
         "@context": "https://schema.org",
         "@graph": [
           {
-            "@id": "https://example.com/#identity",
+            "@id": "https://example.com#identity",
             "@type": "Organization",
             "name": "test",
             "url": "https://example.com"
           },
           {
-            "@id": "https://example.com/#website",
+            "@id": "https://example.com#website",
             "@type": "WebSite",
             "name": "test",
             "url": "https://example.com",
             "publisher": {
-              "@id": "https://example.com/#identity"
+              "@id": "https://example.com#identity"
             }
           }
         ]
@@ -229,7 +229,7 @@ describe('schema.org e2e', () => {
         "@context": "https://schema.org",
         "@graph": [
           {
-            "@id": "https://example.com/about/#webpage",
+            "@id": "https://example.com/about#webpage",
             "url": "https://example.com/about",
             "@type": [
               "WebPage",
@@ -237,15 +237,15 @@ describe('schema.org e2e', () => {
             ],
             "mainEntity": [
               {
-                "@id": "https://example.com/about/#/schema/question/ab1c398"
+                "@id": "https://example.com/about#/schema/question/ab1c398"
               },
               {
-                "@id": "https://example.com/about/#/schema/question/6396da9"
+                "@id": "https://example.com/about#/schema/question/6396da9"
               }
             ]
           },
           {
-            "@id": "https://example.com/about/#/schema/question/ab1c398",
+            "@id": "https://example.com/about#/schema/question/ab1c398",
             "@type": "Question",
             "name": "What is your return policy?",
             "acceptedAnswer": {
@@ -254,7 +254,7 @@ describe('schema.org e2e', () => {
             }
           },
           {
-            "@id": "https://example.com/about/#/schema/question/6396da9",
+            "@id": "https://example.com/about#/schema/question/6396da9",
             "@type": "Question",
             "name": "What is something else?",
             "acceptedAnswer": {

--- a/packages/schema-org/test/e2e/no-plugin.test.ts
+++ b/packages/schema-org/test/e2e/no-plugin.test.ts
@@ -92,7 +92,7 @@ describe('schema.org e2e no plugin', () => {
         "@context": "https://schema.org",
         "@graph": [
           {
-            "@id": "/about/#webpage",
+            "@id": "/about#webpage",
             "name": "About",
             "url": "/about",
             "@type": [
@@ -121,7 +121,7 @@ describe('schema.org e2e no plugin', () => {
         "@context": "https://schema.org",
         "@graph": [
           {
-            "@id": "/about/#webpage",
+            "@id": "/about#webpage",
             "name": "About",
             "url": "/about",
             "@type": [
@@ -170,18 +170,18 @@ describe('schema.org e2e no plugin', () => {
         "@context": "https://schema.org",
         "@graph": [
           {
-            "@id": "https://example.com/#identity",
+            "@id": "https://example.com#identity",
             "@type": "Organization",
             "name": "test",
             "url": "https://example.com"
           },
           {
-            "@id": "https://example.com/#website",
+            "@id": "https://example.com#website",
             "@type": "WebSite",
             "name": "test",
             "url": "https://example.com",
             "publisher": {
-              "@id": "https://example.com/#identity"
+              "@id": "https://example.com#identity"
             }
           }
         ]
@@ -222,7 +222,7 @@ describe('schema.org e2e no plugin', () => {
         "@context": "https://schema.org",
         "@graph": [
           {
-            "@id": "https://example.com/about/#webpage",
+            "@id": "https://example.com/about#webpage",
             "url": "https://example.com/about",
             "@type": [
               "WebPage",
@@ -230,15 +230,15 @@ describe('schema.org e2e no plugin', () => {
             ],
             "mainEntity": [
               {
-                "@id": "https://example.com/about/#/schema/question/ab1c398"
+                "@id": "https://example.com/about#/schema/question/ab1c398"
               },
               {
-                "@id": "https://example.com/about/#/schema/question/6396da9"
+                "@id": "https://example.com/about#/schema/question/6396da9"
               }
             ]
           },
           {
-            "@id": "https://example.com/about/#/schema/question/ab1c398",
+            "@id": "https://example.com/about#/schema/question/ab1c398",
             "@type": "Question",
             "name": "What is your return policy?",
             "acceptedAnswer": {
@@ -247,7 +247,7 @@ describe('schema.org e2e no plugin', () => {
             }
           },
           {
-            "@id": "https://example.com/about/#/schema/question/6396da9",
+            "@id": "https://example.com/about#/schema/question/6396da9",
             "@type": "Question",
             "name": "What is something else?",
             "acceptedAnswer": {

--- a/packages/schema-org/test/ssr/ids.test.ts
+++ b/packages/schema-org/test/ssr/ids.test.ts
@@ -26,7 +26,7 @@ describe('schema.org ssr ids', () => {
 
     const tags = await ssrHead.resolveTags()
     const id = JSON.parse(tags[0].innerHTML!)['@graph'][0]['@id']
-    expect(id).toMatchInlineSnapshot(`"https://example.com/#/schema/web-page/#foo"`)
+    expect(id).toMatchInlineSnapshot(`"https://example.com#/schema/web-page/#foo"`)
   })
   it('allows ids with custom domains', async () => {
     const ssrHead = createHead({
@@ -139,7 +139,7 @@ describe('schema.org ssr ids', () => {
           ],
         },
         {
-          "@id": "https://example.com/#webpage",
+          "@id": "https://example.com#webpage",
           "@type": "WebPage",
           "isPartOf": {
             "@id": "https://example.com/en#website",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
https://github.com/unjs/unhead/issues/469

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `@id` should respect the trailing slash option and not always append a slash at the end.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
