### PR TITLE
fix: ensure json strings are properly encoded

### DIFF
--- a/packages/unhead/src/utils/templateParams.ts
+++ b/packages/unhead/src/utils/templateParams.ts
@@ -19,6 +19,7 @@ function sub(p: TemplateParams, token: string, isJson = false) {
   if (val !== undefined) {
     return isJson
       ? (val || '')
+          .replace(/\\/g, '\\\\')
           .replace(/</g, '\\u003C')
           .replace(/"/g, '\\"')
       : val || ''

--- a/packages/unhead/test/unit/client/templateParams.test.ts
+++ b/packages/unhead/test/unit/client/templateParams.test.ts
@@ -132,7 +132,7 @@ describe('templateParams', () => {
     expect(await useDelayedSerializedDom()).toMatchInlineSnapshot(`
       "<!DOCTYPE html><html><head>
 
-      <title>Home &amp; //&lt;"With Encoding"&gt;\\</title><script type="application/json">{"title":"Home & //\\u003C\\"With Encoding\\">\\"}</script></head>
+      <title>Home &amp; //&lt;"With Encoding"&gt;\\</title><script type="application/json">{"title":"Home & //\\u003C\\"With Encoding\\">\\\\"}</script></head>
       <body>
 
       <div>

--- a/packages/unhead/test/unit/server/templateParams.test.ts
+++ b/packages/unhead/test/unit/server/templateParams.test.ts
@@ -116,7 +116,7 @@ describe('ssr templateParams', () => {
 
     expect(headTags).toMatchInlineSnapshot(`
       "<title>Home &amp; &#x2F;&#x2F;&lt;&quot;With Encoding&quot;&gt;\\</title>
-      <script type="application/json">{"title":"Home & //\\u003C\\"With Encoding\\">\\"}</script>"
+      <script type="application/json">{"title":"Home & //\\u003C\\"With Encoding\\">\\\\"}</script>"
     `)
   })
 


### PR DESCRIPTION
Potential fix for [https://github.com/unjs/unhead/security/code-scanning/2](https://github.com/unjs/unhead/security/code-scanning/2)

To fix the problem, we need to ensure that backslashes are also escaped in the input string. This can be done by adding a replacement for backslashes before the existing replacements for `<` and `"`. The best way to fix this without changing existing functionality is to add a `.replace(/\\/g, '\\\\')` call before the other replacements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
