### PR TITLE
fix: use a backwards-compatible alternative to `Object.hasOwn`

### DIFF
--- a/packages/unhead/src/client/renderDOMHead.ts
+++ b/packages/unhead/src/client/renderDOMHead.ts
@@ -121,7 +121,7 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
         })
       }
       for (const k in tag.props) {
-        if (!Object.hasOwn(tag.props, k))
+        if (!Object.prototype.hasOwnProperty.call(tag.props, k))
           continue
         const value = tag.props[k]
         if (k.startsWith('on') && typeof value === 'function') {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Fixes #524 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replaces `Object.hasOwn` with the more compatible `Object.prototype.hasOwnProperty.call` in client code to account for the visitors who have not managed to update their browser in [last 3 years](https://caniuse.com/mdn-javascript_builtins_object_hasown).

I found another occurrence in server code, but since this will always run in a controlled environment, the modern alternative will be preferred. https://github.com/unjs/unhead/blob/058287f99dbc8b6417e4ef3a2d87146b1f1da12e/packages/unhead/src/server/util/propsToString.ts#L9 
