### PR TITLE
fix(react): update unhead context on initial <Head> render

### DIFF
--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import type { ActiveHeadEntry, ResolvableHead as UseHeadInput } from 'unhead/types'
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { HasElementTags, TagsWithInnerContent, ValidHeadTags } from 'unhead/utils'
 import { useUnhead } from './composables'
 
@@ -8,6 +8,8 @@ interface HeadProps {
   children: ReactNode
   titleTemplate?: string
 }
+
+const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined' && typeof navigator !== 'undefined'
 
 const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
   const headRef = useRef<ActiveHeadEntry<any> | null>(null)
@@ -22,7 +24,7 @@ const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
     }
   }, [])
 
-  useEffect(() => {
+  const applyHeadChanges = useCallback(() => {
     const input: UseHeadInput = {
       titleTemplate,
     }
@@ -57,6 +59,12 @@ const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
       headRef.current.patch(input)
     }
   }, [children, titleTemplate])
+
+  useEffect(applyHeadChanges, [applyHeadChanges])
+
+  // in ssr, apply changes immediately
+  if (!isBrowser)
+    applyHeadChanges()
 
   return null
 }

--- a/packages/react/test/SimpleHeadSSR.test.tsx
+++ b/packages/react/test/SimpleHeadSSR.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { createHead, UnheadProvider } from '../src/client'
+import { renderSSRHead, transformHtmlTemplate } from '../src/server'
+import { SimpleHead } from './fixtures/SimpleHead'
+
+describe('simpleHead component in ssr', () => {
+  it('renders default head tags correctly', async () => {
+    const head = createHead()
+
+    renderToString(
+      <UnheadProvider head={head}>
+        <SimpleHead />
+      </UnheadProvider>,
+    )
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).toMatchInlineSnapshot(`
+        "<meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Default Title 2</title>
+        <script async src="https://example.com/async-script.js"></script>
+        <script noModule src="https://example.com/nomodule.js"></script>
+        <link rel="stylesheet" href="default-styles.css">
+        <style>body { background-color: #f0f0f0; }</style>
+        <link rel="preload" href="https://example.com/font.woff2" as="font" type="font/woff2">
+        <script defer src="https://example.com/defer-script.js"></script>
+        <link rel="dns-prefetch" href="//example.com">
+        <link rel="prefetch" href="https://example.com/next-page">
+        <link rel="prerender" href="https://example.com/next-page">
+        <meta name="description" content="Default Description">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+        <link rel="icon" href="favicon.ico">
+        <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Example","url":"https://www.example.com"}</script>
+        <script type="module" src="https://example.com/module.js"></script>"
+      `)
+  })
+  it('renders head tags correctly with SSR', async () => {
+    const head = createHead()
+    const html = renderToString(
+      <html>
+        <head></head>
+        <body>
+          <UnheadProvider head={head}>
+            <SimpleHead />
+          </UnheadProvider>
+        </body>
+      </html>,
+    )
+
+    const transformed = await transformHtmlTemplate(head, html)
+
+    const headContent = transformed.match(/<head>(.*?)<\/head>/s)?.[1] || ''
+    expect(headContent).toMatchInlineSnapshot(`
+      "<meta name="viewport" content="width=device-width, initial-scale=1">
+      <title>Default Title 2</title>
+      <script async src="https://example.com/async-script.js"></script>
+      <script noModule src="https://example.com/nomodule.js"></script>
+      <link rel="stylesheet" href="default-styles.css">
+      <style>body { background-color: #f0f0f0; }</style>
+      <link rel="preload" href="https://example.com/font.woff2" as="font" type="font/woff2">
+      <script defer src="https://example.com/defer-script.js"></script>
+      <link rel="dns-prefetch" href="//example.com">
+      <link rel="prefetch" href="https://example.com/next-page">
+      <link rel="prerender" href="https://example.com/next-page">
+      <meta name="description" content="Default Description">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+      <link rel="icon" href="favicon.ico">
+      <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Example","url":"https://www.example.com"}</script>
+      <script type="module" src="https://example.com/module.js"></script>"`)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #532

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

During `<Head>` component rendering, `applyHeadChanges ` was conditionally called based on the `isBrowser` flag. Instead, we now leverage the initial value of `useRef` to apply changes to the Unhead context and update it later using useEffect. This approach improves SSR compatibility without relying on environment-specific variables (e.g. `isBrowser`) and ensures `useHead`/`<Head>` calls execute in the correct order. 

The previous implementation (relying on `isBrowser`) did not respect the `useHead`/`<Head>` execution order.

