### PR TITLE
fix(vue): use `setTimeout` as render's debounced delayer

### DIFF
--- a/packages/vue/src/client.ts
+++ b/packages/vue/src/client.ts
@@ -9,7 +9,7 @@ export { renderDOMHead } from 'unhead/client'
 export function createHead(options: CreateClientHeadOptions = {}): VueHeadClient {
   const head = _createHead({
     domOptions: {
-      render: createDebouncedFn(() => renderDOMHead(head), setTimeout),
+      render: createDebouncedFn(() => renderDOMHead(head), fn => setTimeout(fn, 0)),
     },
     ...options,
   }) as VueHeadClient

--- a/packages/vue/src/client.ts
+++ b/packages/vue/src/client.ts
@@ -1,7 +1,6 @@
 import type { CreateClientHeadOptions } from 'unhead/types'
 import type { VueHeadClient } from './types'
 import { createHead as _createHead, createDebouncedFn, renderDOMHead } from 'unhead/client'
-import { nextTick } from 'vue'
 import { vueInstall } from './install'
 
 export { VueHeadMixin } from './VueHeadMixin'
@@ -10,7 +9,7 @@ export { renderDOMHead } from 'unhead/client'
 export function createHead(options: CreateClientHeadOptions = {}): VueHeadClient {
   const head = _createHead({
     domOptions: {
-      render: createDebouncedFn(() => renderDOMHead(head), nextTick),
+      render: createDebouncedFn(() => renderDOMHead(head), setTimeout),
     },
     ...options,
   }) as VueHeadClient


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Resolves #538

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Use `setTimeout` to debounce the `render` function.
