### PR TITLE
perf(unhead): normalize canonicalHost only once in canonical plugin

### DIFF
--- a/packages/unhead/src/plugins/canonical.ts
+++ b/packages/unhead/src/plugins/canonical.ts
@@ -24,19 +24,21 @@ export interface CanonicalPluginOptions {
  */
 export function CanonicalPlugin(options: CanonicalPluginOptions): ((head: Unhead) => HeadPluginOptions & { key: string }) {
   return (head) => {
+    let host = options.canonicalHost || (!head.ssr ? (window.location.origin) : '')
+    // handle https if not provided
+    if (!host.startsWith('http') && !host.startsWith('//')) {
+      host = `https://${host}`
+    }
+    // have error thrown if canonicalHost is not a valid URL
+    host = new URL(host).origin
+
     function resolvePath(path: string) {
       if (options?.customResolver) {
         return options.customResolver(path)
       }
-      let host = options.canonicalHost || (!head.ssr ? (window.location.origin) : '')
-      // handle https if not provided
-      if (!host.startsWith('http') && !host.startsWith('//')) {
-        host = `https://${host}`
-      }
-      // have error thrown if canonicalHost is not a valid URL
-      host = new URL(host).origin
       if (path.startsWith('http') || path.startsWith('//'))
         return path
+
       try {
         return new URL(path, host).toString()
       }


### PR DESCRIPTION
### 🔗 Linked issue

...

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A slight performance improvement, since we only need to check `canonicalHost` once because:

* `options.canonicalHost` is not dynamic
* website doesn't change its URL without a full reload 🤷‍♀️
