### PR TITLE
Canonical plugin : fix #564

### DIFF
--- a/packages/unhead/src/plugins/canonical.ts
+++ b/packages/unhead/src/plugins/canonical.ts
@@ -5,6 +5,17 @@ export interface CanonicalPluginOptions {
   customResolver?: (url: string) => string
 }
 
+const META_TRANSFORMABLE_URL = [
+  "og:url",
+  "og:image",
+  "og:image:secure_url",
+  "twitter:image",
+  "twitter:image:src",
+  "og:video",
+  "og:video:secure_url",
+  "og:see_also",
+];
+
 /**
  * CanonicalPlugin resolves paths in tags that require a canonical host to be set.
  *
@@ -51,13 +62,8 @@ export function CanonicalPlugin(options: CanonicalPluginOptions): ((head: Unhead
       hooks: {
         'tags:resolve': (ctx) => {
           for (const tag of ctx.tags) {
-            if (tag.tag === 'meta') {
-              if (tag.props.property?.startsWith('og:image') || tag.props.name?.startsWith('twitter:image')) {
-                tag.props.content = resolvePath(tag.props.content)
-              }
-              else if (tag.props?.property === 'og:url') {
-                tag.props.content = resolvePath(tag.props.content)
-              }
+            if (tag.tag === 'meta' && META_TRANSFORMABLE_URL.includes(tag.props?.property)) {
+              tag.props.content = resolvePath(tag.props.content)
             }
             else if (tag.tag === 'link' && tag.props.rel === 'canonical') {
               tag.props.href = resolvePath(tag.props.href)


### PR DESCRIPTION

### 🔗 Linked issue

fix #564

### ❓ Type of change

Bug fix


### 📚 Description

The canonical plugin should only transform properties that expect an URL.
I've added a list of such properties.