### PR TITLE
fix: parse multiword attributes in template

### DIFF
--- a/packages/unhead/src/server/util/extractUnheadInputFromHtml.ts
+++ b/packages/unhead/src/server/util/extractUnheadInputFromHtml.ts
@@ -1,6 +1,6 @@
 import type { SerializableHead } from '../../types'
 
-const Attrs = /(\w+)(?:=["']([^"']*)["'])?/g
+const Attrs = /(\w+-?\w+)(?:=["']([^"']*)["'])?/g
 const HtmlTag = /<html[^>]*>/
 const BodyTag = /<body[^>]*>/
 const HeadContent = /<head[^>]*>(.*?)<\/head>/s

--- a/packages/unhead/test/unit/server/ssr.test.ts
+++ b/packages/unhead/test/unit/server/ssr.test.ts
@@ -132,6 +132,31 @@ describe('ssr', () => {
   `)
   })
 
+  it('multiword attributes in html template', async () => {
+    const head = createServerHeadWithContext()
+
+    expect(await transformHtmlTemplate(head, `
+      <html>
+      <head>
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      </head>
+      <body>
+      <!--app-html-->
+      </body>
+      </html>
+      `)).toMatchInlineSnapshot(`
+        "
+        <html>
+        <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"></head>
+        <body>
+        <!--app-html-->
+        </body>
+        </html>
+        "
+      `)
+  })
+
   it('useSeoMeta', async () => {
     const head = createServerHeadWithContext()
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue(https://github.com/unjs/unhead/issues/567)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Changes regex to properly handle multiword attributes in html templates for ssd
