### PR TITLE
fix(schema-org): stripEmptyProperties early returns 

### DIFF
--- a/packages/schema-org/src/utils/index.ts
+++ b/packages/schema-org/src/utils/index.ts
@@ -130,18 +130,26 @@ export function resolveAsGraphKey(key?: Id | string) {
  */
 export function stripEmptyProperties(obj: any) {
   for (const k in obj) {
-    if (!Object.prototype.hasOwnProperty.call(obj, k)) {
+    if (!Object.hasOwn(obj, k))
       continue
-    }
 
-    if (obj[k] && typeof obj[k] === 'object') {
-      // avoid walking vue reactivity
-      if (obj[k].__v_isReadonly || obj[k].__v_isRef)
-        continue
-      stripEmptyProperties(obj[k])
+    const value = obj[k]
+
+    // Skip Vue reactivity objects
+    if (value?.__v_isReadonly || value?.__v_isRef)
+      continue
+
+    // Recursively clean nested objects/arrays
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      stripEmptyProperties(value)
+      // Remove if object is now empty after cleaning
+      if (Object.keys(value).length === 0)
+        delete obj[k]
     }
-    if (obj[k] === '' || obj[k] === null || obj[k] === undefined)
+    // Remove empty values
+    else if (value === '' || value == null) {
       delete obj[k]
+    }
   }
 
   return obj


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed two issues in stripEmptyProperties function:
1. Removed early return after recursive call (line 142) that prevented processing of sibling properties
2. Changed Vue reactivity check return to continue (line 140) to allow sibling properties to be processed

This ensures all properties in an object are properly checked and stripped, not just the first object property encountered.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
