### PR TITLE
feat: `useHead()` type narrowing

### DIFF
--- a/packages/unhead/src/parser/index.ts
+++ b/packages/unhead/src/parser/index.ts
@@ -535,13 +535,13 @@ export function parseHtmlForUnheadExtraction(html: string): PreparedHtmlTemplate
         continue
       }
       else if (tagId === TAG_META) {
-        ;(input.meta ||= []).push(attributes)
+        ;(input.meta ||= []).push(attributes as any)
         position = tagEnd
         lastCopyPosition = position
         continue
       }
       else if (tagId === TAG_LINK) {
-        ;(input.link ||= []).push(attributes)
+        ;(input.link ||= []).push(attributes as any)
         position = tagEnd
         lastCopyPosition = position
         continue

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -1,16 +1,15 @@
 import type { HeadSafe } from '../types/safeSchema'
-import type { RawInput } from '../types/schema'
 import type { HeadTag } from '../types/tags'
 import { defineHeadPlugin } from './defineHeadPlugin'
 
 const WhitelistAttributes = {
-  htmlAttrs: new Set(['class', 'style', 'lang', 'dir'] satisfies (keyof RawInput<'htmlAttrs'>)[]),
-  bodyAttrs: new Set(['class', 'style'] satisfies (keyof RawInput<'bodyAttrs'>)[]),
-  meta: new Set(['name', 'property', 'charset', 'content', 'media'] satisfies (keyof RawInput<'meta'>)[]),
-  noscript: new Set(['textContent'] satisfies (Partial<keyof RawInput<'noscript'>> | 'textContent')[]),
-  style: new Set(['media', 'textContent', 'nonce', 'title', 'blocking'] satisfies (Partial<keyof RawInput<'style'>> | 'textContent')[]),
-  script: new Set(['type', 'textContent', 'nonce', 'blocking'] satisfies (Partial<keyof RawInput<'script'>> | 'textContent')[]),
-  link: new Set(['color', 'crossorigin', 'fetchpriority', 'href', 'hreflang', 'imagesrcset', 'imagesizes', 'integrity', 'media', 'referrerpolicy', 'rel', 'sizes', 'type'] satisfies (keyof RawInput<'link'>)[]),
+  htmlAttrs: new Set(['class', 'style', 'lang', 'dir']),
+  bodyAttrs: new Set(['class', 'style']),
+  meta: new Set(['name', 'property', 'charset', 'content', 'media']),
+  noscript: new Set(['textContent']),
+  style: new Set(['media', 'textContent', 'nonce', 'title', 'blocking']),
+  script: new Set(['type', 'textContent', 'nonce', 'blocking']),
+  link: new Set(['color', 'crossorigin', 'fetchpriority', 'href', 'hreflang', 'imagesrcset', 'imagesizes', 'integrity', 'media', 'referrerpolicy', 'rel', 'sizes', 'type']),
 } as const
 
 function acceptDataAttrs(value: Record<string, string>) {

--- a/packages/unhead/src/types/safeSchema.ts
+++ b/packages/unhead/src/types/safeSchema.ts
@@ -1,22 +1,22 @@
 import type {
   DataKeys,
-  LinkWithoutEvents,
+  GenericLink,
+  GenericScript,
+  MetaGeneric,
   Noscript,
   ResolvableHead,
   SchemaAugmentations,
-  ScriptWithoutEvents,
   Style,
   UnheadBodyAttributesWithoutEvents,
   UnheadHtmlAttributes,
-  UnheadMeta,
 } from './schema'
 import type { ResolvableProperties, ResolvableValue } from './util'
 
 export type SafeBodyAttr = ResolvableProperties<Pick<UnheadBodyAttributesWithoutEvents, 'id' | 'class' | 'style'> & DataKeys & SchemaAugmentations['bodyAttrs']>
 export type SafeHtmlAttr = ResolvableProperties<Pick<UnheadHtmlAttributes, 'id' | 'class' | 'style' | 'lang' | 'dir'> & DataKeys & SchemaAugmentations['htmlAttrs']>
-export type SafeMeta = ResolvableProperties<Pick<UnheadMeta, 'id' | 'name' | 'property' | 'charset' | 'content' | 'media'> & DataKeys & SchemaAugmentations['meta']>
-export type SafeLink = ResolvableProperties<Pick<LinkWithoutEvents, 'id' | 'color' | 'crossorigin' | 'fetchpriority' | 'href' | 'hreflang' | 'imagesrcset' | 'imagesizes' | 'integrity' | 'media' | 'referrerpolicy' | 'rel' | 'sizes' | 'type'> & DataKeys & SchemaAugmentations['link']>
-export type SafeScript = ResolvableProperties<Pick<ScriptWithoutEvents, 'id' | 'type' | 'nonce' | 'blocking'> & DataKeys & SchemaAugmentations['script']>
+export type SafeMeta = ResolvableProperties<Pick<MetaGeneric, 'id' | 'name' | 'property' | 'charset' | 'content' | 'media'> & DataKeys & SchemaAugmentations['meta']>
+export type SafeLink = ResolvableProperties<Pick<GenericLink, 'id' | 'color' | 'crossorigin' | 'fetchpriority' | 'href' | 'hreflang' | 'imagesrcset' | 'imagesizes' | 'integrity' | 'media' | 'referrerpolicy' | 'rel' | 'sizes' | 'type'> & DataKeys & SchemaAugmentations['link']>
+export type SafeScript = ResolvableProperties<Pick<GenericScript, 'id' | 'type' | 'nonce' | 'blocking'> & DataKeys & SchemaAugmentations['script']>
 export type SafeNoscript = ResolvableProperties<Pick<Noscript, 'id'> & DataKeys & Omit<SchemaAugmentations['noscript'], 'innerHTML'>>
 export type SafeStyle = ResolvableProperties<Pick<Style, 'id' | 'media' | 'nonce' | 'title' | 'blocking'> & DataKeys & Omit<SchemaAugmentations['style'], 'innerHTML'>>
 

--- a/packages/unhead/src/types/schema/head.ts
+++ b/packages/unhead/src/types/schema/head.ts
@@ -1,16 +1,69 @@
 import type { InnerContent, ProcessesTemplateParams, ResolvesDuplicates, TagPosition, TagPriority } from '../tags'
 import type { DeepResolvableProperties, ResolvableProperties, ResolvableValue, Stringable } from '../util'
-import type { DataKeys } from './attributes/data'
-import type { HttpEventAttributes } from './attributes/event'
 import type { Base } from './base'
 import type { BodyAttributesWithoutEvents, BodyEvents } from './bodyAttributes'
 import type { HtmlAttributes } from './htmlAttributes'
-import type { LinkWithoutEvents } from './link'
-import type { Meta } from './meta'
+import type {
+  Link,
+  GenericLink,
+  LinkHttpEvents,
+  // Narrowed link types for re-export
+  StylesheetLink,
+  PreloadLink,
+  PreloadImageLink,
+  PreloadFontLink,
+  PreloadScriptLink,
+  PreloadStyleLink,
+  PreloadOtherLink,
+  ModulepreloadLink,
+  PrefetchLink,
+  IconLink,
+  ManifestLink,
+  CanonicalLink,
+  DnsPrefetchLink,
+  PreconnectLink,
+  PrerenderLink,
+  AlternateLink,
+  AuthorLink,
+  LicenseLink,
+  HelpLink,
+  SearchLink,
+  PrevLink,
+  NextLink,
+  PingbackLink,
+  LinkBase,
+  PreloadLinkBase,
+} from './link'
+import type {
+  Meta,
+  NameMeta,
+  PropertyMeta,
+  HttpEquivMeta,
+  CharsetMeta,
+  MetaBase,
+  MetaNames,
+  MetaProperties,
+} from './meta'
 import type { MetaFlat } from './metaFlat'
 import type { Noscript } from './noscript'
-import type { ScriptWithoutEvents } from './script'
+import type {
+  Script,
+  GenericScript,
+  ScriptHttpEvents,
+  // Narrowed script types for re-export
+  ExternalScript,
+  ModuleScript,
+  InlineScript,
+  InlineModuleScript,
+  JsonLdScript,
+  SpeculationRulesScript,
+  ImportMapScript,
+  ApplicationJsonScript,
+  ScriptBase,
+  ImportMapConfig,
+} from './script'
 import type { Style } from './style'
+import type { DataKeys } from './attributes/data'
 
 export interface SchemaAugmentations {
   title: TagPriority
@@ -57,16 +110,14 @@ export interface UnheadHtmlAttributes extends Omit<HtmlAttributes, 'class' | 'st
   style?: MaybeArray<ResolvableValue<Stringable>> | Record<string, ResolvableValue<Stringable>>
 }
 
-export interface UnheadMeta extends Omit<Meta, 'content'> {
-  /**
-   * This attribute contains the value for the http-equiv, name or property attribute, depending on which is used.
-   *
-   * You can provide an array of values to create multiple tags sharing the same name, property or http-equiv.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content
-   */
-  content?: MaybeArray<Stringable> | null
-}
+/**
+ * Unhead meta with support for array content values
+ */
+export type UnheadMeta =
+  | (Omit<NameMeta, 'content'> & { content?: MaybeArray<Stringable> | null })
+  | (Omit<PropertyMeta, 'content'> & { content?: MaybeArray<Stringable> | null })
+  | (Omit<HttpEquivMeta, 'content'> & { content?: MaybeArray<Stringable> | null })
+  | CharsetMeta
 
 export type MaybeEventFnHandlers<T> = {
   [key in keyof T]?: T[key] | ((e: Event) => void)
@@ -75,10 +126,10 @@ export type MaybeEventFnHandlers<T> = {
 export type ResolvableTitle = ResolvableValue<Stringable> | ResolvableProperties<({ textContent: string } & SchemaAugmentations['title'])>
 export type ResolvableTitleTemplate = string | ((title?: string) => string | null) | null | ({ textContent: string | ((title?: string) => string | null) } & SchemaAugmentations['titleTemplate'])
 export type ResolvableBase = ResolvableProperties<Base & SchemaAugmentations['base']>
-export type ResolvableLink = ResolvableProperties<LinkWithoutEvents & DataKeys & SchemaAugmentations['link']> & MaybeEventFnHandlers<HttpEventAttributes>
-export type ResolvableMeta = ResolvableProperties<UnheadMeta & DataKeys & SchemaAugmentations['meta']>
+export type ResolvableLink = ResolvableProperties<Link & SchemaAugmentations['link']> & MaybeEventFnHandlers<LinkHttpEvents>
+export type ResolvableMeta = ResolvableProperties<UnheadMeta & SchemaAugmentations['meta']>
 export type ResolvableStyle = ResolvableProperties<Style & DataKeys & SchemaAugmentations['style']> | string
-export type ResolvableScript = ResolvableProperties<ScriptWithoutEvents & DataKeys & SchemaAugmentations['script']> & MaybeEventFnHandlers<HttpEventAttributes> | string
+export type ResolvableScript = ResolvableProperties<Script & SchemaAugmentations['script']> & MaybeEventFnHandlers<ScriptHttpEvents> | string
 export type ResolvableNoscript = ResolvableProperties<Noscript & DataKeys & SchemaAugmentations['noscript']> | string
 export type ResolvableHtmlAttributes = ResolvableProperties<UnheadHtmlAttributes & DataKeys & SchemaAugmentations['htmlAttrs']>
 export type ResolvableBodyAttributes = ResolvableProperties<UnheadBodyAttributesWithoutEvents & DataKeys & SchemaAugmentations['bodyAttrs']> & MaybeEventFnHandlers<BodyEvents>
@@ -162,10 +213,10 @@ export interface SerializableHead {
   titleTemplate?: string
   base?: Base & DataKeys & SchemaAugmentations['base']
   templateParams?: Record<string, any>
-  link?: (LinkWithoutEvents & DataKeys & HttpEventAttributes & SchemaAugmentations['link'])[]
-  meta?: (Meta & DataKeys & SchemaAugmentations['meta'])[]
+  link?: (Link & SchemaAugmentations['link'])[]
+  meta?: (Meta & SchemaAugmentations['meta'])[]
   style?: (Style & DataKeys & SchemaAugmentations['style'])[]
-  script?: (ScriptWithoutEvents & DataKeys & HttpEventAttributes & SchemaAugmentations['script'])[]
+  script?: (Script & SchemaAugmentations['script'])[]
   noscript?: (Noscript & DataKeys & SchemaAugmentations['noscript'])[]
   htmlAttrs?: HtmlAttributes & DataKeys & SchemaAugmentations['htmlAttrs']
   bodyAttrs?: BodyAttributesWithoutEvents & DataKeys & BodyEvents & SchemaAugmentations['bodyAttrs']
@@ -177,12 +228,102 @@ export type UseSeoMetaInput = DeepResolvableProperties<MetaFlat> & { title?: Res
 
 export type UseHeadInput = ResolvableHead | SerializableHead
 
+// ============================================================================
+// Re-exports
+// ============================================================================
+
+// Attribute types
 export type { AriaAttributes } from './attributes/aria'
 export type { DataKeys } from './attributes/data'
 export type { HttpEventAttributes } from './attributes/event'
 export type { GlobalAttributes } from './attributes/global'
+
+// Body/HTML attributes
 export type { BodyAttributesWithoutEvents, BodyEvents } from './bodyAttributes'
-export type { LinkWithoutEvents } from './link'
+
+// Link types (narrowed)
+export type {
+  Link,
+  LinkBase,
+  LinkHttpEvents,
+  StylesheetLink,
+  PreloadLink,
+  PreloadLinkBase,
+  PreloadImageLink,
+  PreloadFontLink,
+  PreloadScriptLink,
+  PreloadStyleLink,
+  PreloadOtherLink,
+  ModulepreloadLink,
+  PrefetchLink,
+  IconLink,
+  ManifestLink,
+  CanonicalLink,
+  DnsPrefetchLink,
+  PreconnectLink,
+  PrerenderLink,
+  AlternateLink,
+  AuthorLink,
+  LicenseLink,
+  HelpLink,
+  SearchLink,
+  PrevLink,
+  NextLink,
+  PingbackLink,
+  GenericLink,
+}
+
+// Script types (narrowed)
+export type {
+  Script,
+  ScriptBase,
+  ScriptHttpEvents,
+  ExternalScript,
+  ModuleScript,
+  InlineScript,
+  InlineModuleScript,
+  JsonLdScript,
+  SpeculationRulesScript,
+  ImportMapScript,
+  ImportMapConfig,
+  ApplicationJsonScript,
+  GenericScript,
+}
+
+// Meta types (narrowed)
+export type {
+  Meta,
+  MetaBase,
+  MetaNames,
+  MetaProperties,
+  NameMeta,
+  PropertyMeta,
+  HttpEquivMeta,
+  CharsetMeta,
+}
+
+// Other types
 export type { MetaFlat } from './metaFlat'
-export type { ScriptWithoutEvents } from './script'
 export type { SpeculationRules } from './struct/speculationRules'
+
+// Legacy exports for backwards compatibility
+export type { GenericLink as LinkWithoutEvents } from './link'
+export type { GenericScript as ScriptWithoutEvents } from './script'
+
+// ============================================================================
+// Utility Types for Internal Use
+// ============================================================================
+// These types provide access to all possible properties across union members,
+// which is needed for internal code that dynamically creates/validates tags.
+
+/**
+ * Flat meta type with all properties optional (for internal use)
+ * @internal
+ */
+export interface MetaGeneric extends MetaBase {
+  name?: MetaNames | (string & Record<never, never>)
+  property?: MetaProperties | (string & Record<never, never>)
+  'http-equiv'?: 'content-security-policy' | 'content-type' | 'default-style' | 'x-ua-compatible' | 'refresh' | 'accept-ch' | (string & Record<never, never>)
+  charset?: 'utf-8' | (string & Record<never, never>)
+  content?: Stringable
+}

--- a/packages/unhead/src/types/schema/index.ts
+++ b/packages/unhead/src/types/schema/index.ts
@@ -6,7 +6,7 @@ export type Base = RawInput<'base'>
 export type HtmlAttributes = RawInput<'htmlAttrs'>
 export type Noscript = RawInput<'noscript'>
 export type Style = RawInput<'style'>
-export type Meta = RawInput<'meta'>
-export type Script = RawInput<'script'>
-export type Link = RawInput<'link'>
 export type BodyAttributes = RawInput<'bodyAttrs'>
+
+// Note: Meta, Script, and Link are now discriminated unions exported from head.ts
+// They include: Link, Script, Meta and all their narrowed variants

--- a/packages/unhead/src/types/schema/link.ts
+++ b/packages/unhead/src/types/schema/link.ts
@@ -2,6 +2,536 @@ import type { HttpEventAttributes } from './attributes/event'
 import type { GlobalAttributes } from './attributes/global'
 import type { ReferrerPolicy } from './shared'
 import type { Blocking } from './struct/blocking'
+import type { DataKeys } from './attributes/data'
+
+// ============================================================================
+// Link Type Narrowing
+// ============================================================================
+// This implements discriminated unions for link types based on the `rel` attribute.
+// Each link type only exposes properties relevant to that specific type.
+
+/**
+ * Events that fire on link elements (load/error)
+ */
+export type LinkHttpEvents = Pick<HttpEventAttributes, 'onload' | 'onerror'>
+
+/**
+ * Base properties shared by all link types
+ */
+export interface LinkBase extends Pick<GlobalAttributes, 'nonce' | 'id'>, Blocking, DataKeys {
+  /**
+   * Provides a hint of the relative priority to use when fetching a preloaded resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-fetchpriority
+   */
+  fetchpriority?: 'high' | 'low' | 'auto'
+  /**
+   * A string indicating which referrer to use when fetching the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-referrerpolicy
+   */
+  referrerpolicy?: ReferrerPolicy
+}
+
+// ============================================================================
+// Stylesheet Link
+// ============================================================================
+
+/**
+ * Stylesheet-specific link (fires events)
+ */
+export interface StylesheetLink extends LinkBase, LinkHttpEvents {
+  rel: 'stylesheet'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+  /**
+   * This attribute specifies the media that the linked resource applies to.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-media
+   */
+  media?: string
+  /**
+   * Contains inline metadata — a base64-encoded cryptographic hash of the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-integrity
+   */
+  integrity?: string
+  /**
+   * This enumerated attribute indicates whether CORS must be used when fetching the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
+   */
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+  /**
+   * The title attribute has special semantics on the `<link>` element.
+   * When used on a `<link rel="stylesheet">` it defines a default or an alternate stylesheet.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-title
+   */
+  title?: string
+  /**
+   * Whether the stylesheet is disabled.
+   */
+  disabled?: boolean
+}
+
+// ============================================================================
+// Preload Links - Narrowed by `as` value
+// ============================================================================
+
+/**
+ * Base for preload links (fires events)
+ */
+export interface PreloadLinkBase extends LinkBase, LinkHttpEvents {
+  rel: 'preload'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+  /**
+   * This enumerated attribute indicates whether CORS must be used when fetching the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
+   */
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+  /**
+   * Contains inline metadata — a base64-encoded cryptographic hash of the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-integrity
+   */
+  integrity?: string
+  /**
+   * This attribute specifies the media that the linked resource applies to.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-media
+   */
+  media?: string
+}
+
+/**
+ * Preload: image (has imagesrcset/imagesizes)
+ */
+export interface PreloadImageLink extends PreloadLinkBase {
+  as: 'image'
+  type?: 'image/webp' | 'image/avif' | 'image/png' | 'image/jpeg' | 'image/gif' | 'image/svg+xml' | (string & Record<never, never>)
+  /**
+   * For rel="preload" and as="image" only, the imagesizes attribute indicates
+   * to preload the appropriate resource used by an img element.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-imagesizes
+   */
+  imagesizes?: string
+  /**
+   * For rel="preload" and as="image" only, the imagesrcset attribute indicates
+   * to preload the appropriate resource used by an img element.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-imagesrcset
+   */
+  imagesrcset?: string
+}
+
+/**
+ * Preload: font
+ */
+export interface PreloadFontLink extends PreloadLinkBase {
+  as: 'font'
+  type?: 'font/woff2' | 'font/woff' | 'font/ttf' | 'font/otf' | (string & Record<never, never>)
+  /**
+   * For fonts, crossorigin is required for CORS.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
+   */
+  crossorigin: '' | 'anonymous' | 'use-credentials'
+}
+
+/**
+ * Preload: script
+ */
+export interface PreloadScriptLink extends PreloadLinkBase {
+  as: 'script'
+  type?: 'text/javascript' | 'module' | (string & Record<never, never>)
+}
+
+/**
+ * Preload: style
+ */
+export interface PreloadStyleLink extends PreloadLinkBase {
+  as: 'style'
+  type?: 'text/css' | (string & Record<never, never>)
+}
+
+/**
+ * Preload: other types
+ */
+export interface PreloadOtherLink extends PreloadLinkBase {
+  as: 'audio' | 'document' | 'embed' | 'fetch' | 'object' | 'track' | 'video' | 'worker'
+  type?: string
+}
+
+/**
+ * Combined preload union
+ */
+export type PreloadLink =
+  | PreloadImageLink
+  | PreloadFontLink
+  | PreloadScriptLink
+  | PreloadStyleLink
+  | PreloadOtherLink
+
+// ============================================================================
+// Modulepreload Link
+// ============================================================================
+
+/**
+ * Modulepreload-specific link (fires events)
+ */
+export interface ModulepreloadLink extends LinkBase, LinkHttpEvents {
+  rel: 'modulepreload'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+  /**
+   * Contains inline metadata — a base64-encoded cryptographic hash of the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-integrity
+   */
+  integrity?: string
+  /**
+   * This enumerated attribute indicates whether CORS must be used when fetching the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
+   */
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+}
+
+// ============================================================================
+// Prefetch Link
+// ============================================================================
+
+/**
+ * Prefetch-specific link
+ */
+export interface PrefetchLink extends LinkBase {
+  rel: 'prefetch'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+  /**
+   * This attribute is used when rel="prefetch" to specify the type of content being loaded.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-as
+   */
+  as?: 'audio' | 'document' | 'embed' | 'fetch' | 'font' | 'image' | 'object' | 'script' | 'style' | 'track' | 'video' | 'worker'
+  /**
+   * This enumerated attribute indicates whether CORS must be used when fetching the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
+   */
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+}
+
+// ============================================================================
+// Icon Links
+// ============================================================================
+
+/**
+ * Icon-specific link
+ */
+export interface IconLink extends LinkBase {
+  rel: 'icon' | 'apple-touch-icon' | 'shortcut icon'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+  /**
+   * This attribute defines the sizes of the icons for visual media contained in the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-sizes
+   */
+  sizes?: 'any' | '16x16' | '32x32' | '48x48' | '64x64' | '96x96' | '128x128' | '180x180' | '192x192' | '512x512' | (string & Record<never, never>)
+  /**
+   * This attribute is used to define the type of the content linked to.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-type
+   */
+  type?: 'image/png' | 'image/svg+xml' | 'image/x-icon' | 'image/gif' | 'image/webp' | (string & Record<never, never>)
+  /**
+   * The color attribute is used with the mask-icon link type.
+   *
+   * @see https://html.spec.whatwg.org/multipage/semantics.html#attr-link-color
+   */
+  color?: string
+}
+
+// ============================================================================
+// Manifest Link
+// ============================================================================
+
+/**
+ * Manifest link
+ */
+export interface ManifestLink extends LinkBase {
+  rel: 'manifest'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+  /**
+   * This enumerated attribute indicates whether CORS must be used when fetching the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
+   */
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+}
+
+// ============================================================================
+// Canonical Link
+// ============================================================================
+
+/**
+ * Canonical link
+ */
+export interface CanonicalLink extends LinkBase {
+  rel: 'canonical'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+}
+
+// ============================================================================
+// DNS-Prefetch Link
+// ============================================================================
+
+/**
+ * DNS-prefetch link (no events, minimal props)
+ */
+export interface DnsPrefetchLink extends LinkBase {
+  rel: 'dns-prefetch'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+}
+
+// ============================================================================
+// Preconnect Link
+// ============================================================================
+
+/**
+ * Preconnect link (no events)
+ */
+export interface PreconnectLink extends LinkBase {
+  rel: 'preconnect'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+  /**
+   * This enumerated attribute indicates whether CORS must be used when fetching the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
+   */
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+}
+
+// ============================================================================
+// Prerender Link
+// ============================================================================
+
+/**
+ * Prerender link
+ */
+export interface PrerenderLink extends LinkBase {
+  rel: 'prerender'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+}
+
+// ============================================================================
+// Alternate Link
+// ============================================================================
+
+/**
+ * Alternate link (RSS, translations, etc.)
+ */
+export interface AlternateLink extends LinkBase {
+  rel: 'alternate'
+  /**
+   * This attribute specifies the URL of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
+   */
+  href: string
+  /**
+   * This attribute is used to define the type of the content linked to.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-type
+   */
+  type?: 'application/rss+xml' | 'application/atom+xml' | 'application/json' | (string & Record<never, never>)
+  /**
+   * This attribute indicates the language of the linked resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-hreflang
+   */
+  hreflang?: string
+  /**
+   * The title attribute defines the title of the link.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-title
+   */
+  title?: string
+  /**
+   * This attribute specifies the media that the linked resource applies to.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-media
+   */
+  media?: string
+}
+
+// ============================================================================
+// Other Standard Links
+// ============================================================================
+
+/**
+ * Author link
+ */
+export interface AuthorLink extends LinkBase {
+  rel: 'author'
+  href: string
+}
+
+/**
+ * License link
+ */
+export interface LicenseLink extends LinkBase {
+  rel: 'license'
+  href: string
+}
+
+/**
+ * Help link
+ */
+export interface HelpLink extends LinkBase {
+  rel: 'help'
+  href: string
+}
+
+/**
+ * Search link
+ */
+export interface SearchLink extends LinkBase {
+  rel: 'search'
+  href: string
+  type?: 'application/opensearchdescription+xml' | (string & Record<never, never>)
+  title?: string
+}
+
+/**
+ * Prev/Next navigation links
+ */
+export interface PrevLink extends LinkBase {
+  rel: 'prev'
+  href: string
+}
+
+export interface NextLink extends LinkBase {
+  rel: 'next'
+  href: string
+}
+
+/**
+ * Pingback link
+ */
+export interface PingbackLink extends LinkBase {
+  rel: 'pingback'
+  href: string
+}
+
+// ============================================================================
+// Generic/Fallback Link
+// ============================================================================
+
+/**
+ * Fallback for custom/unknown rel types (keeps full flexibility)
+ * Note: Event handlers are added separately via MaybeEventFnHandlers in head.ts
+ */
+export interface GenericLink extends LinkBase {
+  rel?: string
+  href?: string
+  as?: 'audio' | 'document' | 'embed' | 'fetch' | 'font' | 'image' | 'object' | 'script' | 'style' | 'track' | 'video' | 'worker' | (string & Record<never, never>)
+  sizes?: string
+  type?: string
+  media?: string
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+  integrity?: string
+  hreflang?: string
+  imagesizes?: string
+  imagesrcset?: string
+  color?: string
+  title?: string
+  disabled?: boolean
+  prefetch?: string
+}
+
+// ============================================================================
+// Link Discriminated Union
+// ============================================================================
+
+/**
+ * Discriminated union of all link types.
+ * Order matters for TypeScript narrowing - specific types before generic.
+ */
+export type Link =
+  | StylesheetLink
+  | PreloadLink
+  | ModulepreloadLink
+  | PrefetchLink
+  | IconLink
+  | ManifestLink
+  | CanonicalLink
+  | DnsPrefetchLink
+  | PreconnectLink
+  | PrerenderLink
+  | AlternateLink
+  | AuthorLink
+  | LicenseLink
+  | HelpLink
+  | SearchLink
+  | PrevLink
+  | NextLink
+  | PingbackLink
+  | GenericLink
+
+// ============================================================================
+// Legacy Exports (for backwards compatibility during migration)
+// ============================================================================
 
 export type LinkRelTypes = 'alternate'
   | 'author'
@@ -34,223 +564,7 @@ export type LinkRelTypes = 'alternate'
   | 'apple-touch-icon'
   | 'apple-touch-startup-image'
 
-export interface LinkWithoutEvents extends Pick<GlobalAttributes, 'nonce' | 'id'>, Blocking {
-  /**
-   * This attribute is only used when rel="preload" or rel="prefetch" has been set on the `<link>` element.
-   * It specifies the type of content being loaded by the `<link>`, which is necessary for request matching,
-   * application of correct content security policy, and setting of correct Accept request header.
-   * Furthermore, rel="preload" uses this as a signal for request prioritization.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-as
-   */
-  as?: 'audio'
-    | 'document'
-    | 'embed'
-    | 'fetch'
-    | 'font'
-    | 'image'
-    | 'object'
-    | 'script'
-    | 'style'
-    | 'track'
-    | 'video'
-    | 'worker'
-  /**
-   * The color attribute is used with the mask-icon link type.
-   * The attribute must only be specified on link elements that have a rel attribute
-   * that contains the mask-icon keyword.
-   * The value must be a string that matches the CSS `<color>` production,
-   * defining a suggested color that user agents can use to customize the display
-   * of the icon that the user sees when they pin your site.
-   *
-   * @see https://html.spec.whatwg.org/multipage/semantics.html#attr-link-color
-   */
-  color?: string
-  /**
-   * This enumerated attribute indicates whether CORS must be used when fetching the resource.
-   * CORS-enabled images can be reused in the `<canvas>` element without being tainted.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
-   */
-  crossorigin?: ''
-    | 'anonymous'
-    | 'use-credentials'
-  /**
-   * Provides a hint of the relative priority to use when fetching a preloaded resource.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-fetchpriority
-   */
-  fetchpriority?: 'high'
-    | 'low'
-    | 'auto'
-  /**
-   * This attribute specifies the URL of the linked resource. A URL can be absolute or relative.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
-   */
-  href?: string
-  /**
-   * This attribute indicates the language of the linked resource. It is purely advisory.
-   * Allowed values are specified by RFC 5646: Tags for Identifying Languages (also known as BCP 47).
-   * Use this attribute only if the href attribute is present.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-hreflang
-   */
-  hreflang?: string
-  /**
-   * For rel="preload" and as="image" only, the imagesizes attribute is a sizes attribute that indicates to preload
-   * the appropriate resource used by an img element with corresponding values for its srcset and sizes attributes.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-imagesizes
-   */
-  imagesizes?: string
-  /**
-   * For rel="preload" and as="image" only, the imagesrcset attribute is a sourceset attribute that indicates
-   * to preload the appropriate resource used by an img element with corresponding values for its srcset and
-   * sizes attributes.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-imagesrcset
-   */
-  imagesrcset?: string
-  /**
-   * Contains inline metadata — a base64-encoded cryptographic hash of the resource (file)
-   * you're telling the browser to fetch.
-   * The browser can use this to verify that the fetched resource has been delivered free of unexpected manipulation.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-integrity
-   */
-  integrity?: string
-  /**
-   * This attribute specifies the media that the linked resource applies to.
-   * Its value must be a media type / media query.
-   * This attribute is mainly useful when linking to external stylesheets —
-   * it allows the user agent to pick the best adapted one for the device it runs on.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-integrity
-   */
-  media?: string
-
-  /**
-   * Identifies a resource that might be required by the next navigation and that the user agent should retrieve it.
-   * This allows the user agent to respond faster when the resource is requested in the future.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-prefetch
-   */
-  prefetch?: string
-
-  /**
-   * A string indicating which referrer to use when fetching the resource.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-referrerpolicy
-   */
-  referrerpolicy?: ReferrerPolicy
-  /**
-   * This attribute names a relationship of the linked document to the current document.
-   * The attribute must be a space-separated list of link type values.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-rel
-   */
-  rel?: LinkRelTypes | (string & Record<never, never>)
-  /**
-   * This attribute defines the sizes of the icons for visual media contained in the resource.
-   * It must be present only if the rel contains a value of icon or a non-standard type
-   * such as Apple's apple-touch-icon.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-sizes
-   */
-  sizes?: 'any' | '16x16' | '32x32' | '64x64' | '180x180' | (string & Record<never, never>)
-  /**
-   * The title attribute has special semantics on the `<link>` element.
-   * When used on a `<link rel="stylesheet">` it defines a default or an alternate stylesheet.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-title
-   */
-  title?: string
-  /**
-   * This attribute is used to define the type of the content linked to.
-   * The value of the attribute should be a MIME type such as text/html, text/css, and so on.
-   * The common use of this attribute is to define the type of stylesheet being referenced (such as text/css),
-   * but given that CSS is the only stylesheet language used on the web,
-   * not only is it possible to omit the type attribute, but is actually now recommended practice.
-   * It is also used on rel="preload" link types, to make sure the browser only downloads file types that it supports.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-type
-   */
-  type?: 'audio/aac'
-    | 'application/x-abiword'
-    | 'application/x-freearc'
-    | 'image/avif'
-    | 'video/x-msvideo'
-    | 'application/vnd.amazon.ebook'
-    | 'application/octet-stream'
-    | 'image/bmp'
-    | 'application/x-bzip'
-    | 'application/x-bzip2'
-    | 'application/x-cdf'
-    | 'application/x-csh'
-    | 'text/css'
-    | 'text/csv'
-    | 'application/msword'
-    | 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-    | 'application/vnd.ms-fontobject'
-    | 'application/epub+zip'
-    | 'application/gzip'
-    | 'image/gif'
-    | 'text/html'
-    | 'image/vnd.microsoft.icon'
-    | 'text/calendar'
-    | 'application/java-archive'
-    | 'image/jpeg'
-    | 'text/javascript'
-    | 'application/json'
-    | 'application/ld+json'
-    | 'audio/midi'
-    | 'audio/x-midi'
-    | 'audio/mpeg'
-    | 'video/mp4'
-    | 'video/mpeg'
-    | 'application/vnd.apple.installer+xml'
-    | 'application/vnd.oasis.opendocument.presentation'
-    | 'application/vnd.oasis.opendocument.spreadsheet'
-    | 'application/vnd.oasis.opendocument.text'
-    | 'audio/ogg'
-    | 'video/ogg'
-    | 'application/ogg'
-    | 'audio/opus'
-    | 'font/otf'
-    | 'image/png'
-    | 'application/pdf'
-    | 'application/x-httpd-php'
-    | 'application/vnd.ms-powerpoint'
-    | 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
-    | 'application/vnd.rar'
-    | 'application/rtf'
-    | 'application/x-sh'
-    | 'image/svg+xml'
-    | 'application/x-tar'
-    | 'image/tiff'
-    | 'video/mp2t'
-    | 'font/ttf'
-    | 'text/plain'
-    | 'application/vnd.visio'
-    | 'audio/wav'
-    | 'audio/webm'
-    | 'video/webm'
-    | 'image/webp'
-    | 'font/woff'
-    | 'font/woff2'
-    | 'application/xhtml+xml'
-    | 'application/vnd.ms-excel'
-    | 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-    | 'text/xml'
-    | 'application/atom+xml'
-    | 'application/xml'
-    | 'application/vnd.mozilla.xul+xml'
-    | 'application/zip'
-    | 'video/3gpp'
-    | 'audio/3gpp'
-    | 'video/3gpp2'
-    | 'audio/3gpp2' | (string & Record<never, never>)
-}
-
-export type Link = LinkWithoutEvents & HttpEventAttributes
+/**
+ * @deprecated Use the narrowed Link union type instead
+ */
+export type LinkWithoutEvents = GenericLink

--- a/packages/unhead/src/types/schema/meta.ts
+++ b/packages/unhead/src/types/schema/meta.ts
@@ -1,67 +1,88 @@
 import type { Stringable } from '../util'
 import type { GlobalAttributes } from './attributes/global'
+import type { DataKeys } from './attributes/data'
 
-export type MetaNames
-  = 'apple-itunes-app'
-    | 'apple-mobile-web-app-capable'
-    | 'apple-mobile-web-app-status-bar-style'
-    | 'apple-mobile-web-app-title'
-    | 'application-name'
-    | 'author'
-    | 'charset'
-    | 'color-scheme'
-    | 'content-security-policy'
-    | 'content-type'
-    | 'creator'
-    | 'default-style'
-    | 'description'
-    | 'fb:app_id'
-    | 'format-detection'
-    | 'generator'
-    | 'google-site-verification'
-    | 'google'
-    | 'googlebot'
-    | 'keywords'
-    | 'mobile-web-app-capable'
-    | 'msapplication-Config'
-    | 'msapplication-TileColor'
-    | 'msapplication-TileImage'
-    | 'publisher'
-    | 'rating'
-    | 'referrer'
-    | 'refresh'
-    | 'robots'
-    | 'theme-color'
-    | 'twitter:app:id:googleplay'
-    | 'twitter:app:id:ipad'
-    | 'twitter:app:id:iphone'
-    | 'twitter:app:name:googleplay'
-    | 'twitter:app:name:ipad'
-    | 'twitter:app:name:iphone'
-    | 'twitter:app:url:googleplay'
-    | 'twitter:app:url:ipad'
-    | 'twitter:app:url:iphone'
-    | 'twitter:card'
-    | 'twitter:creator:id'
-    | 'twitter:creator'
-    | 'twitter:data:1'
-    | 'twitter:data:2'
-    | 'twitter:description'
-    | 'twitter:image:alt'
-    | 'twitter:image'
-    | 'twitter:label:1'
-    | 'twitter:label:2'
-    | 'twitter:player:height'
-    | 'twitter:player:stream'
-    | 'twitter:player:width'
-    | 'twitter:player'
-    | 'twitter:site:id'
-    | 'twitter:site'
-    | 'twitter:title'
-    | 'viewport'
-    | 'x-ua-compatible'
+// ============================================================================
+// Meta Type Narrowing
+// ============================================================================
+// This implements discriminated unions for meta types with mutual exclusion
+// of name/property/http-equiv/charset. This prevents common mistakes like
+// using both `name` and `property` on the same meta tag.
+//
+// Note: Deeper narrowing (e.g., viewport-specific content types) is intentionally
+// skipped because:
+// 1. `useSeoMeta` is the recommended path for SEO meta tags
+// 2. The complexity/benefit ratio isn't favorable
+// 3. Content values are too varied to narrow effectively
 
-export type MetaProperties = 'article:author'
+/**
+ * Known meta name values
+ */
+export type MetaNames =
+  | 'apple-itunes-app'
+  | 'apple-mobile-web-app-capable'
+  | 'apple-mobile-web-app-status-bar-style'
+  | 'apple-mobile-web-app-title'
+  | 'application-name'
+  | 'author'
+  | 'charset'
+  | 'color-scheme'
+  | 'content-security-policy'
+  | 'content-type'
+  | 'creator'
+  | 'default-style'
+  | 'description'
+  | 'fb:app_id'
+  | 'format-detection'
+  | 'generator'
+  | 'google-site-verification'
+  | 'google'
+  | 'googlebot'
+  | 'keywords'
+  | 'mobile-web-app-capable'
+  | 'msapplication-Config'
+  | 'msapplication-TileColor'
+  | 'msapplication-TileImage'
+  | 'publisher'
+  | 'rating'
+  | 'referrer'
+  | 'refresh'
+  | 'robots'
+  | 'theme-color'
+  | 'twitter:app:id:googleplay'
+  | 'twitter:app:id:ipad'
+  | 'twitter:app:id:iphone'
+  | 'twitter:app:name:googleplay'
+  | 'twitter:app:name:ipad'
+  | 'twitter:app:name:iphone'
+  | 'twitter:app:url:googleplay'
+  | 'twitter:app:url:ipad'
+  | 'twitter:app:url:iphone'
+  | 'twitter:card'
+  | 'twitter:creator:id'
+  | 'twitter:creator'
+  | 'twitter:data:1'
+  | 'twitter:data:2'
+  | 'twitter:description'
+  | 'twitter:image:alt'
+  | 'twitter:image'
+  | 'twitter:label:1'
+  | 'twitter:label:2'
+  | 'twitter:player:height'
+  | 'twitter:player:stream'
+  | 'twitter:player:width'
+  | 'twitter:player'
+  | 'twitter:site:id'
+  | 'twitter:site'
+  | 'twitter:title'
+  | 'viewport'
+  | 'x-ua-compatible'
+
+/**
+ * Known meta property values (OpenGraph, etc.)
+ */
+export type MetaProperties =
+  | 'article:author'
   | 'article:expiration_time'
   | 'article:modified_time'
   | 'article:published_time'
@@ -100,53 +121,112 @@ export type MetaProperties = 'article:author'
   | 'profile:last_name'
   | 'profile:username'
 
-export interface Meta extends Pick<GlobalAttributes, 'id'> {
+/**
+ * Base properties shared by all meta types
+ */
+export interface MetaBase extends Pick<GlobalAttributes, 'id'>, DataKeys {
   /**
-   * This attribute declares the document's character encoding.
-   * If the attribute is present, its value must be an ASCII case-insensitive match for the string "utf-8",
-   * because UTF-8 is the only valid encoding for HTML5 documents.
-   * `<meta>` elements which declare a character encoding must be located entirely within the first 1024 bytes
-   * of the document.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset
-   */
-  charset?: 'utf-8' | (string & Record<never, never>)
-  /**
-   * This attribute contains the value for the http-equiv or name attribute, depending on which is used.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content
-   */
-  content?: Stringable
-  /**
-   * Defines a pragma directive. The attribute is named http-equiv(alent) because all the allowed values are names of
-   * particular HTTP headers.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-http-equiv
-   */
-  ['http-equiv']?: 'content-security-policy'
-    | 'content-type'
-    | 'default-style'
-    | 'x-ua-compatible'
-    | 'refresh'
-    | 'accept-ch'
-    | (string & Record<never, never>)
-  /**
-   * The name and content attributes can be used together to provide document metadata in terms of name-value pairs,
-   * with the name attribute giving the metadata name, and the content attribute giving the value.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-name
-   */
-  name?: MetaNames | (string & Record<never, never>)
-  /**
-   * The property attribute is used to define a property associated with the content attribute.
-   *
-   * Mainly used for og and twitter meta tags.
-   */
-  property?: MetaProperties | (string & Record<never, never>)
-  /**
-   * A valid media query list that can be included to set the media the `theme-color` metadata applies to.
+   * A valid media query list that can be included to set the media the metadata applies to.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color
    */
   media?: '(prefers-color-scheme: light)' | '(prefers-color-scheme: dark)' | (string & Record<never, never>)
 }
+
+// ============================================================================
+// Name-based Meta
+// ============================================================================
+
+/**
+ * Name-based meta (description, viewport, robots, etc.)
+ * Mutual exclusion: no property, no http-equiv, no charset
+ */
+export interface NameMeta extends MetaBase {
+  /**
+   * The name and content attributes can be used together to provide document metadata
+   * in terms of name-value pairs.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-name
+   */
+  name: MetaNames | (string & Record<never, never>)
+  /**
+   * This attribute contains the value for the name attribute.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content
+   */
+  content: Stringable
+}
+
+// ============================================================================
+// Property-based Meta
+// ============================================================================
+
+/**
+ * Property-based meta (OpenGraph, etc.)
+ * Mutual exclusion: no name, no http-equiv, no charset
+ */
+export interface PropertyMeta extends MetaBase {
+  /**
+   * The property attribute is used to define a property associated with the content attribute.
+   * Mainly used for og and twitter meta tags.
+   */
+  property: MetaProperties | (string & Record<never, never>)
+  /**
+   * This attribute contains the value for the property attribute.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content
+   */
+  content: Stringable
+}
+
+// ============================================================================
+// HTTP-equiv Meta
+// ============================================================================
+
+/**
+ * HTTP-equiv meta
+ * Mutual exclusion: no name, no property, no charset
+ */
+export interface HttpEquivMeta extends MetaBase {
+  /**
+   * Defines a pragma directive. The attribute is named http-equiv(alent) because all
+   * the allowed values are names of particular HTTP headers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-http-equiv
+   */
+  'http-equiv': 'content-security-policy' | 'content-type' | 'default-style' | 'x-ua-compatible' | 'refresh' | 'accept-ch' | (string & Record<never, never>)
+  /**
+   * This attribute contains the value for the http-equiv attribute.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content
+   */
+  content: Stringable
+}
+
+// ============================================================================
+// Charset Meta
+// ============================================================================
+
+/**
+ * Charset meta (standalone, no content)
+ * Mutual exclusion: no name, no property, no http-equiv, no content
+ */
+export interface CharsetMeta extends MetaBase {
+  /**
+   * This attribute declares the document's character encoding.
+   * If the attribute is present, its value must be an ASCII case-insensitive match for the string "utf-8".
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset
+   */
+  charset: 'utf-8' | (string & Record<never, never>)
+}
+
+// ============================================================================
+// Meta Discriminated Union
+// ============================================================================
+
+/**
+ * Discriminated union of all meta types.
+ * Provides mutual exclusion of name/property/http-equiv/charset.
+ */
+export type Meta = NameMeta | PropertyMeta | HttpEquivMeta | CharsetMeta

--- a/packages/unhead/src/types/schema/script.ts
+++ b/packages/unhead/src/types/schema/script.ts
@@ -1,31 +1,67 @@
 import type { Booleanable } from '../util'
 import type { HttpEventAttributes } from './attributes/event'
 import type { GlobalAttributes } from './attributes/global'
+import type { DataKeys } from './attributes/data'
 import type { ReferrerPolicy } from './shared'
 import type { Blocking } from './struct/blocking'
+import type { SpeculationRules } from './struct/speculationRules'
 
-export interface ScriptWithoutEvents extends Pick<GlobalAttributes, 'nonce' | 'id'>, Blocking {
+// ============================================================================
+// Script Type Narrowing
+// ============================================================================
+// This implements discriminated unions for script types based on the `type` attribute.
+// Each script type only exposes properties relevant to that specific type.
+
+/**
+ * Events that fire on script elements (load/error)
+ */
+export type ScriptHttpEvents = Pick<HttpEventAttributes, 'onload' | 'onerror'>
+
+/**
+ * Base properties shared by all script types
+ */
+export interface ScriptBase extends Pick<GlobalAttributes, 'nonce' | 'id'>, Blocking, DataKeys {
+  /**
+   * Provides a hint of the relative priority to use when fetching an external script.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-fetchpriority
+   */
+  fetchpriority?: 'high' | 'low' | 'auto'
+  /**
+   * Indicates which referrer to send when fetching the script, or resources fetched by the script.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-referrerpolicy
+   */
+  referrerpolicy?: ReferrerPolicy
+}
+
+// ============================================================================
+// External JavaScript Script
+// ============================================================================
+
+/**
+ * External JavaScript (fires events)
+ */
+export interface ExternalScript extends ScriptBase, ScriptHttpEvents {
+  /**
+   * This attribute specifies the URI of an external script.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-src
+   */
+  src: string
+  /**
+   * This attribute indicates the type of script represented.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
+   */
+  type?: '' | 'text/javascript'
   /**
    * For classic scripts, if the async attribute is present,
    * then the classic script will be fetched in parallel to parsing and evaluated as soon as it is available.
    *
-   * For module scripts,
-   * if the async attribute is present then the scripts and all their dependencies will be executed in the defer queue,
-   * therefore they will get fetched in parallel to parsing and evaluated as soon as they are available.
-   *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-async
    */
   async?: Booleanable
-  /**
-   * Normal script elements pass minimal information to the window.onerror
-   * for scripts which do not pass the standard CORS checks.
-   * To allow error logging for sites which use a separate domain for static media, use this attribute.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin
-   */
-  crossorigin?: ''
-    | 'anonymous'
-    | 'use-credentials'
   /**
    * This Boolean attribute is set to indicate to a browser that the script is meant to be executed after the document
    * has been parsed, but before firing DOMContentLoaded.
@@ -34,13 +70,12 @@ export interface ScriptWithoutEvents extends Pick<GlobalAttributes, 'nonce' | 'i
    */
   defer?: Booleanable
   /**
-   * Provides a hint of the relative priority to use when fetching an external script.
+   * Normal script elements pass minimal information to the window.onerror
+   * for scripts which do not pass the standard CORS checks.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-fetchpriority
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin
    */
-  fetchpriority?: 'high'
-    | 'low'
-    | 'auto'
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
   /**
    * This attribute contains inline metadata that a user agent can use to verify
    * that a fetched resource has been delivered free of unexpected manipulation.
@@ -50,21 +85,212 @@ export interface ScriptWithoutEvents extends Pick<GlobalAttributes, 'nonce' | 'i
   integrity?: string
   /**
    * This Boolean attribute is set to indicate that the script should not be executed in browsers
-   * that support ES modules — in effect,
-   * this can be used to serve fallback scripts to older browsers that do not support modular JavaScript code.
+   * that support ES modules.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-nomodule
    */
   nomodule?: Booleanable
+}
+
+// ============================================================================
+// ES Module Script
+// ============================================================================
+
+/**
+ * ES Module script (fires events)
+ */
+export interface ModuleScript extends ScriptBase, ScriptHttpEvents {
   /**
-   * Indicates which referrer to send when fetching the script, or resources fetched by the script.
+   * This attribute specifies the URI of an external script.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-referrerpolicy
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-src
    */
-  referrerpolicy?: ReferrerPolicy
+  src: string
   /**
-   * This attribute specifies the URI of an external script;
-   * this can be used as an alternative to embedding a script directly within a document.
+   * This attribute indicates the type of script represented.
+   * Required discriminant for module scripts.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
+   */
+  type: 'module'
+  /**
+   * For module scripts, if the async attribute is present then the scripts and all their dependencies
+   * will be executed in the defer queue.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-async
+   */
+  async?: Booleanable
+  /**
+   * Normal script elements pass minimal information to the window.onerror
+   * for scripts which do not pass the standard CORS checks.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin
+   */
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+  /**
+   * This attribute contains inline metadata that a user agent can use to verify
+   * that a fetched resource has been delivered free of unexpected manipulation.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-integrity
+   */
+  integrity?: string
+}
+
+// ============================================================================
+// Inline JavaScript Script
+// ============================================================================
+
+/**
+ * Inline JavaScript (no events, no src)
+ */
+export interface InlineScript extends ScriptBase {
+  /**
+   * This attribute indicates the type of script represented.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
+   */
+  type?: '' | 'text/javascript'
+  /**
+   * Sets the textContent of an element. Safer for XSS.
+   */
+  textContent: string
+  // Explicitly no: src, async, defer, integrity, crossorigin
+}
+
+// ============================================================================
+// Inline Module Script
+// ============================================================================
+
+/**
+ * Inline ES Module script (no src)
+ */
+export interface InlineModuleScript extends ScriptBase {
+  /**
+   * This attribute indicates the type of script represented.
+   * Required discriminant for module scripts.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
+   */
+  type: 'module'
+  /**
+   * Sets the textContent of an element. Safer for XSS.
+   */
+  textContent: string
+  // Explicitly no: src, async, defer, integrity, crossorigin
+}
+
+// ============================================================================
+// JSON-LD Structured Data Script
+// ============================================================================
+
+/**
+ * JSON-LD structured data (uses textContent for XSS safety)
+ * Note: For full schema.org typing, use @unhead/schema-org with useSchemaOrg()
+ */
+export interface JsonLdScript extends ScriptBase {
+  /**
+   * This attribute indicates the type of script represented.
+   * Required discriminant for JSON-LD scripts.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
+   */
+  type: 'application/ld+json'
+  /**
+   * Sets the textContent of an element. Safer for XSS.
+   * Can be a string or an object that will be serialized to JSON.
+   */
+  textContent: string | Record<string, unknown>
+  // Explicitly no: src, async, defer, integrity, crossorigin
+}
+
+// ============================================================================
+// Speculation Rules Script
+// ============================================================================
+
+/**
+ * Speculation Rules (uses textContent for safety)
+ */
+export interface SpeculationRulesScript extends ScriptBase {
+  /**
+   * This attribute indicates the type of script represented.
+   * Required discriminant for speculation rules scripts.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
+   */
+  type: 'speculationrules'
+  /**
+   * Sets the textContent of an element.
+   * Can be a string or a SpeculationRules object that will be serialized to JSON.
+   */
+  textContent: string | SpeculationRules
+  // Explicitly no: src, async, defer, integrity, crossorigin
+}
+
+// ============================================================================
+// Import Map Script
+// ============================================================================
+
+/**
+ * Import map configuration
+ */
+export interface ImportMapConfig {
+  imports: Record<string, string>
+  scopes?: Record<string, Record<string, string>>
+}
+
+/**
+ * Import map
+ */
+export interface ImportMapScript extends ScriptBase {
+  /**
+   * This attribute indicates the type of script represented.
+   * Required discriminant for import map scripts.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
+   */
+  type: 'importmap'
+  /**
+   * Sets the textContent of an element.
+   * Can be a string or an ImportMapConfig object that will be serialized to JSON.
+   */
+  textContent: string | ImportMapConfig
+  // Explicitly no: src, async, defer, integrity, crossorigin
+}
+
+// ============================================================================
+// Application JSON Script
+// ============================================================================
+
+/**
+ * Application JSON script (generic JSON data)
+ */
+export interface ApplicationJsonScript extends ScriptBase {
+  /**
+   * This attribute indicates the type of script represented.
+   * Required discriminant for JSON scripts.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
+   */
+  type: 'application/json'
+  /**
+   * Sets the textContent of an element. Safer for XSS.
+   * Can be a string or an object that will be serialized to JSON.
+   */
+  textContent: string | Record<string, unknown>
+  // Explicitly no: src, async, defer, integrity, crossorigin
+}
+
+// ============================================================================
+// Generic/Fallback Script
+// ============================================================================
+
+/**
+ * Generic/fallback (keeps full flexibility)
+ * Note: Event handlers are added separately via MaybeEventFnHandlers in head.ts
+ */
+export interface GenericScript extends ScriptBase {
+  /**
+   * This attribute specifies the URI of an external script.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-src
    */
@@ -74,13 +300,52 @@ export interface ScriptWithoutEvents extends Pick<GlobalAttributes, 'nonce' | 'i
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
    */
-  type?: ''
-    | 'text/javascript'
-    | 'module'
-    | 'application/json'
-    | 'application/ld+json'
-    | 'speculationrules'
-    | (string & Record<never, never>)
+  type?: string
+  /**
+   * For classic scripts, if the async attribute is present,
+   * then the classic script will be fetched in parallel to parsing and evaluated as soon as it is available.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-async
+   */
+  async?: Booleanable
+  /**
+   * This Boolean attribute is set to indicate to a browser that the script is meant to be executed after the document
+   * has been parsed, but before firing DOMContentLoaded.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer
+   */
+  defer?: Booleanable
+  /**
+   * Normal script elements pass minimal information to the window.onerror
+   * for scripts which do not pass the standard CORS checks.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin
+   */
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+  /**
+   * This attribute contains inline metadata that a user agent can use to verify
+   * that a fetched resource has been delivered free of unexpected manipulation.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-integrity
+   */
+  integrity?: string
+  /**
+   * This Boolean attribute is set to indicate that the script should not be executed in browsers
+   * that support ES modules.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-nomodule
+   */
+  nomodule?: Booleanable
+  /**
+   * Text content of the tag.
+   *
+   * Warning: This is not safe for XSS. Do not use this with user input, use `textContent` instead.
+   */
+  innerHTML?: string
+  /**
+   * Sets the textContent of an element. Safer for XSS.
+   */
+  textContent?: string | Record<string, unknown>
   /**
    * A custom element name
    *
@@ -91,4 +356,30 @@ export interface ScriptWithoutEvents extends Pick<GlobalAttributes, 'nonce' | 'i
   ['custom-element']?: 'amp-story' | 'amp-carousel' | 'amp-ad' | (string & Record<never, never>)
 }
 
-export type Script = ScriptWithoutEvents & HttpEventAttributes
+// ============================================================================
+// Script Discriminated Union
+// ============================================================================
+
+/**
+ * Discriminated union of all script types.
+ * Order matters for TypeScript narrowing - specific types before generic.
+ */
+export type Script =
+  | ExternalScript
+  | ModuleScript
+  | InlineScript
+  | InlineModuleScript
+  | JsonLdScript
+  | SpeculationRulesScript
+  | ImportMapScript
+  | ApplicationJsonScript
+  | GenericScript
+
+// ============================================================================
+// Legacy Exports (for backwards compatibility during migration)
+// ============================================================================
+
+/**
+ * @deprecated Use the narrowed Script union type instead
+ */
+export type ScriptWithoutEvents = GenericScript


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Implements discriminated union types for `useHead()` input, narrowing types based on discriminator properties.

#### Before / After

**Link: `rel` narrows available properties**

Before: all properties available on all links
```ts
useHead({
  link: [{
    rel: 'canonical',
    href: '/page',
    imagesrcset: '...',  // no error - but invalid for canonical!
    onload: () => {},    // no error - but canonical doesn't fire events!
  }]
})
```

After: CanonicalLink only has relevant props
```ts
useHead({
  link: [{
    rel: 'canonical',
    href: '/page',
    imagesrcset: '...',  // ❌ Error: Property 'imagesrcset' does not exist
    onload: () => {},    // ❌ Error: Property 'onload' does not exist
  }]
})
```

**Link: preload `as` narrows further**

Before: imagesrcset available on all preloads
```ts
useHead({
  link: [{ rel: 'preload', as: 'script', href: '/app.js', imagesrcset: '...' }]  // no error
})
```

After: imagesrcset only on PreloadImageLink
```ts
useHead({
  link: [{ rel: 'preload', as: 'image', href: '/hero.webp', imagesrcset: '...' }]  // ✅ valid
})
```
```ts
useHead({
  link: [{ rel: 'preload', as: 'script', href: '/app.js', imagesrcset: '...' }]   // ❌ Error
})
```

**Link: font preload requires crossorigin**

Before: no enforcement
```ts
useHead({
  link: [{ rel: 'preload', as: 'font', href: '/font.woff2' }]  // no error - but broken!
})
```

After: PreloadFontLink requires crossorigin
```ts
useHead({
  link: [{ rel: 'preload', as: 'font', href: '/font.woff2' }]  // ❌ Error: crossorigin required
})
```
```ts
useHead({
  link: [{ rel: 'preload', as: 'font', href: '/font.woff2', crossorigin: 'anonymous' }]  // ✅
})
```

**Script: `type` narrows available properties**

Before: async/defer available on JSON-LD
```ts
useHead({
  script: [{ type: 'application/ld+json', textContent: {...}, async: true }]  // no error - invalid!
})
```

After: JsonLdScript only has textContent
```ts
useHead({
  script: [{ type: 'application/ld+json', textContent: {...}, async: true }]  // ❌ Error
})
```

**Script: events only on external scripts**

Before: onload on inline scripts
```ts
useHead({
  script: [{ textContent: 'console.log("hi")', onload: () => {} }]  // no error - never fires!
})
```

After: InlineScript has no event handlers
```ts
useHead({
  script: [{ textContent: 'console.log("hi")', onload: () => {} }]  // ❌ Error
})
```
```ts
useHead({
  script: [{ src: '/app.js', onload: () => {} }]  // ✅ ExternalScript has events
})
```

**Meta: mutual exclusion of name/property/http-equiv/charset**

Before: can use name + property together
```ts
useHead({
  meta: [{ name: 'description', property: 'og:description', content: '...' }]  // no error - invalid HTML!
})
```

After: discriminated union prevents this
```ts
useHead({
  meta: [{ name: 'description', property: 'og:description', content: '...' }]  // ❌ Error
})
```
```ts
useHead({
  meta: [{ name: 'description', content: '...' }]       // ✅ NameMeta
})
```
```ts
useHead({
  meta: [{ property: 'og:description', content: '...' }] // ✅ PropertyMeta
})
```

#### Summary

| Type | Discriminator | Narrowed Types |
|------|---------------|----------------|
| Link | `rel` | `StylesheetLink`, `PreloadLink`, `CanonicalLink`, `IconLink`, etc. |
| Link (preload) | `as` | `PreloadImageLink`, `PreloadFontLink`, `PreloadScriptLink`, etc. |
| Script | `type`/`src` | `ExternalScript`, `ModuleScript`, `JsonLdScript`, `InlineScript`, etc. |
| Meta | `name`/`property`/`http-equiv`/`charset` | `NameMeta`, `PropertyMeta`, `HttpEquivMeta`, `CharsetMeta` |

Legacy aliases (`LinkWithoutEvents`, `ScriptWithoutEvents`) preserved via `GenericLink`/`GenericScript`.
