### PR TITLE
fix(unhead): delay patching until hydration is complete

### DIFF
--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -52,10 +52,15 @@ export interface HeadEntry<Input> {
    */
   _tags?: HeadTag[]
   /**
-   * Entry needs re-normalization (client-only)
+   * Pending patch to apply on next render (client-only)
    * @internal
    */
-  _dirty?: boolean
+  _pending?: Input
+  /**
+   * Original input for hydration side effect tracking (client-only)
+   * @internal
+   */
+  _originalInput?: Input
   /**
    * @internal
    */

--- a/packages/unhead/test/unit/client/state.test.ts
+++ b/packages/unhead/test/unit/client/state.test.ts
@@ -12,8 +12,10 @@ describe('state', () => {
     expect(head.entries).toMatchInlineSnapshot(`
       Map {
         1 => {
-          "_dirty": true,
           "_i": 1,
+          "_originalInput": {
+            "title": "hello",
+          },
           "input": {
             "title": "hello",
           },

--- a/packages/vue/test/unit/dom/classes.test.ts
+++ b/packages/vue/test/unit/dom/classes.test.ts
@@ -3,7 +3,7 @@
 import { renderDOMHead } from '@unhead/dom'
 import { useHead } from '@unhead/vue'
 import { describe, it } from 'vitest'
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useDom } from '../../../../unhead/test/fixtures'
 import { csrVueAppWithUnhead } from '../../util'
 
@@ -42,5 +42,56 @@ describe('vue dom classes', () => {
       </head>
       <body class="active-navbar-body"><div id="app" data-v-app=""><div>hello world</div></div></body></html>"
     `)
+  })
+
+  it('toggle class in onMounted - removes loading class', async () => {
+    const dom = useDom()
+    // simulate SSR hydration scenario - body already has loading class
+    dom.window.document.body.className = 'loading'
+
+    const isLoaded = ref(false)
+    const head = csrVueAppWithUnhead(dom, () => {
+      useHead({
+        bodyAttrs: {
+          class: computed(() => {
+            return !isLoaded.value ? 'loading' : ''
+          }),
+        },
+      })
+      // this runs synchronously during component setup, before renderDOMHead
+      onMounted(() => {
+        isLoaded.value = true
+      })
+    })
+
+    // wait for Vue's effect queue to flush
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // first render - the patch from onMounted happened BEFORE this
+    renderDOMHead(head, { document: dom.window.document })
+
+    // bug: class should be '' but might still be 'loading' if patch was lost
+    expect(dom.window.document.body.className).toBe('')
+  })
+
+  it('explicit patch before render - removes class', async () => {
+    const dom = useDom()
+    dom.window.document.body.className = 'loading'
+
+    let entry: ReturnType<typeof useHead>
+    const head = csrVueAppWithUnhead(dom, () => {
+      entry = useHead({
+        bodyAttrs: {
+          class: 'loading',
+        },
+      })
+    })
+
+    // Explicitly patch before first render
+    entry!.patch({ bodyAttrs: { class: '' } })
+
+    renderDOMHead(head, { document: dom.window.document })
+
+    expect(dom.window.document.body.className).toBe('')
   })
 })


### PR DESCRIPTION
## Summary

Fixes https://github.com/nuxt/nuxt/issues/26272

The issue relates to patches called before the first render (e.g., in Vue's `onMounted`) so the initial SSR is lost, meaning we can't track side effects.
