### PR TITLE
fix(vue): support computed getter trigger

### DIFF
--- a/packages/vue/test/unit/useScript.test.ts
+++ b/packages/vue/test/unit/useScript.test.ts
@@ -117,6 +117,43 @@ describe('vue e2e scripts', () => {
     expect(status2.value).toEqual('loading')
   })
 
+  it('getter function trigger', async () => {
+    const dom = useDom()
+    const head = createHead({
+      document: dom.window.document,
+    })
+
+    const shouldLoad = ref(false)
+
+    const { status, _triggerPromises } = useScript({
+      src: '//getter-trigger.script',
+    }, {
+      // getter function like () => shouldLoad.value
+      trigger: () => shouldLoad.value,
+      head,
+    })
+
+    // promise pending
+    expect(_triggerPromises).toMatchInlineSnapshot(`
+      [
+        Promise {},
+      ]
+    `)
+
+    expect(status.value).toEqual('awaitingLoad')
+
+    // trigger by setting the ref
+    shouldLoad.value = true
+    // wait next tick
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve()
+      }, 25)
+    })
+
+    expect(status.value).toEqual('loading')
+  })
+
   it('respects useScript privacy controls - #293', async () => {
     const head = createHeadCore()
     const script = useScript({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

```ts
// ❌ Before: getter functions didn't work (silently failed to trigger)
  const shouldLoad = ref(false)
  useScript('https://example.com/script.js', {
    trigger: () => shouldLoad.value
  })

  // ✅ After: getter functions now work the same as refs
  const shouldLoad = ref(false)
  useScript('https://example.com/script.js', {
    trigger: () => shouldLoad.value  // works!
  })

  // All three formats are now equivalent:
  trigger: shouldLoad                          // ref
  trigger: computed(() => shouldLoad.value)    // computed ref  
  trigger: () => shouldLoad.value              // getter function
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
