### PR TITLE
fix(vue): guard `s._statusRef`

### DIFF
--- a/packages/vue/src/scripts/useScript.ts
+++ b/packages/vue/src/scripts/useScript.ts
@@ -104,7 +104,10 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   // @ts-expect-error untyped
   head._scriptStatusWatcher = head._scriptStatusWatcher || head.hooks.hook('script:updated', ({ script: s }) => {
     // @ts-expect-error untyped
-    s._statusRef.value = s.status
+    if (s._statusRef) {
+      // @ts-expect-error untyped
+      s._statusRef.value = s.status
+    }
   })
   // @ts-expect-error untyped
   const script = _useScript(head, input as BaseUseScriptInput, options)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

with hookable v6, hooks _can_ be synchronous and so this hook can end up being called before `s._statusRef` is set

discovered in https://github.com/danielroe/roe.dev/actions/runs/21084385110/job/60644791143?pr=1788