### PR TITLE
fix(schema-org): remove unimplemented SchemaOrgDebug

### DIFF
--- a/packages/schema-org/src/vue/meta.ts
+++ b/packages/schema-org/src/vue/meta.ts
@@ -18,7 +18,6 @@ export const schemaOrgAutoImports = [
 ]
 
 export const schemaOrgComponents = [
-  'SchemaOrgDebug',
   'SchemaOrgArticle',
   'SchemaOrgBreadcrumb',
   'SchemaOrgComment',


### PR DESCRIPTION
## Summary

Remove `SchemaOrgDebug` from `schemaOrgComponents` array - listed since initial commit but never implemented.

Causes build errors with static ESM re-exports:
```
module '@unhead/schema-org/vue' does not provide export 'SchemaOrgDebug'
```

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [unhead-schema-org-debug](https://stackblitz.com/github/onmax/repros/tree/repro/unhead-schema-org-debug/unhead-schema-org-debug?startScript=dev) | ❌ Export error |
| Fix | [unhead-schema-org-debug-fix](https://stackblitz.com/github/onmax/repros/tree/repro/unhead-schema-org-debug/unhead-schema-org-debug-fix?startScript=dev) | ✅ Works |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/unhead-schema-org-debug https://github.com/onmax/repros.git
cd repros && git sparse-checkout set unhead-schema-org-debug
cd unhead-schema-org-debug && pnpm i && pnpm dev
# ❌ Expected: "module does not provide export 'SchemaOrgDebug'"
```

## Verify fix

```bash
git sparse-checkout add unhead-schema-org-debug-fix
cd ../unhead-schema-org-debug-fix && pnpm i && pnpm dev
# ✅ Expected: dev server starts without errors
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.