### PR TITLE
perf(vue): avoid duplicating error message in the bundle

### DIFF
--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -26,10 +26,9 @@ export function injectHead() {
   if (hasInjectionContext()) {
     // fallback to vue context
     const instance = inject<VueHeadClient>(headSymbol)
-    if (!instance) {
-      throw new Error('useHead() was called without provide context, ensure you call it through the setup() function.')
+    if (instance) {
+      return instance
     }
-    return instance
   }
   throw new Error('useHead() was called without provide context, ensure you call it through the setup() function.')
 }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed the error message is duplicated in our bundle. This should decrease the bundle size by a tiny bit.

-----
btw. you might want to just change the original error, because I don't think it was 100% correct. But if you're working with Vue, you usually know what's the problem when you see an error like this.