### PR TITLE
fix(unhead): dedupe alternate links by hreflang/type without href

### DIFF
--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -29,8 +29,9 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
   if (name === 'link' && props.rel === 'canonical')
     return 'canonical'
 
-  if (name === 'link' && props.rel === 'alternate') {
-    return `alternate:${props.hreflang || props.type || 'x-default'}:${props.href || ''}`
+  const altKey = props.hreflang || props.type
+  if (name === 'link' && props.rel === 'alternate' && altKey) {
+    return `alternate:${altKey}`
   }
 
   if (props.charset)


### PR DESCRIPTION
### 🔗 Linked issue

Related to #655

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The previous alternate link dedupe key included `href`, which meant same-hreflang entries with different URLs were treated as distinct tags instead of deduping. This removes `href` from the key so `<link rel="alternate">` dedupes by `hreflang` or `type` only (last push wins). Bare alternates without either property now fall through to the generic deduping logic instead of being grouped under `x-default`.

Adds edge case tests for RSS/Atom feed coexistence, same-type feed deduping, and bare alternate fallthrough.