### PR TITLE
fix(unhead): dedupe link rel without hreflang or type

### DIFF
--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -29,9 +29,12 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
   if (name === 'link' && props.rel === 'canonical')
     return 'canonical'
 
-  const altKey = props.hreflang || props.type
-  if (name === 'link' && props.rel === 'alternate' && altKey) {
-    return `alternate:${altKey}`
+  // dedupe alternate links with hreflang/type by that attribute
+  if (name === 'link' && props.rel === 'alternate') {
+    const altKey = props.hreflang || props.type
+    if (altKey) {
+      return `alternate:${altKey}`
+    }
   }
 
   if (props.charset)
@@ -57,6 +60,11 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
 
   if (props.id) {
     return `${name}:id:${props.id}`
+  }
+
+  // bare alternate links (no hreflang/type/key/id) dedupe by href
+  if (name === 'link' && props.rel === 'alternate') {
+    return `alternate:${props.href || ''}`
   }
 
   // avoid duplicate tags with the same content (if no key is provided)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/unjs/unhead/pull/655
https://github.com/unjs/unhead/pull/656

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

we ideally want to dedupe `<link rel>` even if there's no type/hreflang attribute