### PR TITLE
docs: add skilld agent skill snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ The latest major is now stable! Check out the [v2 release notes](https://unhead.
 
 ## Get Started
 
+Install `unhead` dependency to your project:
+
+```bash
+npm install unhead
+```
+
+> [!TIP]
+> Generate an Agent Skill for this package using [skilld](https://github.com/harlan-zw/skilld):
+> ```bash
+> npx skilld add unhead
+> ```
+
 Visit the [documentation site](https://unhead.unjs.io/) for guides and API references.
 
 ## Sponsors

--- a/docs/0.typescript/head/guides/0.get-started/1.installation.md
+++ b/docs/0.typescript/head/guides/0.get-started/1.installation.md
@@ -25,6 +25,12 @@ Install `unhead`{lang="bash"} dependency to your project.
 
 :ModuleInstall{name="unhead"}
 
+> [!TIP]
+> Generate an Agent Skill for this package using [skilld](https://github.com/harlan-zw/skilld):
+> ```bash
+> npx skilld add unhead
+> ```
+
 ## How do I setup client-side rendering?
 
 To begin with, we'll import the function to initialize Unhead in our _client_ app from `unhead/client`{lang="bash"}.


### PR DESCRIPTION
Adds a tip callout after installation instructions showing how to generate an AI agent skill for this package using [skilld](https://github.com/harlan-zw/skilld).