### PR TITLE
fix(scripts): prevent scope disposal from aborting unrelated trigger in `useScript`

### DIFF
--- a/packages/unhead/src/scripts/types.ts
+++ b/packages/unhead/src/scripts/types.ts
@@ -95,7 +95,7 @@ export interface ScriptInstance<T extends BaseScriptApi> {
   /**
    * @internal
    */
-  _triggerAbortPromise?: Promise<void>
+  _triggerAbortControllers?: Set<AbortController>
   /**
    * @internal
    */

--- a/packages/vue/src/scripts/useScript.ts
+++ b/packages/vue/src/scripts/useScript.ts
@@ -61,9 +61,11 @@ function registerVueScopeHandlers<T extends Record<symbol | string, any> = Recor
   // if we have a scope we should make these callbacks reactive
   script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
   script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  // capture the controller at registration time so this scope only aborts
+  // the controller it was associated with, not a newer one created by a later scope
+  const triggerAbortController = script._triggerAbortController
   onScopeDispose(() => {
-    // stop any trigger promises
-    script._triggerAbortController?.abort()
+    triggerAbortController?.abort()
   })
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/scripts/issues/597

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a problem where a stale Vue scope disposal could abort an unrelated trigger during client-side navigation.

When navigating between pages that both use `useScript` with the same `src`, the new page mounts before the old page unmounts. The old page's `onScopeDispose` called abort() on `script._triggerAbortController`, which by that point was the new scope's controller. This cancelled the new page's trigger and prevented the script from ever loading.