### PR TITLE
fix(unhead): deduplicate matching tags inside same render cycle

### DIFF
--- a/packages/unhead/src/client/renderDOMHead.ts
+++ b/packages/unhead/src/client/renderDOMHead.ts
@@ -38,7 +38,7 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
             const count = dupeKeyCounter.get(tag._d!) || 0
             const res = {
               tag,
-              id: (count ? `${tag._d}:${count}` : tag._d) || hashTag(tag),
+              id: (count ? `${tag._d}:${count}` : tag._d) || tag._h!,
               shouldRender: true,
             }
             if (tag._d && isMetaArrayDupeKey(tag._d)) {

--- a/packages/unhead/src/unhead.ts
+++ b/packages/unhead/src/unhead.ts
@@ -12,7 +12,7 @@ import type {
 } from './types'
 import { createHooks } from 'hookable'
 import { isMetaArrayDupeKey, sortTags, tagWeight, UsesMergeStrategy, ValidHeadTags } from './utils'
-import { dedupeKey } from './utils/dedupe'
+import { dedupeKey, hashTag } from './utils/dedupe'
 import { normalizeEntryToTags } from './utils/normalize'
 
 function registerPlugin(head: Unhead<any>, p: HeadPluginInput) {
@@ -111,6 +111,8 @@ export function createUnhead<T = ResolvableHead>(resolvedOptions: CreateHeadOpti
             t._w = tagWeight(head, t)
             t._p = (e._i << 10) + i
             t._d = dedupeKey(t)
+            if (!t._d)
+              t._h = hashTag(t)
             return t
           })
         }
@@ -120,7 +122,7 @@ export function createUnhead<T = ResolvableHead>(resolvedOptions: CreateHeadOpti
         .flatMap(e => (e._tags || []).map(t => ({ ...t, props: { ...t.props } })))
         .sort(sortTags)
         .reduce((acc, next) => {
-          const k = String(next._d || next._p)
+          const k = next._d || next._h!
           if (!acc.has(k))
             return acc.set(k, next)
 

--- a/packages/unhead/test/unit/client/promises.test.ts
+++ b/packages/unhead/test/unit/client/promises.test.ts
@@ -31,6 +31,7 @@ describe('promises', () => {
         },
         {
           "_d": undefined,
+          "_h": "script:src:https://example.com/script.js",
           "_p": 1025,
           "_w": 50,
           "props": {

--- a/packages/unhead/test/unit/client/resolveTags.test.ts
+++ b/packages/unhead/test/unit/client/resolveTags.test.ts
@@ -58,6 +58,7 @@ describe('resolveTags', () => {
         },
         {
           "_d": undefined,
+          "_h": "script:src:https://cdn.example.com/script.js",
           "_p": 1026,
           "_w": 50,
           "props": {
@@ -88,6 +89,7 @@ describe('resolveTags', () => {
         },
         {
           "_d": undefined,
+          "_h": "link:rel:icon,type:image/x-icon,href:https://cdn.example.com/favicon.ico",
           "_p": 1028,
           "_w": 100,
           "props": {
@@ -122,6 +124,7 @@ describe('resolveTags', () => {
       [
         {
           "_d": undefined,
+          "_h": "script:src:https://cdn.example.com/script2.js",
           "_p": 2048,
           "_w": 50,
           "props": {
@@ -162,6 +165,7 @@ describe('resolveTags', () => {
         },
         {
           "_d": undefined,
+          "_h": "script:src:https://cdn.example.com/script2.js",
           "_p": 1026,
           "_w": 50,
           "props": {
@@ -192,6 +196,7 @@ describe('resolveTags', () => {
         },
         {
           "_d": undefined,
+          "_h": "link:rel:icon,type:image/x-icon,href:https://cdn.example.com/favicon.ico",
           "_p": 1028,
           "_w": 100,
           "props": {

--- a/packages/unhead/test/unit/e2e/deduping.test.ts
+++ b/packages/unhead/test/unit/e2e/deduping.test.ts
@@ -182,6 +182,52 @@ describe('unhead e2e deduping', () => {
     `)
   })
 
+  it('duplicate script src and link href across entries', async () => {
+    const ssrHead = createClientHeadWithContext()
+    ssrHead.push({
+      script: [{ src: 'https://example.com/app.js', async: true }],
+      link: [{ rel: 'stylesheet', href: 'https://example.com/style.css' }],
+    })
+    ssrHead.push({
+      script: [{ src: 'https://example.com/app.js', async: true }],
+      link: [{ rel: 'stylesheet', href: 'https://example.com/style.css' }],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+    expect(data.headTags).toMatchInlineSnapshot(`
+      "<script src="https://example.com/app.js" async></script>
+      <link rel="stylesheet" href="https://example.com/style.css">"
+    `)
+
+    const dom = useDom(data)
+    const csrHead = createClientHeadWithContext()
+    csrHead.push({
+      script: [{ src: 'https://example.com/app.js', async: true }],
+      link: [{ rel: 'stylesheet', href: 'https://example.com/style.css' }],
+    })
+    csrHead.push({
+      script: [{ src: 'https://example.com/app.js', async: true }],
+      link: [{ rel: 'stylesheet', href: 'https://example.com/style.css' }],
+    })
+    await renderDOMHead(csrHead, { document: dom.window.document })
+
+    expect(dom.serialize()).toMatchInlineSnapshot(`
+      "<!DOCTYPE html><html><head>
+      <script src="https://example.com/app.js" async=""></script>
+      <link rel="stylesheet" href="https://example.com/style.css">
+      </head>
+      <body>
+
+      <div>
+      <h1>hello world</h1>
+      </div>
+
+
+
+      </body></html>"
+    `)
+  })
+
   it('duplicate no key', async () => {
     const input = {
       style: ['this will be inserted twice'],

--- a/packages/unhead/test/unit/server/tagPriority.test.ts
+++ b/packages/unhead/test/unit/server/tagPriority.test.ts
@@ -25,6 +25,7 @@ describe('tag priority', () => {
       [
         {
           "_d": undefined,
+          "_h": "script:src:/very-important-script.js",
           "_p": 1024,
           "_w": 42,
           "props": {
@@ -35,6 +36,7 @@ describe('tag priority', () => {
         },
         {
           "_d": undefined,
+          "_h": "script:src:/not-important-script.js",
           "_p": 2048,
           "_w": 50,
           "props": {

--- a/packages/vue/test/unit/promises.test.ts
+++ b/packages/vue/test/unit/promises.test.ts
@@ -36,6 +36,7 @@ describe('vue promises', () => {
         },
         {
           "_d": undefined,
+          "_h": "script:src:https://example.com/script.js",
           "_p": 1025,
           "_w": 50,
           "props": {


### PR DESCRIPTION
### 🔗 Linked issue

Closes #666

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Tags without an explicit dedup key (`script[src]`, `link[href]`) were keyed by their unique position index during tag resolution, so identical tags from separate entries were never deduplicated within the same render cycle.

Now falls back to `hashTag()` (content-based hash) instead of position index, so matching tags collide and deduplicate correctly. The hash is precomputed during normalization and cached on `_h` to avoid recomputation in the DOM renderer.