### PR TITLE
chore: fix typecheck errors in CI

### DIFF
--- a/packages/schema-org/test/ssr/dupes.test.ts
+++ b/packages/schema-org/test/ssr/dupes.test.ts
@@ -63,7 +63,6 @@ describe('schema.org dupes', () => {
         {
           type: 'application/ld+json',
           key: 'schema-org-graph',
-          // @ts-expect-error untyped
           nodes: [
             defineWebSite({
               url: '/',
@@ -75,7 +74,6 @@ describe('schema.org dupes', () => {
         {
           type: 'application/ld+json',
           key: 'schema-org-graph',
-          // @ts-expect-error untyped
           nodes: [
             // @ts-expect-error broken
             defineWebSite({
@@ -86,14 +84,13 @@ describe('schema.org dupes', () => {
         {
           type: 'application/ld+json',
           key: 'schema-org-graph',
-          // @ts-expect-error untyped
           nodes: [
             defineWebSite({
               name: 'third',
             }),
           ],
         },
-      ],
+      ] as any,
     })
 
     const data = await renderSSRHead(ssrHead)

--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -5,7 +5,6 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { defineProject } from 'vitest/config'
 
 export default defineProject({
-  // @ts-expect-error vite version mismatch between svelte plugin and vitest
   plugins: [svelte({ compilerOptions: { generate: 'client' } as any })],
   resolve: {
     conditions: ['browser'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,8 @@
     "examples",
     "bench",
     "packages/angular",
-    "packages/addons"
+    "packages/addons",
+    "**/stream/vite.ts",
+    "**/vite-plugin.test.ts"
   ]
 }


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Fixes the broken CI typecheck on v3 by addressing three issues:

- **tsconfig.json**: Exclude `**/stream/vite.ts` and `**/vite-plugin.test.ts` from typecheck — these depend on optional build-time packages (`vite`, `magic-string`, `oxc-walker`) that aren't installed for the root `vue-tsc` pass
- **schema-org dupes test**: Cast script entries with untyped `nodes` property as `any` to avoid discriminated union mismatch (`application/ld+json` vs `application/json`)
- **svelte vitest config**: Remove stale `@ts-expect-error` for a vite version mismatch that no longer exists