### PR TITLE
docs: improve SEO for schema.org pages and React Helmet migration

### DIFF
--- a/docs/0.react/head/guides/0.get-started/migrate-from-react-helmet.md
+++ b/docs/0.react/head/guides/0.get-started/migrate-from-react-helmet.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating from React Helmet to Unhead
-description: 'Replace React Helmet with Unhead. Smaller bundle size (4.5kb gzipped), TypeScript support, and modern features.'
+description: 'Replace React Helmet with Unhead - 60% smaller bundle (4.5kb gzipped), automatic Capo.js tag sorting, TypeScript support, and modern head management.'
 navigation:
   title: 'Migrate React Helmet'
 ---
@@ -11,16 +11,16 @@ navigation:
 
 [React Helmet](https://github.com/nfl/react-helmet) was the go-to solution for managing `<head>` tags in React applications for years. However, its last major release was in 2020 and the project is now in maintenance mode.
 
-Outside of regular maintenance [Unhead](/) offers a modern alternative with:
+::tip{icon="i-heroicons-scale"}
+**Bundle size:** React Helmet 26.6 kB (9.2 kB gzipped) → Unhead 10.7 kB (4.5 kB gzipped) — **60% smaller**
+::
+
+[Unhead](/) offers a modern alternative with:
 - Full TypeScript safety
 - DOM event handlers
 - Advanced DOM patching algorithm built for reactive frameworks
+- Automatic [Capo.js-based tag sorting](/docs/head/guides/core-concepts/positions) for optimal page load performance
 - Ecosystem of extras: `useSchemaOrg()`{lang="ts"}, `useScript()`{lang="ts"}, and more
-- Intelligent tag sorting for improved performance
-
-As well as a improved bundle size:
-- REACT HELMET Size: 26.6 kB (gzipped: 9.2 kB)
-- UNHEAD Size: 10.7 kB (gzipped: 4.5 kB)
 
 ## What's the Difference Between React Helmet and Unhead?
 

--- a/docs/head/1.guides/0.get-started/0.overview.md
+++ b/docs/head/1.guides/0.get-started/0.overview.md
@@ -1,6 +1,6 @@
 ---
-title: "Welcome To Unhead"
-description: "Framework-agnostic head management for Vue, React, Svelte, Solid, Angular. Manage titles, meta tags, scripts with SSR support."
+title: "Unhead - Head Management for Vue, React, Svelte & More"
+description: "Framework-agnostic library for managing HTML head tags. Titles, meta tags, scripts, and structured data with SSR support for Vue, React, Svelte, Solid, Angular."
 navigation:
   title: "Overview"
 ---

--- a/docs/schema-org/5.api/9.schema/article.md
+++ b/docs/schema-org/5.api/9.schema/article.md
@@ -1,7 +1,43 @@
 ---
-title: Article Schema
-description: Use defineArticle() to add Article structured data to your pages. Enable rich snippets for blog posts, news, and content with author, date, and image information.
+title: Article Schema - JSON-LD Guide & Examples
+description: Implement Article structured data with Unhead. JSON-LD examples for BlogPosting, NewsArticle, TechArticle with datePublished and author markup.
+navigation:
+  title: Article
 ---
+
+Article schema identifies written content like blog posts, news articles, and technical documentation. It helps search engines understand authorship, publish dates, and content type for rich results in Google Search.
+
+### JSON-LD Example
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Build a REST API with Node.js",
+  "image": "https://example.com/photos/api-guide.jpg",
+  "datePublished": "2026-01-15T08:00:00+00:00",
+  "dateModified": "2026-02-20T10:30:00+00:00",
+  "author": {
+    "@type": "Person",
+    "name": "Jane Smith",
+    "url": "https://example.com/authors/jane"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Dev Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png"
+    }
+  }
+}
+```
+
+With Unhead, generate this using the `defineArticle()` composable — see the [API reference](#schema-org-article) below.
+
+::tip{icon="i-heroicons-wrench-screwdriver"}
+Use the [Schema.org Generator](/tools/schema-generator) to build your structured data visually.
+::
 
 ## Schema.org Article
 

--- a/docs/schema-org/5.api/9.schema/how-to.md
+++ b/docs/schema-org/5.api/9.schema/how-to.md
@@ -1,7 +1,40 @@
 ---
-title: HowTo Schema
-description: Use defineHowTo() to add HowTo structured data. Enable step-by-step rich snippets with images and time estimates in Google search results.
+title: HowTo Schema - JSON-LD Guide & Examples
+description: Add HowTo structured data to your site with Unhead. Step-by-step JSON-LD examples, required properties, and Google rich result guidance.
+navigation:
+  title: HowTo
 ---
+
+HowTo schema marks up step-by-step instructions so Google can display them as rich results with expandable steps. Use it for tutorials, guides, DIY instructions, and how-to content.
+
+### JSON-LD Example
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Tie a Tie",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "text": "Drape the tie around your neck with the wide end on your right, about 1/3 longer than the narrow end.",
+      "image": "https://example.com/step1.jpg"
+    },
+    {
+      "@type": "HowToStep",
+      "text": "Cross the wide end over the narrow end, then bring it underneath.",
+      "image": "https://example.com/step2.jpg"
+    }
+  ],
+  "totalTime": "PT5M"
+}
+```
+
+With Unhead, generate this using the `defineHowTo()` composable — see the [API reference](#schema-org-howto) below.
+
+::tip{icon="i-heroicons-wrench-screwdriver"}
+Use the [Schema.org Generator](/tools/schema-generator) to build your structured data visually.
+::
 
 ## Schema.org HowTo
 

--- a/docs/schema-org/5.api/9.schema/item-list.md
+++ b/docs/schema-org/5.api/9.schema/item-list.md
@@ -1,7 +1,43 @@
 ---
-title: ItemList Schema
-description: Use defineItemList() to add ItemList structured data. Create carousels and ordered lists for products, articles, and other content in search.
+title: ItemList Schema - JSON-LD Guide & Examples
+description: Add ItemList structured data with Unhead. JSON-LD examples for carousels, ranked lists, and product collections with Google rich result support.
+navigation:
+  title: ItemList
 ---
+
+ItemList schema represents an ordered or unordered list of items. Google uses it to display carousel rich results for recipes, products, courses, and other list-based content.
+
+### JSON-LD Example
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "url": "https://example.com/best-phones/iphone"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "url": "https://example.com/best-phones/pixel"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "url": "https://example.com/best-phones/galaxy"
+    }
+  ]
+}
+```
+
+With Unhead, generate this using the `defineItemList()` composable — see the [API reference](#schema-org-itemlist) below.
+
+::tip{icon="i-heroicons-wrench-screwdriver"}
+Use the [Schema.org Generator](/tools/schema-generator) to build your structured data visually.
+::
 
 ## Schema.org ItemList
 

--- a/docs/schema-org/5.api/9.schema/job-posting.md
+++ b/docs/schema-org/5.api/9.schema/job-posting.md
@@ -1,7 +1,54 @@
 ---
-title: Job Posting Schema
-description: Use defineJobPosting() to add JobPosting structured data. Display job listings with salary, location, and apply buttons in Google Jobs search.
+title: JobPosting Schema - JSON-LD Guide & Examples
+description: Implement JobPosting structured data with Unhead. JSON-LD examples, required fields for Google Jobs, salary markup, and validation tips.
+navigation:
+  title: JobPosting
 ---
+
+JobPosting schema enables your job listings to appear in Google Jobs search results with salary, location, and application details. It's required for Google Jobs integration.
+
+### JSON-LD Example
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "JobPosting",
+  "title": "Software Engineer",
+  "description": "We are looking for a Software Engineer to join our team.",
+  "datePosted": "2026-01-15",
+  "validThrough": "2026-04-15",
+  "employmentType": "FULL_TIME",
+  "hiringOrganization": {
+    "@type": "Organization",
+    "name": "Acme Corp",
+    "sameAs": "https://acme.com"
+  },
+  "jobLocation": {
+    "@type": "Place",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "San Francisco",
+      "addressRegion": "CA",
+      "addressCountry": "US"
+    }
+  },
+  "baseSalary": {
+    "@type": "MonetaryAmount",
+    "currency": "USD",
+    "value": {
+      "@type": "QuantitativeValue",
+      "value": 120000,
+      "unitText": "YEAR"
+    }
+  }
+}
+```
+
+With Unhead, generate this using the `defineJobPosting()` composable — see the [API reference](#schema-org-job-posting) below.
+
+::tip{icon="i-heroicons-wrench-screwdriver"}
+Use the [Schema.org Generator](/tools/schema-generator) to build your structured data visually.
+::
 
 ## Schema.org Job Posting
 

--- a/docs/schema-org/5.api/9.schema/local-business.md
+++ b/docs/schema-org/5.api/9.schema/local-business.md
@@ -1,7 +1,46 @@
 ---
-title: Local Business Schema
-description: Use defineLocalBusiness() to add LocalBusiness structured data. Display your business address, hours, and contact info in Google Maps and local search.
+title: LocalBusiness Schema - JSON-LD Guide & Examples
+description: Implement LocalBusiness structured data with Unhead. JSON-LD examples, required properties, subtypes (Dentist, Restaurant, Store), and Google rich result setup.
+navigation:
+  title: LocalBusiness
 ---
+
+LocalBusiness schema tells search engines about a physical business location — its name, address, opening hours, and services. It powers Google's local business panels, Maps listings, and "near me" search results.
+
+For better visibility, use a specific subtype like `Dentist`, `Restaurant`, or `ProfessionalService` rather than the generic `LocalBusiness` type.
+
+### JSON-LD Example
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "name": "Dave's Steak House",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "148 W 51st St",
+    "addressLocality": "New York",
+    "addressRegion": "NY",
+    "postalCode": "10019",
+    "addressCountry": "US"
+  },
+  "telephone": "+12122459600",
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+      "opens": "11:30",
+      "closes": "23:00"
+    }
+  ]
+}
+```
+
+With Unhead, generate this using the `defineLocalBusiness()` composable — see the [API reference](#schema-org-localbusiness) below.
+
+::tip{icon="i-heroicons-wrench-screwdriver"}
+Use the [Schema.org Generator](/tools/schema-generator) to build your structured data visually.
+::
 
 ## Schema.org LocalBusiness
 

--- a/docs/schema-org/5.api/9.schema/organization.md
+++ b/docs/schema-org/5.api/9.schema/organization.md
@@ -1,7 +1,39 @@
 ---
-title: Organization Schema
-description: Use defineOrganization() to add Organization structured data. Display your company logo, social profiles, and contact info in Google Knowledge Panel.
+title: Organization Schema - JSON-LD Guide & Examples
+description: Add Organization structured data with Unhead. JSON-LD examples for company identity, logo, sameAs social profiles, and Google Knowledge Panel setup.
+navigation:
+  title: Organization
 ---
+
+Organization schema establishes your company or brand identity for search engines. It powers Google's Knowledge Panel, connects social profiles via `sameAs`, and serves as the publisher/author identity for other schema types like Article and LocalBusiness.
+
+### JSON-LD Example
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Acme Corp",
+  "url": "https://acme.com",
+  "logo": "https://acme.com/logo.png",
+  "sameAs": [
+    "https://twitter.com/acme",
+    "https://github.com/acme",
+    "https://linkedin.com/company/acme"
+  ],
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "telephone": "+1-800-555-0199",
+    "contactType": "customer service"
+  }
+}
+```
+
+With Unhead, generate this using the `defineOrganization()` composable — see the [API reference](#schema-org-organization) below.
+
+::tip{icon="i-heroicons-wrench-screwdriver"}
+Use the [Schema.org Generator](/tools/schema-generator) to build your structured data visually.
+::
 
 ## Schema.org Organization
 

--- a/docs/schema-org/5.api/9.schema/software-app.md
+++ b/docs/schema-org/5.api/9.schema/software-app.md
@@ -1,7 +1,39 @@
 ---
-title: Software App Schema
-description: Use defineSoftwareApp() to add SoftwareApplication structured data. Enable app rich results with ratings, pricing, and download info in search.
+title: SoftwareApplication Schema - JSON-LD Guide & Examples
+description: Implement SoftwareApplication structured data with Unhead. JSON-LD examples for app listings, ratings, pricing, and Google rich results.
+navigation:
+  title: SoftwareApplication
 ---
+
+SoftwareApplication schema describes a software product with its features, pricing, ratings, and platform compatibility. It enables rich result display in Google Search with star ratings and pricing information.
+
+### JSON-LD Example
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Photo Editor Pro",
+  "operatingSystem": "Windows, macOS",
+  "applicationCategory": "DesignApplication",
+  "offers": {
+    "@type": "Offer",
+    "price": "9.99",
+    "priceCurrency": "USD"
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.7",
+    "ratingCount": 1250
+  }
+}
+```
+
+With Unhead, generate this using the `defineSoftwareApp()` composable — see the [API reference](#schema-org-softwareapp) below.
+
+::tip{icon="i-heroicons-wrench-screwdriver"}
+Use the [Schema.org Generator](/tools/schema-generator) to build your structured data visually.
+::
 
 ## Schema.org SoftwareApp
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A — driven by GSC data analysis showing 20,000+ impressions with near-zero CTR on schema.org pages.

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Schema.org API reference pages (LocalBusiness, HowTo, JobPosting, ItemList, Article, Organization, SoftwareApp) collectively receive 20,000+ Google impressions per quarter but have near-zero click-through rate (0.03% CTR). Searchers expect "What is X schema?" guides with JSON-LD examples, but our pages are pure API reference.

Changes:
- **7 schema type pages**: Added search-intent intro sections explaining what each schema type does, copy-paste JSON-LD examples, SEO-optimized titles/descriptions, and cross-links to the Schema.org Generator tool
- **Overview page**: Updated title from "Welcome To Unhead" to match "vuejs seo" search intent (currently ranking pos 3.2 with only 0.2% CTR)
- **React Helmet migration**: Improved meta description, added Capo.js tag sorting as a value prop, reformatted bundle size comparison as a prominent callout

Target: Move schema pages from 0.03% to 2-3% CTR = 300-500 new monthly clicks.