### PR TITLE
chore: add deprecation warnings to aliased packages

### DIFF
--- a/packages-aliased/dom/package.json
+++ b/packages-aliased/dom/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"
   },
-  "sideEffects": false,
+  "sideEffects": true,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages-aliased/dom/src/index.ts
+++ b/packages-aliased/dom/src/index.ts
@@ -1,1 +1,3 @@
+console.warn('[unhead] `@unhead/dom` is deprecated. Please migrate to `unhead/client` instead.')
+
 export * from 'unhead/client'

--- a/packages-aliased/shared/package.json
+++ b/packages-aliased/shared/package.json
@@ -23,7 +23,7 @@
     "meta tags",
     "types"
   ],
-  "sideEffects": false,
+  "sideEffects": true,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages-aliased/shared/src/index.ts
+++ b/packages-aliased/shared/src/index.ts
@@ -1,1 +1,3 @@
+console.warn('[unhead] `@unhead/shared` is deprecated. Please migrate to `unhead/utils` instead.')
+
 export * from 'unhead/utils'

--- a/packages-aliased/ssr/package.json
+++ b/packages-aliased/ssr/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"
   },
-  "sideEffects": false,
+  "sideEffects": true,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages-aliased/ssr/src/index.ts
+++ b/packages-aliased/ssr/src/index.ts
@@ -1,1 +1,3 @@
+console.warn('[unhead] `@unhead/ssr` is deprecated. Please migrate to `unhead/server` instead.')
+
 export * from 'unhead/server'


### PR DESCRIPTION
## Summary
- Adds console.warn deprecation notices to `@unhead/dom`, `@unhead/shared`, and `@unhead/ssr` alias packages
- Users are directed to migrate to `unhead/dom`, `unhead/shared`, `unhead/ssr` respectively
- Re-exports still work, just with a warning

Closes #531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * @unhead/dom is deprecated; migrate to unhead/client.
  * @unhead/shared is deprecated; migrate to unhead/utils.
  * @unhead/ssr is deprecated; migrate to unhead/server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->