### PR TITLE
fix: respect user-provided twitter:card in InferSeoMetaPlugin

### DIFF
--- a/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
@@ -23,13 +23,19 @@ export interface InferSeoMetaPluginOptions {
 
 export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
   return defineHeadPlugin((head) => {
+    if (options.twitterCard !== false) {
+      head.push({
+        meta: [
+          {
+            name: 'twitter:card',
+            content: options.twitterCard || 'summary_large_image',
+            tagPriority: 'low',
+          },
+        ],
+      })
+    }
     head.push({
       meta: [
-        {
-          name: 'twitter:card',
-          content: options.twitterCard || 'summary_large_image',
-          tagPriority: 'low',
-        },
         {
           'property': 'og:title',
           'tagPriority': 'low',

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -1,5 +1,6 @@
 import { renderSSRHead } from '@unhead/ssr'
 import { describe, it } from 'vitest'
+import { useHead, useSeoMeta } from '../../../src'
 import { InferSeoMetaPlugin, TemplateParamsPlugin } from '../../../src/plugins'
 import { createHead } from '../../../src/server'
 
@@ -329,6 +330,46 @@ describe('inferSeoMetaPlugin', () => {
       "<title>Nuxt SEO – Hello World</title>
       <meta name="twitter:card" content="summary_large_image">
       <meta property="og:title" data-infer="" content="Nuxt SEO – Hello World">"
+    `)
+  })
+
+  it('user twitterCard via useSeoMeta overrides plugin default (#555)', () => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin()],
+    })
+
+    useSeoMeta(head, { twitterCard: 'summary' })
+
+    const result = renderSSRHead(head)
+    expect(result.headTags).toMatchInlineSnapshot(`"<meta name="twitter:card" content="summary">"`)
+  })
+
+  it('user twitter:card via useHead overrides plugin default (#555)', () => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin()],
+    })
+
+    useHead(head, { meta: [{ name: 'twitter:card', content: 'summary' }] })
+
+    const result = renderSSRHead(head)
+    expect(result.headTags).toMatchInlineSnapshot(`"<meta name="twitter:card" content="summary">"`)
+  })
+
+  it('plugin twitterCard: false disables twitter:card output (#555)', () => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin({ twitterCard: false })],
+    })
+
+    head.push({ title: 'My Title' })
+
+    const result = renderSSRHead(head)
+    expect(result.headTags).not.toContain('twitter:card')
+    expect(result.headTags).toMatchInlineSnapshot(`
+      "<title>My Title</title>
+      <meta property="og:title" data-infer="" content="My Title">"
     `)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #555

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `InferSeoMetaPlugin` used `||` to fall back to `'summary_large_image'` for `twitterCard`, which meant passing `twitterCard: false` to disable the output was ignored. Wrapped the twitter:card meta push in `if (options.twitterCard !== false)` so users can opt out entirely. The existing `tagPriority: 'low'` mechanism already handles runtime overrides via `useSeoMeta`/`useHead`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Twitter card meta tag handling is now configurable—users can disable it or customize the card type through settings
  * Existing configurations remain unaffected

* **Tests**
  * Added comprehensive test coverage for Twitter card customization and disable scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->