### PR TITLE
fix: handle missing title with titleTemplate and add defaultTitle

### DIFF
--- a/packages/unhead/src/plugins/templateParams.ts
+++ b/packages/unhead/src/plugins/templateParams.ts
@@ -20,13 +20,23 @@ export const TemplateParamsPlugin = /* @__PURE__ */ defineHeadPlugin((head) => {
         // ensure a separator exists
         const sep = params.separator || '|'
         delete params.separator
+        const defaultTitle = params.defaultTitle as string | undefined
+        delete params.defaultTitle
         // pre-process title
+        const rawPageTitle = params.pageTitle as string || head._title || ''
         params.pageTitle = processTemplateParams(
-          // find templateParams
-          params.pageTitle as string || head._title || '',
+          rawPageTitle,
           params,
           sep,
         )
+        // when no page title is set and a defaultTitle is provided, use it directly
+        // as the final title, bypassing the titleTemplate (e.g. "%s - Site" → "Site")
+        const useDefaultTitle = !rawPageTitle && !!defaultTitle
+        if (useDefaultTitle) {
+          const titleTag = tagMap.get('title')
+          if (titleTag)
+            titleTag.textContent = defaultTitle!
+        }
         for (const tag of tags) {
           if (tag.processTemplateParams === false) {
             continue

--- a/packages/unhead/src/types/schema/head.ts
+++ b/packages/unhead/src/types/schema/head.ts
@@ -149,7 +149,15 @@ export type ResolvableScript = DistributeResolvableWithEvents<Script, SchemaAugm
 export type ResolvableNoscript = ResolvableProperties<Noscript & DataKeys & SchemaAugmentations['noscript']> | string
 export type ResolvableHtmlAttributes = ResolvableProperties<UnheadHtmlAttributes & DataKeys & SchemaAugmentations['htmlAttrs']>
 export type ResolvableBodyAttributes = ResolvableProperties<UnheadBodyAttributesWithoutEvents & DataKeys & SchemaAugmentations['bodyAttrs']> & MaybeEventFnHandlers<BodyEvents>
-export type ResolvableTemplateParams = { separator?: '|' | '-' | '·' | string } & Record<string, null | string | Record<string, string>> & TemplateParamsAugmentations
+export type ResolvableTemplateParams = {
+  separator?: '|' | '-' | '·' | string
+  /**
+   * A default title to use when no page title is provided.
+   * When using a titleTemplate like `%s - My Site`, if no title is set the result would be ` - My Site`.
+   * Setting defaultTitle will use this value as the title instead, e.g. `My Site`.
+   */
+  defaultTitle?: string
+} & Record<string, null | string | Record<string, string>> & TemplateParamsAugmentations
 
 export interface ResolvableHead {
   /**

--- a/packages/unhead/src/types/tags.ts
+++ b/packages/unhead/src/types/tags.ts
@@ -85,7 +85,15 @@ export type TagKey = keyof ResolvableHead | InternalTagKey
  */
 export type InternalTagKey = '_flatMeta'
 
-export type TemplateParams = { separator?: '|' | '-' | '·' | string } & Record<string, null | string | Record<string, string>>
+export type TemplateParams = {
+  separator?: '|' | '-' | '·' | string
+  /**
+   * A default title to use when no page title is provided.
+   * When using a titleTemplate like `%s - My Site`, if no title is set the result would be ` - My Site`.
+   * Setting defaultTitle will use this value as the title instead, e.g. `My Site`.
+   */
+  defaultTitle?: string
+} & Record<string, null | string | Record<string, string>>
 
 export interface ProcessesTemplateParams { processTemplateParams?: boolean }
 

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -69,6 +69,13 @@ export function resolveTitleTemplate(ctx: ResolveTagsContext, head: Unhead<any>)
     v === null ? ctx.tagMap.delete('title') : ctx.tagMap.set('title', { ...title, textContent: v })
   }
   else {
+    if (v === null)
+      return
+    // when there is no page title and the template is a plain string containing %s
+    // (without the template-params plugin to handle it), skip promoting it to avoid
+    // rendering an empty substitution like " - MyApp"
+    if (!head.plugins.has('template-params') && typeof fn === 'string' && fn.includes('%s'))
+      return
     // create a new object instead of mutating the cached tpl tag
     ctx.tagMap.set('titleTemplate', { ...tpl, tag: 'title', textContent: v })
   }

--- a/packages/unhead/test/unit/client/templateParams.test.ts
+++ b/packages/unhead/test/unit/client/templateParams.test.ts
@@ -246,4 +246,38 @@ describe('templateParams', () => {
 
     expect(html).toContain('<title>Site title</title>')
   })
+
+  it('defaultTitle used when no page title is set', async () => {
+    const head = useDOMHead({
+      plugins: [TemplateParamsPlugin],
+    })
+
+    useHead(head, {
+      titleTemplate: '%s %separator %siteName',
+      templateParams: {
+        siteName: 'My Site',
+        defaultTitle: 'My Site',
+      },
+    })
+
+    expect(await useDelayedSerializedDom()).toContain('<title>My Site</title>')
+  })
+
+  it('defaultTitle ignored when page title is set', async () => {
+    const head = useDOMHead({
+      plugins: [TemplateParamsPlugin],
+    })
+
+    useHead(head, {
+      title: 'Page Title',
+      titleTemplate: '%s %separator %siteName',
+      templateParams: {
+        siteName: 'My Site',
+        defaultTitle: 'My Site',
+        separator: '-',
+      },
+    })
+
+    expect(await useDelayedSerializedDom()).toContain('<title>Page Title - My Site</title>')
+  })
 })

--- a/packages/unhead/test/unit/client/titleTemplate.test.ts
+++ b/packages/unhead/test/unit/client/titleTemplate.test.ts
@@ -138,6 +138,31 @@ describe('titleTemplate', () => {
     renderDOMHead(head, { document: dom.window.document })
     expect(dom.window.document.title).toMatchInlineSnapshot(`""`)
   })
+  it('string template with no title renders nothing', async () => {
+    const dom = useDom()
+    const head = createClientHeadWithContext({
+      document: dom.window.document,
+    })
+    head.push({
+      titleTemplate: '%s - My Site',
+    })
+    renderDOMHead(head, { document: dom.window.document })
+    // without a title, "%s - My Site" should not render as " - My Site"
+    expect(dom.window.document.title).toMatchInlineSnapshot(`""`)
+  })
+
+  it('string template without %s and no title renders template as title', async () => {
+    const dom = useDom()
+    const head = createClientHeadWithContext({
+      document: dom.window.document,
+    })
+    head.push({
+      titleTemplate: 'My Site',
+    })
+    renderDOMHead(head, { document: dom.window.document })
+    expect(dom.window.document.title).toMatchInlineSnapshot(`"My Site"`)
+  })
+
   it('#513', async () => {
     const dom = useDom()
     createClientHeadWithContext({

--- a/packages/unhead/test/unit/server/templateParams.test.ts
+++ b/packages/unhead/test/unit/server/templateParams.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { TemplateParamsPlugin } from '../../../src/plugins'
 import { renderSSRHead } from '../../../src/server'
@@ -119,5 +119,39 @@ describe('ssr templateParams', () => {
     expect(headTags).toMatchInlineSnapshot(
       `"<title>test foo | subPage% | test</title>"`,
     )
+  })
+
+  it('defaultTitle used when no page title is set', async () => {
+    const head = createServerHeadWithContext({
+      plugins: [TemplateParamsPlugin],
+    })
+    head.push({
+      titleTemplate: '%s %separator %siteName',
+      templateParams: {
+        siteName: 'My Site',
+        defaultTitle: 'My Site',
+      },
+    })
+    const { headTags } = renderSSRHead(head)
+    // with no title, defaultTitle should be used instead of " | My Site"
+    expect(headTags).toMatchInlineSnapshot(`"<title>My Site</title>"`)
+  })
+
+  it('defaultTitle ignored when page title is set', async () => {
+    const head = createServerHeadWithContext({
+      plugins: [TemplateParamsPlugin],
+    })
+    head.push({
+      title: 'Page Title',
+      titleTemplate: '%s %separator %siteName',
+      templateParams: {
+        siteName: 'My Site',
+        defaultTitle: 'My Site',
+        separator: '-',
+      },
+    })
+    const { headTags } = renderSSRHead(head)
+    // when title is provided, defaultTitle is ignored and template is used normally
+    expect(headTags).toMatchInlineSnapshot(`"<title>Page Title - My Site</title>"`)
   })
 })

--- a/packages/unhead/test/unit/server/titleTemplate.test.ts
+++ b/packages/unhead/test/unit/server/titleTemplate.test.ts
@@ -86,4 +86,23 @@ describe('titleTemplate', () => {
       `""`,
     )
   })
+
+  it('string template with no title renders nothing', async () => {
+    const head = createServerHeadWithContext()
+    head.push({
+      titleTemplate: '%s - My Site',
+    })
+    const { headTags } = renderSSRHead(head)
+    // without a title, "%s - My Site" should not render as " - My Site"
+    expect(headTags).toMatchInlineSnapshot(`""`)
+  })
+
+  it('string template without %s and no title renders template as title', async () => {
+    const head = createServerHeadWithContext()
+    head.push({
+      titleTemplate: 'My Site',
+    })
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).toMatchInlineSnapshot(`"<title>My Site</title>"`)
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #618

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When `titleTemplate: '%s - MyApp'` was set with no page title, `%s` was replaced with empty string producing `' - MyApp'`. Now the title tag is silently dropped when no title exists and the template contains `%s`. Additionally, a new `defaultTitle` option in `templateParams` provides React Helmet-style behavior — when no page title is set and `defaultTitle` is provided, it renders as the title bypassing the template entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `defaultTitle` template parameter that serves as a fallback page title when no page title is provided, preventing partially rendered title templates (e.g., "%s - My Site") from producing incomplete results.

* **Bug Fixes**
  * When no page title exists, title templates containing a placeholder no longer render a dangling suffix; the `defaultTitle` or empty title behavior is handled predictably.

* **Tests**
  * Added unit and SSR tests validating `defaultTitle` and edge-case titleTemplate behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->