### PR TITLE
feat(vue): add onHeadUpdated composable for DOM sync

### DIFF
--- a/packages/vue/src/autoImports.ts
+++ b/packages/vue/src/autoImports.ts
@@ -1,3 +1,3 @@
 export const unheadVueComposablesImports = {
-  '@unhead/vue': ['injectHead', 'useHead', 'useSeoMeta', 'useHeadSafe'],
+  '@unhead/vue': ['injectHead', 'onHeadUpdated', 'useHead', 'useSeoMeta', 'useHeadSafe'],
 }

--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -15,6 +15,7 @@ import {
   onActivated,
   onBeforeUnmount,
   onDeactivated,
+  onUnmounted,
   ref,
   watchEffect,
 } from 'vue'
@@ -86,3 +87,25 @@ export function useSeoMeta(input: UseSeoMetaInput = {}, options: UseHeadOptions 
 }
 
 export { useScript } from './scripts/useScript'
+
+/**
+ * Register a callback to be called after unhead has finished applying DOM updates.
+ * Useful for synchronising analytics tools (e.g. Amplitude) with the current page title.
+ *
+ * @example
+ * onHeadUpdated(({ renders }) => {
+ *   amplitude.track('Page View', { title: document.title })
+ * })
+ */
+export function onHeadUpdated(
+  callback: (ctx: { renders: import('unhead/types').DomRenderTagContext[] }) => void | Promise<void>,
+  options: { head?: import('unhead/types').Unhead<any> } = {},
+): () => void {
+  const head = options.head || injectHead()
+  const unhook = head.hooks.hook('dom:rendered', callback as any)
+  const vm = getCurrentInstance()
+  if (vm) {
+    onUnmounted(unhook)
+  }
+  return unhook
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,5 +1,5 @@
 export { unheadVueComposablesImports } from './autoImports'
-export { injectHead, useHead, useHeadSafe, useScript, useSeoMeta } from './composables'
+export { injectHead, onHeadUpdated, useHead, useHeadSafe, useScript, useSeoMeta } from './composables'
 export { headSymbol } from './install'
 export type * from './scripts/index'
 export type * from './types'

--- a/packages/vue/test/unit/dom/onHeadUpdated.test.ts
+++ b/packages/vue/test/unit/dom/onHeadUpdated.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { useDom } from '../../../../unhead/test/fixtures'
+import { onHeadUpdated, useHead } from '../../../src'
+import { renderDOMHead } from '../../../src/client'
+import { csrVueAppWithUnhead } from '../../util'
+
+describe('onHeadUpdated', () => {
+  it('calls callback after DOM is rendered', async () => {
+    const dom = useDom()
+    const callback = vi.fn()
+
+    const head = csrVueAppWithUnhead(dom, () => {
+      onHeadUpdated(callback)
+      useHead({ title: 'Hello World' })
+    })
+
+    renderDOMHead(head, { document: dom.window.document })
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(dom.window.document.title).toBe('Hello World')
+  })
+
+  it('callback receives renders context with tags', async () => {
+    const dom = useDom()
+    let capturedCtx: any
+
+    const head = csrVueAppWithUnhead(dom, () => {
+      onHeadUpdated((ctx) => {
+        capturedCtx = ctx
+      })
+      useHead({ title: 'Test Page' })
+    })
+
+    renderDOMHead(head, { document: dom.window.document })
+
+    expect(capturedCtx).toBeDefined()
+    expect(capturedCtx.renders).toBeInstanceOf(Array)
+    const titleRender = capturedCtx.renders.find((r: any) => r.tag.tag === 'title')
+    expect(titleRender).toBeDefined()
+    expect(titleRender.tag.textContent).toBe('Test Page')
+  })
+
+  it('called on every render', async () => {
+    const dom = useDom()
+    const callback = vi.fn()
+    const title = ref('Initial')
+
+    const head = csrVueAppWithUnhead(dom, () => {
+      onHeadUpdated(callback)
+      useHead({ title })
+    })
+
+    renderDOMHead(head, { document: dom.window.document })
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(dom.window.document.title).toBe('Initial')
+
+    title.value = 'Updated'
+    // wait for watchEffect to flush and mark head dirty
+    await nextTick()
+    renderDOMHead(head, { document: dom.window.document })
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(dom.window.document.title).toBe('Updated')
+  })
+
+  it('returns unsubscribe function that stops further callbacks', async () => {
+    const dom = useDom()
+    const callback = vi.fn()
+
+    const head = csrVueAppWithUnhead(dom, () => {
+      useHead({ title: 'Page' })
+    })
+
+    const unsub = onHeadUpdated(callback, { head })
+
+    renderDOMHead(head, { document: dom.window.document })
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    unsub()
+
+    head.push({ title: 'Page 2' })
+    renderDOMHead(head, { document: dom.window.document })
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #615

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Users had no way to synchronize analytics tools (Amplitude, etc.) with unhead's async DOM updates — `document.title` wasn't ready after `onMounted` + `nextTick`. Added `onHeadUpdated(callback)` composable that hooks into the internal `dom:rendered` event. Auto-cleans up via `onUnmounted` when used inside a component, or returns an unsubscribe function for manual control. Also added to Vue auto-imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `onHeadUpdated` composable that enables registering callbacks to execute after document head updates are applied. Callbacks receive render context information and automatically clean up on component unmount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->