### PR TITLE
feat(validate): add performance validation rules

### DIFF
--- a/docs/head/1.guides/plugins/validate.md
+++ b/docs/head/1.guides/plugins/validate.md
@@ -118,6 +118,21 @@ export interface ValidatePluginOptions {
 
 Typo detection only runs for recognized prefixes (`og:`, `article:`, `book:`, `profile:`, `fb:`, `twitter:`, or standard meta names without a colon). Custom prefixes like `custom:foo` are ignored.
 
+### Performance Hints
+
+Rules inspired by [webperf-snippets](https://webperf-snippets.nucliweb.net/) that catch common performance anti-patterns in head tags:
+
+| Rule ID | Severity | What it catches |
+|---------|----------|----------------|
+| `preload-fetchpriority-conflict` | `warn` | `<link rel="preload" fetchpriority="low">` is contradictory — preload signals critical, low priority contradicts that |
+| `too-many-preloads` | `warn` | More than 6 `<link rel="preload">` tags compete for bandwidth and hurt performance |
+| `too-many-preconnects` | `warn` | More than 4 `<link rel="preconnect">` tags — each initiates a TCP+TLS handshake, competing for limited connections |
+| `redundant-dns-prefetch` | `info` | Same origin has both `<link rel="preconnect">` and `<link rel="dns-prefetch">` — preconnect already includes DNS resolution |
+| `preload-async-defer-conflict` | `warn` | A script is preloaded but also has `async` or `defer` — preload escalates the priority, defeating the purpose |
+| `prefetch-preload-conflict` | `warn` | Same resource has both `preload` and `prefetch` — use preload for current page, prefetch for future navigation |
+| `inline-style-size` | `info` | Inline `<style>` exceeds 14KB (the critical CSS budget for the first TCP round-trip) |
+| `inline-script-size` | `info` | Inline `<script>` exceeds 2KB — consider moving to an external file for cacheability |
+
 ## How Do I Configure Rules?
 
 Rules can be disabled or have their severity overridden, similar to ESLint's flat config:
@@ -133,6 +148,23 @@ ValidatePlugin({
 })
 ```
 ::
+
+Some rules accept an options object as an ESLint-style `[severity, options]` tuple:
+
+::code-block
+```ts [Input]
+ValidatePlugin({
+  rules: {
+    'too-many-preloads': ['warn', { max: 10 }],
+    'too-many-preconnects': ['warn', { max: 6 }],
+    'inline-style-size': ['info', { maxKB: 20 }],
+    'inline-script-size': ['info', { maxKB: 5 }],
+  }
+})
+```
+::
+
+The configuration is fully type-safe — only rules that support options accept the tuple form, and options are typed per-rule.
 
 ## How Does Source Tracing Work?
 

--- a/packages/unhead/src/plugins/index.ts
+++ b/packages/unhead/src/plugins/index.ts
@@ -7,4 +7,4 @@ export { PromisesPlugin } from './promises' // optional
 export { SafeInputPlugin } from './safe' // optional
 export { TemplateParamsPlugin } from './templateParams' // optional
 export { ValidatePlugin } from './validate' // optional
-export type { HeadValidationRule, RuleSeverity, ValidatePluginOptions, ValidationRuleId } from './validate'
+export type { HeadValidationRule, RuleConfig, RulesConfig, RuleSeverity, ValidatePluginOptions, ValidationRuleId, ValidationRuleOptions } from './validate'

--- a/packages/unhead/src/plugins/validate.ts
+++ b/packages/unhead/src/plugins/validate.ts
@@ -8,6 +8,8 @@ export type ValidationRuleId
     | 'empty-meta-content'
     | 'empty-title'
     | 'html-in-title'
+    | 'inline-script-size'
+    | 'inline-style-size'
     | 'missing-description'
     | 'missing-title'
     | 'non-absolute-canonical'
@@ -16,13 +18,32 @@ export type ValidationRuleId
     | 'og-missing-description'
     | 'og-missing-title'
     | 'possible-typo'
+    | 'prefetch-preload-conflict'
+    | 'preload-async-defer-conflict'
+    | 'preload-fetchpriority-conflict'
     | 'preload-font-crossorigin'
     | 'preload-missing-as'
+    | 'redundant-dns-prefetch'
     | 'robots-conflict'
     | 'script-src-with-content'
+    | 'too-many-preconnects'
+    | 'too-many-preloads'
     | 'twitter-handle-missing-at'
     | 'unresolved-template-param'
     | 'viewport-user-scalable'
+
+export interface ValidationRuleOptions {
+  'inline-script-size': { maxKB: number }
+  'inline-style-size': { maxKB: number }
+  'too-many-preloads': { max: number }
+  'too-many-preconnects': { max: number }
+}
+
+export type RuleConfig<Id extends ValidationRuleId> = Id extends keyof ValidationRuleOptions
+  ? RuleSeverity | [severity: RuleSeverity, options: ValidationRuleOptions[Id]]
+  : RuleSeverity
+
+export type RulesConfig = { [K in ValidationRuleId]?: RuleConfig<K> }
 
 export interface HeadValidationRule {
   id: ValidationRuleId
@@ -39,9 +60,19 @@ export interface ValidatePluginOptions {
    */
   onReport?: (rules: HeadValidationRule[]) => void
   /**
-   * Configure rule severity. Set to 'off' to disable, or 'warn'/'info' to override severity.
+   * Configure rule severity and options. Accepts a severity string or an ESLint-style
+   * `[severity, options]` tuple for rules that support configuration.
+   *
+   * @example
+   * ```ts
+   * rules: {
+   *   'missing-description': 'off',
+   *   'too-many-preloads': ['warn', { max: 10 }],
+   *   'inline-style-size': ['info', { maxKB: 20 }],
+   * }
+   * ```
    */
-  rules?: Partial<Record<ValidationRuleId, RuleSeverity>>
+  rules?: RulesConfig
   /**
    * Project root path. When set, source locations are displayed as relative paths.
    */
@@ -206,6 +237,23 @@ function isAbsoluteUrl(url: string): boolean {
   return url.startsWith('http://') || url.startsWith('https://')
 }
 
+function resolveSeverity(config: RuleSeverity | [RuleSeverity, unknown] | undefined, fallback: RuleSeverity): RuleSeverity {
+  if (config == null)
+    return fallback
+  return Array.isArray(config) ? config[0] : config
+}
+
+function resolveOptions<Id extends keyof ValidationRuleOptions>(
+  config: RulesConfig,
+  id: Id,
+  defaults: ValidationRuleOptions[Id],
+): ValidationRuleOptions[Id] {
+  const entry = config[id]
+  if (Array.isArray(entry))
+    return { ...defaults, ...entry[1] }
+  return defaults
+}
+
 function captureSource(root?: string): string | undefined {
   const stack = new Error('source').stack
   if (!stack)
@@ -252,7 +300,7 @@ export function ValidatePlugin(options: ValidatePluginOptions = {}) {
           const rules: HeadValidationRule[] = []
 
           function report(id: ValidationRuleId, message: string, defaultSeverity: 'warn' | 'info', tag?: HeadTag) {
-            const severity = ruleConfig[id] ?? defaultSeverity
+            const severity = resolveSeverity(ruleConfig[id] as RuleSeverity | [RuleSeverity, unknown] | undefined, defaultSeverity)
             if (severity === 'off')
               return
             const entryIndex = tag?._p != null ? tag._p >> 10 : undefined
@@ -382,6 +430,31 @@ export function ValidatePlugin(options: ValidatePluginOptions = {}) {
 
             if (tag.tag === 'script' && props.src && (tag.innerHTML || tag.textContent))
               report('script-src-with-content', `Script has both "src" and inline content — the browser will ignore the inline content.`, 'warn', tag)
+
+            // === Performance Hints ===
+            // Inspired by webperf-snippets (https://webperf-snippets.nucliweb.net/)
+
+            // Preload + fetchpriority="low" is contradictory
+            if (tag.tag === 'link' && props.rel === 'preload' && props.fetchpriority === 'low')
+              report('preload-fetchpriority-conflict', `Preload with fetchpriority="low" is contradictory — preload signals critical, low priority contradicts that.`, 'warn', tag)
+
+            // Inline style size check (14KB critical CSS budget)
+            if (tag.tag === 'style' && (tag.innerHTML || tag.textContent)) {
+              const content = tag.innerHTML || tag.textContent || ''
+              const sizeKB = new TextEncoder().encode(content).byteLength / 1024
+              const { maxKB: styleMaxKB } = resolveOptions(ruleConfig, 'inline-style-size', { maxKB: 14 })
+              if (sizeKB > styleMaxKB)
+                report('inline-style-size', `Inline <style> is ${sizeKB.toFixed(1)}KB — exceeds ${styleMaxKB}KB critical CSS budget. Consider moving to an external stylesheet for cacheability.`, 'info', tag)
+            }
+
+            // Inline script size check (2KB threshold)
+            if (tag.tag === 'script' && !props.src && (tag.innerHTML || tag.textContent)) {
+              const content = tag.innerHTML || tag.textContent || ''
+              const sizeKB = new TextEncoder().encode(content).byteLength / 1024
+              const { maxKB: scriptMaxKB } = resolveOptions(ruleConfig, 'inline-script-size', { maxKB: 2 })
+              if (sizeKB > scriptMaxKB)
+                report('inline-script-size', `Inline <script> is ${sizeKB.toFixed(1)}KB — consider moving to an external file for cacheability.`, 'info', tag)
+            }
           }
 
           // === Cross-tag Validation ===
@@ -410,6 +483,64 @@ export function ValidatePlugin(options: ValidatePluginOptions = {}) {
           // Missing description (only when indexable)
           if (!hasDescription && isIndexable)
             report('missing-description', `Page is missing a meta description and is indexable by search engines.`, 'warn')
+
+          // === Performance Cross-tag Checks ===
+          // Inspired by webperf-snippets (https://webperf-snippets.nucliweb.net/)
+
+          // Too many preloads compete for bandwidth
+          const { max: maxPreloads } = resolveOptions(ruleConfig, 'too-many-preloads', { max: 6 })
+          const preloadCount = tags.filter((t: HeadTag) => t.tag === 'link' && t.props.rel === 'preload').length
+          if (preloadCount > maxPreloads)
+            report('too-many-preloads', `Found ${preloadCount} preload links — more than ${maxPreloads} preloads compete for bandwidth and can hurt performance.`, 'warn')
+
+          // Too many preconnects waste connections
+          const { max: maxPreconnects } = resolveOptions(ruleConfig, 'too-many-preconnects', { max: 4 })
+          const preconnectCount = tags.filter((t: HeadTag) => t.tag === 'link' && t.props.rel === 'preconnect').length
+          if (preconnectCount > maxPreconnects)
+            report('too-many-preconnects', `Found ${preconnectCount} preconnect links — each initiates a TCP+TLS handshake, more than ${maxPreconnects} compete for limited connections.`, 'warn')
+
+          // Redundant dns-prefetch when preconnect exists for same origin
+          const preconnectOrigins = new Set<string>()
+          const dnsPrefetchTags: HeadTag[] = []
+          for (const tag of tags) {
+            if (tag.tag === 'link' && tag.props.href) {
+              if (tag.props.rel === 'preconnect')
+                preconnectOrigins.add(tag.props.href)
+              else if (tag.props.rel === 'dns-prefetch')
+                dnsPrefetchTags.push(tag)
+            }
+          }
+          for (const tag of dnsPrefetchTags) {
+            if (preconnectOrigins.has(tag.props.href))
+              report('redundant-dns-prefetch', `dns-prefetch for "${tag.props.href}" is redundant — preconnect already includes DNS resolution.`, 'info', tag)
+          }
+
+          // Preload + async/defer script conflict (priority escalation anti-pattern)
+          const preloadScriptHrefs = new Map<string, HeadTag>()
+          for (const tag of tags) {
+            if (tag.tag === 'link' && tag.props.rel === 'preload' && tag.props.as === 'script' && tag.props.href)
+              preloadScriptHrefs.set(tag.props.href, tag)
+          }
+          for (const tag of tags) {
+            if (tag.tag === 'script' && tag.props.src && (tag.props.async || tag.props.defer)) {
+              const preloadTag = preloadScriptHrefs.get(tag.props.src)
+              if (preloadTag) {
+                const attr = tag.props.async ? 'async' : 'defer'
+                report('preload-async-defer-conflict', `Script "${tag.props.src}" is preloaded but has "${attr}" — preload escalates priority, defeating the purpose of ${attr}. Remove the preload or add fetchpriority="low" to the script.`, 'warn', preloadTag)
+              }
+            }
+          }
+
+          // Prefetch + preload conflict (should be one or the other)
+          const preloadHrefs = new Set<string>()
+          for (const tag of tags) {
+            if (tag.tag === 'link' && tag.props.rel === 'preload' && tag.props.href)
+              preloadHrefs.add(tag.props.href)
+          }
+          for (const tag of tags) {
+            if (tag.tag === 'link' && tag.props.rel === 'prefetch' && tag.props.href && preloadHrefs.has(tag.props.href))
+              report('prefetch-preload-conflict', `"${tag.props.href}" has both preload and prefetch — use preload for current page resources, prefetch for future navigation.`, 'warn', tag)
+          }
 
           // Dispatch
           if (rules.length) {

--- a/packages/unhead/test/unit/plugins/validate.test.ts
+++ b/packages/unhead/test/unit/plugins/validate.test.ts
@@ -599,4 +599,244 @@ describe('validatePlugin', () => {
       expect(rules.length).toBeGreaterThanOrEqual(2)
     })
   })
+
+  describe('performance hints', () => {
+    it('warns on preload with fetchpriority="low"', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: [{ rel: 'preload', href: '/font.woff2', as: 'font', crossorigin: 'anonymous', fetchpriority: 'low' as const }],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'preload-fetchpriority-conflict')).toBeTruthy()
+    })
+
+    it('does not warn on preload with fetchpriority="high"', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: [{ rel: 'preload', href: '/font.woff2', as: 'font', crossorigin: 'anonymous', fetchpriority: 'high' as const }],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'preload-fetchpriority-conflict')).toBeFalsy()
+    })
+
+    it('warns when more than 6 preloads exist', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: Array.from({ length: 7 }, (_, i) => ({
+          rel: 'preload' as const,
+          href: `/resource-${i}.js`,
+          as: 'script' as const,
+        })),
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'too-many-preloads')).toBeTruthy()
+    })
+
+    it('does not warn when 6 or fewer preloads exist', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: Array.from({ length: 6 }, (_, i) => ({
+          rel: 'preload' as const,
+          href: `/resource-${i}.js`,
+          as: 'script' as const,
+        })),
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'too-many-preloads')).toBeFalsy()
+    })
+
+    it('warns on redundant dns-prefetch when preconnect exists', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: [
+          { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+          { rel: 'dns-prefetch', href: 'https://fonts.googleapis.com' },
+        ],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'redundant-dns-prefetch')).toBeTruthy()
+    })
+
+    it('does not warn on dns-prefetch without matching preconnect', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: [
+          { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+          { rel: 'dns-prefetch', href: 'https://cdn.example.com' },
+        ],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'redundant-dns-prefetch')).toBeFalsy()
+    })
+
+    it('warns on preload + async script conflict', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: [{ rel: 'preload', href: '/analytics.js', as: 'script' as const }],
+        script: [{ src: '/analytics.js', async: true }],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'preload-async-defer-conflict')).toBeTruthy()
+    })
+
+    it('warns on preload + defer script conflict', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: [{ rel: 'preload', href: '/app.js', as: 'script' as const }],
+        script: [{ src: '/app.js', defer: true }],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'preload-async-defer-conflict')).toBeTruthy()
+    })
+
+    it('does not warn on preload + blocking script', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: [{ rel: 'preload', href: '/critical.js', as: 'script' as const }],
+        script: [{ src: '/critical.js' }],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'preload-async-defer-conflict')).toBeFalsy()
+    })
+
+    it('warns on prefetch + preload conflict', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: [
+          { rel: 'preload', href: '/style.css', as: 'style' as const },
+          { rel: 'prefetch', href: '/style.css' },
+        ],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'prefetch-preload-conflict')).toBeTruthy()
+    })
+
+    it('does not warn on prefetch without matching preload', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: [
+          { rel: 'preload', href: '/style.css', as: 'style' as const },
+          { rel: 'prefetch', href: '/next-page.js' },
+        ],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'prefetch-preload-conflict')).toBeFalsy()
+    })
+
+    it('warns on large inline style (>14KB)', () => {
+      const { head, rules } = createValidationHead()
+      const largeCSS = 'a'.repeat(15 * 1024)
+      head.push({
+        style: [{ innerHTML: largeCSS }],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'inline-style-size')).toBeTruthy()
+    })
+
+    it('does not warn on small inline style', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        style: [{ innerHTML: 'body { color: red; }' }],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'inline-style-size')).toBeFalsy()
+    })
+
+    it('warns on large inline script (>2KB)', () => {
+      const { head, rules } = createValidationHead()
+      const largeJS = 'a'.repeat(3 * 1024)
+      head.push({
+        script: [{ innerHTML: largeJS }],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'inline-script-size')).toBeTruthy()
+    })
+
+    it('does not warn on small inline script', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        script: [{ innerHTML: 'console.log("hi")' }],
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'inline-script-size')).toBeFalsy()
+    })
+
+    it('warns when more than 4 preconnects exist', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: Array.from({ length: 5 }, (_, i) => ({
+          rel: 'preconnect' as const,
+          href: `https://cdn${i}.example.com`,
+        })),
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'too-many-preconnects')).toBeTruthy()
+    })
+
+    it('does not warn when 4 or fewer preconnects exist', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: Array.from({ length: 4 }, (_, i) => ({
+          rel: 'preconnect' as const,
+          href: `https://cdn${i}.example.com`,
+        })),
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'too-many-preconnects')).toBeFalsy()
+    })
+
+    it('respects custom max for too-many-preloads', () => {
+      const { head, rules } = createValidationHead({ rules: { 'too-many-preloads': ['warn', { max: 3 }] } })
+      head.push({
+        link: Array.from({ length: 4 }, (_, i) => ({
+          rel: 'preload' as const,
+          href: `/resource-${i}.js`,
+          as: 'script' as const,
+        })),
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'too-many-preloads')).toBeTruthy()
+    })
+
+    it('respects custom max for too-many-preconnects', () => {
+      const { head, rules } = createValidationHead({ rules: { 'too-many-preconnects': ['warn', { max: 2 }] } })
+      head.push({
+        link: Array.from({ length: 3 }, (_, i) => ({
+          rel: 'preconnect' as const,
+          href: `https://cdn${i}.example.com`,
+        })),
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'too-many-preconnects')).toBeTruthy()
+    })
+
+    it('respects custom maxKB for inline-style-size', () => {
+      const { head, rules } = createValidationHead({ rules: { 'inline-style-size': ['info', { maxKB: 1 }] } })
+      const css = 'a'.repeat(2 * 1024)
+      head.push({ style: [{ innerHTML: css }] })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'inline-style-size')).toBeTruthy()
+    })
+
+    it('respects custom maxKB for inline-script-size', () => {
+      const { head, rules } = createValidationHead({ rules: { 'inline-script-size': ['info', { maxKB: 1 }] } })
+      const js = 'a'.repeat(1.5 * 1024)
+      head.push({ script: [{ innerHTML: js }] })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'inline-script-size')).toBeTruthy()
+    })
+
+    it('tuple severity can disable a rule with options', () => {
+      const { head, rules } = createValidationHead({ rules: { 'too-many-preloads': ['off', { max: 3 }] } })
+      head.push({
+        link: Array.from({ length: 10 }, (_, i) => ({
+          rel: 'preload' as const,
+          href: `/resource-${i}.js`,
+          as: 'script' as const,
+        })),
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'too-many-preloads')).toBeFalsy()
+    })
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds 8 performance validation rules to the ValidatePlugin, inspired by [webperf-snippets](https://webperf-snippets.nucliweb.net/). These catch common performance anti-patterns in head tags:

- `preload-fetchpriority-conflict` — contradictory preload + low fetchpriority
- `too-many-preloads` — more than 6 preloads competing for bandwidth
- `too-many-preconnects` — more than 4 preconnects saturating connections
- `redundant-dns-prefetch` — dns-prefetch redundant when preconnect exists
- `preload-async-defer-conflict` — preloaded script with async/defer
- `prefetch-preload-conflict` — same resource both preloaded and prefetched
- `inline-style-size` — inline style exceeds 14KB critical CSS budget
- `inline-script-size` — inline script exceeds 2KB cacheability threshold

Also introduces ESLint-style type-safe rule configuration. Rules with options accept `[severity, options]` tuples with per-rule typed options:

```ts
ValidatePlugin({
  rules: {
    'too-many-preloads': ['warn', { max: 10 }],
    'inline-style-size': ['info', { maxKB: 20 }],
    'missing-description': 'off',
  }
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 8 new performance validation rules detecting oversized inline styles and scripts, excessive resource counts, and conflicting performance tags.
  * Enhanced rule configuration supporting per-rule options for customizable size limits and resource thresholds.

* **Documentation**
  * Added comprehensive "Performance Hints" documentation explaining all 9 validation rules with configuration examples and per-rule option settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->