### PR TITLE
fix: prioritize SEO meta tags above style tags

### DIFF
--- a/packages/unhead/src/server/sort.ts
+++ b/packages/unhead/src/server/sort.ts
@@ -15,15 +15,14 @@ const isTruthy = (v?: string | boolean) => v === '' || v === true
 // SEO meta tags that should appear before style tags for crawler visibility
 const SEO_META_NAMES = new Set(['description', 'keywords', 'author', 'robots', 'generator', 'theme-color'])
 function isSeoMeta(props: Record<string, unknown>): boolean {
-  const prop = String(props.property || '')
+  const prop = String(props.property || '').toLowerCase()
   if (prop.startsWith('og:') || prop.startsWith('twitter:') || prop.startsWith('fb:'))
     return true
   const name = String(props.name || '').toLowerCase()
   if (SEO_META_NAMES.has(name))
     return true
   // article:, book:, profile: prefixes are also SEO-related
-  const propLower = prop.toLowerCase()
-  return propLower.startsWith('article:') || propLower.startsWith('book:') || propLower.startsWith('profile:')
+  return prop.startsWith('article:') || prop.startsWith('book:') || prop.startsWith('profile:')
 }
 
 export function capoTagWeight(tag: HeadTag): number {

--- a/packages/unhead/test/unit/server/tagPriority.test.ts
+++ b/packages/unhead/test/unit/server/tagPriority.test.ts
@@ -309,7 +309,7 @@ describe('tag priority', () => {
         },
       ],
     })
-    const { headTags } = await renderSSRHead(head)
+    const { headTags } = renderSSRHead(head)
     // SEO meta tags should appear before style tags
     const ogIndex = headTags.indexOf('og:title')
     const styleIndex = headTags.indexOf('<style>')


### PR DESCRIPTION
Fixes #693

## Problem

SEO meta tags (`og:title`, `description`, etc.) are rendered **after** `<style>` tags in the SSR output. This hurts SEO because crawlers expect important meta tags near the top of `<head>`.

```js
// Current behavior:
// <style>body { background: red; }</style>
// <meta property="og:title" ...>
// <meta name="description" ...>

// Expected behavior:
// <meta property="og:title" ...>
// <meta name="description" ...>
// <style>body { background: red; }</style>
```

## Root Cause

`capoTagWeight()` in `sort.ts` assigns:
- `style` tags: weight 60 (sync) / 40 (imported)
- Generic `meta` tags: weight 100 (default fallback)

Lower weight = higher priority, so styles render first.

## Fix

1. Add `seo: 55` to `CAPO_WEIGHTS.meta` (between async scripts at 30 and sync styles at 60)
2. Add `isSeoMeta()` helper that detects SEO-related meta tags by:
   - `property` prefix: `og:`, `twitter:`, `fb:`, `article:`, `book:`, `profile:`
   - `name` value: `description`, `keywords`, `author`, `robots`, `generator`, `theme-color`
3. Update the meta tag detection in `capoTagWeight()` to use `isSeoMeta()`

## Changes

- `packages/unhead/src/server/sort.ts`: Add SEO meta detection and weight
- `packages/unhead/test/unit/server/tagPriority.test.ts`: Add test for SEO meta before style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Meta tag ordering optimized so SEO-related meta tags (Open Graph, Twitter, common description/author/robots, article/book/profile) are prioritized before style tags in the document head.

* **Tests**
  * Added unit test to validate that SEO meta tags appear earlier than inline style blocks in server-rendered head output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->