### PR TITLE
docs: update link reference in vue installation guide

### DIFF
--- a/docs/0.vue/head/guides/0.get-started/1.installation.md
+++ b/docs/0.vue/head/guides/0.get-started/1.installation.md
@@ -62,7 +62,7 @@ app.mount('#app')
 ### 3. Setup Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-your-first-tags) this step.
+Serving your app as an SPA? You can [skip](#_4-what-default-tags-does-unhead-add) this step.
 ::
 
 Setting up server-side rendering is more complicated as it requires rendering out the tags to the HTML string before sending it to the client.


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Fixes the reference link that skips setting up server-side rendering section in Vue installation guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved navigation flow in the installation guide for Single-Page Application users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->