### PR TITLE
fix(schema-org): dedupe typed arrays by @type during node merge

### DIFF
--- a/packages/schema-org/src/core/util.ts
+++ b/packages/schema-org/src/core/util.ts
@@ -45,7 +45,21 @@ export function merge(target: any, source: any): any {
           target[key] = Object.values(byType)
         }
         else {
-          target[key] = merged
+          // For arrays of typed schema.org objects, dedupe by @type so that
+          // later definitions override earlier ones (e.g. two Products defining
+          // offers with different availability values)
+          const hasTypedObjects = merged.length > 0 && merged.every((item: any) =>
+            item && typeof item === 'object' && item['@type'],
+          )
+          if (hasTypedObjects) {
+            const byType: Record<string, any> = Object.create(null)
+            for (const item of merged)
+              byType[item['@type']] = item
+            target[key] = Object.values(byType)
+          }
+          else {
+            target[key] = merged
+          }
         }
       }
       else {

--- a/packages/schema-org/test/ssr/dupes.test.ts
+++ b/packages/schema-org/test/ssr/dupes.test.ts
@@ -1,4 +1,4 @@
-import { defineWebSite, UnheadSchemaOrg } from '@unhead/schema-org'
+import { defineProduct, defineWebSite, UnheadSchemaOrg } from '@unhead/schema-org'
 import { useHead } from 'unhead'
 import { createHead, renderSSRHead } from 'unhead/server'
 import { describe, expect, it } from 'vitest'
@@ -6,6 +6,50 @@ import { describe, expect, it } from 'vitest'
 const JSON_LD_RE = /application\/ld\+json/g
 
 describe('schema.org dupes', () => {
+  it('merges two Products with conflicting offers.availability', async () => {
+    const ssrHead = createHead()
+
+    ssrHead.use(UnheadSchemaOrg())
+
+    useHead(ssrHead, {
+      script: [
+        {
+          type: 'application/ld+json',
+          key: 'schema-org-graph',
+          nodes: [
+            defineProduct({
+              name: 'Test Product',
+              image: '/image.jpg',
+              offers: {
+                price: 100,
+                availability: 'InStock',
+              },
+            }),
+          ],
+        } as any,
+        {
+          type: 'application/ld+json',
+          key: 'schema-org-graph',
+          nodes: [
+            defineProduct({
+              name: 'Test Product',
+              image: '/image.jpg',
+              offers: {
+                price: 100,
+                availability: 'OutOfStock',
+              },
+            }),
+          ],
+        } as any,
+      ],
+    })
+
+    const data = await renderSSRHead(ssrHead)
+    // The second Product's offers should win, with OutOfStock availability
+    expect(data.bodyTags).toContain('https://schema.org/OutOfStock')
+    expect(data.bodyTags).not.toContain('https://schema.org/InStock')
+  })
+
   it('basic websites', async () => {
     const ssrHead = createHead()
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves harlan-zw/nuxt-schema-org#94

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When two schema-org entries share the same `@id` (e.g. two `Product` nodes from different components), the `merge()` function deep-merged their nested objects. For arrays of typed schema objects like `offers`, this caused conflicting scalar values (e.g. `availability: InStock` vs `OutOfStock`) to both be retained instead of the later definition winning.

Extends the existing `@type` deduplication logic (previously only applied to `potentialAction`) to all arrays of typed schema objects. When merging arrays where every element has a `@type` property, later definitions now override earlier ones by type.