### PR TITLE
fix: add `fediverse:creator` meta tag support

### DIFF
--- a/packages/unhead/src/plugins/validate.ts
+++ b/packages/unhead/src/plugins/validate.ts
@@ -149,6 +149,7 @@ const KNOWN_META_NAMES = new Set([
   'creator',
   'description',
   'fb:app_id',
+  'fediverse:creator',
   'format-detection',
   'generator',
   'google-site-verification',
@@ -401,7 +402,7 @@ export function ValidatePlugin(options: ValidatePluginOptions = {}) {
                   report('possible-typo', `Unknown meta property "${props.property}". Did you mean "${suggestion}"?`, 'warn', tag)
               }
 
-              if (props.name && !KNOWN_META_NAMES.has(props.name) && (props.name.startsWith('twitter:') || !props.name.includes(':'))) {
+              if (props.name && !KNOWN_META_NAMES.has(props.name) && (props.name.startsWith('twitter:') || props.name.startsWith('fediverse:') || !props.name.includes(':'))) {
                 const suggestion = findClosestMatch(props.name, KNOWN_META_NAMES)
                 if (suggestion)
                   report('possible-typo', `Unknown meta name "${props.name}". Did you mean "${suggestion}"?`, 'warn', tag)

--- a/packages/unhead/src/types/schema/meta.ts
+++ b/packages/unhead/src/types/schema/meta.ts
@@ -28,6 +28,7 @@ export type MetaNames
     | 'creator'
     | 'description'
     | 'fb:app_id'
+    | 'fediverse:creator'
     | 'format-detection'
     | 'generator'
     | 'google-site-verification'

--- a/packages/unhead/src/types/schema/metaFlat.ts
+++ b/packages/unhead/src/types/schema/metaFlat.ts
@@ -612,6 +612,13 @@ export interface MetaFlat extends MetaFlatArticle, MetaFlatBook, MetaFlatProfile
    * @see https://developers.facebook.com/docs/sharing/webmasters#basic
    */
   fbAppId?: string | number
+  /**
+   * The Fediverse account of the content creator.
+   *
+   * @example '@gargron@mastodon.social'
+   * @see https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/
+   */
+  fediverseCreator?: string
   // Twitter meta
   /**
    * The card type

--- a/packages/unhead/src/utils/meta.ts
+++ b/packages/unhead/src/utils/meta.ts
@@ -4,7 +4,7 @@ import { MetaTagsArrayable } from './const'
 type MetaKeyType = 'name' | 'property' | 'http-equiv'
 
 export const NAMESPACES = /* @__PURE__ */ {
-  META: new Set(['twitter']),
+  META: new Set(['twitter', 'fediverse']),
   OG: new Set(['og', 'book', 'article', 'profile', 'fb']),
   MEDIA: new Set(['ogImage', 'ogVideo', 'ogAudio', 'twitterImage']),
   HTTP_EQUIV: new Set(['contentType', 'defaultStyle', 'xUaCompatible']),


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #26

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds support for the `fediverse:creator` meta tag, used by Mastodon and other Fediverse platforms to attribute content to creators. This enables author highlighting when links are shared across the Fediverse.

```ts
// useHead
useHead({ meta: [{ name: 'fediverse:creator', content: '@gargron@mastodon.social' }] })

// useSeoMeta
useSeoMeta({ fediverseCreator: '@gargron@mastodon.social' })
```

Changes:
- Added `fediverse:creator` to `MetaNames` type
- Added `fediverseCreator` to `MetaFlat` interface for `useSeoMeta` support
- Added `fediverse` namespace to `NAMESPACES.META` for correct camelCase conversion
- Added `fediverse:creator` to validation known names and typo detection scope

Reference: https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Fediverse creator meta tags, enabling proper configuration and validation of Fediverse platform metadata (including Mastodon-compatible tags).
  * Extended type definitions to recognize Fediverse-prefixed meta attributes.

* **Improvements**
  * Validation now properly handles Fediverse meta names without reporting false positive typo warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->