### PR TITLE
chore(react): configure oxc jsx transform for vitest

### DIFF
--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -5,7 +5,9 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   oxc: {
-    jsx: 'react-jsx',
+    jsx: {
+      runtime: 'automatic',
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Vite 8 uses oxc as the default transformer instead of esbuild. The React package vitest config was missing JSX transform configuration, causing all 9 React test suites to fail with `Failed to parse source for import analysis because the content contains invalid JS syntax. If you use tsconfig.json, make sure to not set jsx to preserve.`

Switches from `defineProject` to `defineConfig` and adds `oxc: { jsx: 'react-jsx' }` so oxc correctly transforms JSX in `.tsx` test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Vitest configuration for the React package to enhance JSX handling in tests by enabling automatic JSX runtime while preserving existing test globals and resolver aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->