### PR TITLE
fix: avoid mutating cached titleTemplate tag in resolveTitleTemplate

### DIFF
--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -69,8 +69,8 @@ export function resolveTitleTemplate(ctx: ResolveTagsContext, head: Unhead<any>)
     v === null ? ctx.tagMap.delete('title') : ctx.tagMap.set('title', { ...title, textContent: v })
   }
   else {
-    tpl.tag = 'title'
-    tpl.textContent = v
+    // create a new object instead of mutating the cached tpl tag
+    ctx.tagMap.set('titleTemplate', { ...tpl, tag: 'title', textContent: v })
   }
 }
 


### PR DESCRIPTION
## Summary

- `resolveTitleTemplate()` was mutating the `titleTemplate` tag object in-place (`tpl.tag = 'title'`, `tpl.textContent = v`), which corrupts the entry's `_tags` cache on subsequent renders. Now creates a new object via spread instead.

This is a correctness fix — the mutation could cause stale `titleTemplate` data to persist across re-renders when the entry's `_tags` cache is reused.

## Test plan

- [x] All 1019 tests pass
- [ ] Verify titleTemplate updates correctly across multiple reactive re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved title template resolution to prevent unintended mutations of cached objects, enhancing stability and reliability of title tag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->