### PR TITLE
fix: use correct `@__PURE__` annotation on SafeInputPlugin

### DIFF
--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -226,7 +226,7 @@ function makeTagSafe(tag: HeadTag): HeadSafe | false {
   return tag
 }
 
-export const SafeInputPlugin = /* @PURE */ defineHeadPlugin({
+export const SafeInputPlugin = /* @__PURE__ */ defineHeadPlugin({
   key: 'safe',
   hooks: {
     'entries:normalize': (ctx) => {


### PR DESCRIPTION
## Summary

- `SafeInputPlugin` was annotated with `/* @PURE */` instead of `/* @__PURE__ */`
- Bundlers (Rollup, esbuild, webpack) only recognize `@__PURE__` — the incorrect annotation prevented tree-shaking of the entire SafeInputPlugin (~6KB) when `useHeadSafe()` isn't used

One-character fix (added underscores).

## Test plan

- [x] Existing tests pass (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build optimization configuration for better tree-shaking and bundle efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->