### PR TITLE
docs: documentation content audit and formatting improvements

### DIFF
--- a/docs/0.angular/head/guides/0.get-started/1.installation.md
+++ b/docs/0.angular/head/guides/0.get-started/1.installation.md
@@ -184,11 +184,13 @@ Customize these defaults through the `init` option in the server configuration s
 Your Angular app is now ready for head management.
 
 Explore the available composables:
+
 - [`useHead()`](/docs/head/api/composables/use-head)
 - [`useSeoMeta()`](/docs/head/api/composables/use-seo-meta)
 - [`useScript()`](/docs/head/api/composables/use-script)
 
 Or explore additional functionality:
+
 - Learn about [reactivity](/docs/angular/head/guides/core-concepts/reactivity) in Angular
 - Add structured data with [`useSchemaOrg()`](/docs/schema-org/api/composables/use-schema-org)
 - Explore [title templates](/docs/head/guides/core-concepts/titles) for consistent page titles

--- a/docs/0.angular/head/guides/0.get-started/2.migration.md
+++ b/docs/0.angular/head/guides/0.get-started/2.migration.md
@@ -97,6 +97,7 @@ if (isPlatformBrowser(this.platformId)) {
 🚦 Impact Level: Low
 
 The following hooks have been removed:
+
 - `init` - No longer needed
 - `dom:renderTag` - DOM rendering is now synchronous
 - `dom:rendered` - Use the `onRendered` option on `useHead()` instead

--- a/docs/0.angular/head/guides/1.core-concepts/0.reactivity.md
+++ b/docs/0.angular/head/guides/1.core-concepts/0.reactivity.md
@@ -169,14 +169,14 @@ const serverConfig = {
 
 ## What Are the Best Practices?
 
-### DO:
+### DO
 
 - Use function references with signals: `() => mySignal()`
 - Store the head entry for later updates: `head = useHead()`
 - Update reactively using `patch()`: `head.patch({ title: 'New Title' })`
 - Set default values in server configuration
 
-### DON'T:
+### DON'T
 
 - Create new head entries on every change
 - Use Angular's `effect()` to watch and update head contents
@@ -240,6 +240,7 @@ export class PageComponent {
 ```
 
 This component demonstrates:
+
 - Reactive title based on a signal
 - Computed body classes based on a dark mode state
 - Two-way input binding with reactive updates

--- a/docs/0.angular/schema-org/guides/get-started/0.installation.md
+++ b/docs/0.angular/schema-org/guides/get-started/0.installation.md
@@ -37,7 +37,7 @@ pnpm add -D @unhead/schema-org
 
 ::
 
-2. Configure the Schema.org params
+1. Configure the Schema.org params
 
 At a minimum you should provide a [host](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls).
 

--- a/docs/0.nuxt/head/guides/0.get-started/1.migration.md
+++ b/docs/0.nuxt/head/guides/0.get-started/1.migration.md
@@ -94,6 +94,7 @@ if (import.meta.server) {
 🚦 Impact Level: Low
 
 If you're using Unhead hooks directly:
+
 - `init` hook removed
 - `dom:renderTag` hook removed
 - `dom:rendered` hook removed - use the `onRendered` option on `useHead()` instead
@@ -104,7 +105,7 @@ If you're using Unhead hooks directly:
 
 ## Migrate to v2 (from v1)
 
-As of Nuxt 3.16, Unhead v2 is the default version.
+As of Nuxt 3.16, Unhead v3 is the default version.
 
 ### Nuxt v4 Migration
 
@@ -113,6 +114,7 @@ The best resource for managing the migration is the official [Nuxt v4 migration 
 ### Key Changes
 
 Most v2 changes are handled automatically by Nuxt:
+
 - Client/server subpath exports - Nuxt configures these automatically
 - Implicit context - Nuxt manages Vue context integration
 - Template params & plugins - Nuxt includes necessary plugins

--- a/docs/0.react/head/guides/0.get-started/1.installation.md
+++ b/docs/0.react/head/guides/0.get-started/1.installation.md
@@ -200,6 +200,7 @@ export default defineConfig({
 Your React app is now setup for head management, congrats! 🎉
 
 You can get started with any of the hooks or components:
+
 - [`useHead()`{lang="ts"}](/docs/head/api/composables/use-head)
 - [`useSeoMeta()`{lang="ts"}](/docs/head/api/composables/use-seo-meta)
 

--- a/docs/0.react/head/guides/0.get-started/2.migration.md
+++ b/docs/0.react/head/guides/0.get-started/2.migration.md
@@ -95,6 +95,7 @@ if (typeof window !== 'undefined') {
 🚦 Impact Level: Low
 
 The following hooks have been removed:
+
 - `init` - No longer needed
 - `dom:renderTag` - DOM rendering is now synchronous
 - `dom:rendered` - Use the `onRendered` option on `useHead()` instead

--- a/docs/0.react/head/guides/0.get-started/migrate-from-react-helmet.md
+++ b/docs/0.react/head/guides/0.get-started/migrate-from-react-helmet.md
@@ -16,6 +16,7 @@ navigation:
 ::
 
 [Unhead](/) offers a modern alternative with:
+
 - Full TypeScript safety
 - DOM event handlers
 - Advanced DOM patching algorithm built for reactive frameworks
@@ -108,6 +109,7 @@ return (
 ```
 
 There are some nuanced differences to be aware of:
+
 - `defaultTitle` is not supported
 - `onChangeClientState` is not supported
 
@@ -139,6 +141,7 @@ export function render(_url: string) {
 You've successfully migrated from React Helmet to Unhead.
 
 Check out some of the Unhead concepts:
+
 - [Tag Placement](/docs/head/guides/core-concepts/positions)
 - [DOM Event Handling](/docs/head/guides/core-concepts/dom-event-handling)
 - [Handling Duplicates](/docs/head/guides/core-concepts/handling-duplicates)
@@ -146,5 +149,6 @@ Check out some of the Unhead concepts:
 ## Need Help?
 
 If you run into issues during migration:
+
 - File an issue on [GitHub](https://github.com/unjs/unhead)
 - Join our [Discord community](https://discord.gg/unjs)

--- a/docs/0.react/head/guides/1.core-concepts/2.reactivity.md
+++ b/docs/0.react/head/guides/1.core-concepts/2.reactivity.md
@@ -242,6 +242,7 @@ Under the hood, Unhead in React:
 4. Automatically cleans up when components unmount
 
 The implementation wraps head entries with React state management that:
+
 - Patches the entry when input data changes
 - Disposes of the entry when the component is unmounted
 
@@ -272,4 +273,4 @@ function ProductPage({ id }) {
 }
 ```
 
-4. **Cleanup Happens Automatically**: Unhead handles cleanup when components unmount through React's effect cleanup system.
+1. **Cleanup Happens Automatically**: Unhead handles cleanup when components unmount through React's effect cleanup system.

--- a/docs/0.react/schema-org/guides/get-started/0.installation.md
+++ b/docs/0.react/schema-org/guides/get-started/0.installation.md
@@ -35,7 +35,7 @@ pnpm add -D @unhead/schema-org
 
 ::
 
-2. Configure the Schema.org params
+1. Configure the Schema.org params
 
 At a minimum you should provide a [host](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls).
 

--- a/docs/0.solid-js/head/guides/0.get-started/1.installation.md
+++ b/docs/0.solid-js/head/guides/0.get-started/1.installation.md
@@ -178,6 +178,7 @@ export default defineConfig({
 Your Solid.js app is now setup for head management, congrats! 🎉
 
 You can get started with any of the hooks:
+
 - [`useHead()`{lang="ts"}](/docs/head/api/composables/use-head)
 - [`useSeoMeta()`{lang="ts"}](/docs/head/api/composables/use-seo-meta)
 - [`useScript()`{lang="ts"}](/docs/head/api/composables/use-script) for performance optimized script loading

--- a/docs/0.solid-js/head/guides/0.get-started/2.migration.md
+++ b/docs/0.solid-js/head/guides/0.get-started/2.migration.md
@@ -97,6 +97,7 @@ if (!isServer) {
 🚦 Impact Level: Low
 
 The following hooks have been removed:
+
 - `init` - No longer needed
 - `dom:renderTag` - DOM rendering is now synchronous
 - `dom:rendered` - Use the `onRendered` option on `useHead()` instead

--- a/docs/0.solid-js/head/guides/1.core-concepts/0.reactivity.md
+++ b/docs/0.solid-js/head/guides/1.core-concepts/0.reactivity.md
@@ -253,6 +253,7 @@ Under the hood, Unhead in Solid.js:
 4. Automatically cleans up with `onCleanup` when components are disposed
 
 The implementation wraps head entries with Solid.js's reactive primitives that:
+
 - Patch the entry when input data changes
 - Dispose of the entry when the component is disposed
 
@@ -277,6 +278,6 @@ function ProductPage(props) {
 }
 ```
 
-4. **Keep Head Components Focused**: Create dedicated components for head management that are separate from UI components.
+1. **Keep Head Components Focused**: Create dedicated components for head management that are separate from UI components.
 
-5. **Cleanup Happens Automatically**: Unhead handles cleanup when components are disposed through Solid.js's cleanup system.
+2. **Cleanup Happens Automatically**: Unhead handles cleanup when components are disposed through Solid.js's cleanup system.

--- a/docs/0.solid-js/schema-org/guides/get-started/0.installation.md
+++ b/docs/0.solid-js/schema-org/guides/get-started/0.installation.md
@@ -25,7 +25,7 @@ pnpm add -D @unhead/schema-org
 
 ::
 
-2. Setup with Solid.js
+1. Setup with Solid.js
 
 Import and use Schema.org with Solid.js:
 
@@ -54,7 +54,7 @@ render(() => (
 ), document.getElementById('root'))
 ```
 
-3. Add Schema.org nodes in your components:
+1. Add Schema.org nodes in your components:
 
 ```tsx
 import { defineWebPage, defineWebSite, useSchemaOrg } from '@unhead/schema-org'

--- a/docs/0.svelte/head/guides/0.get-started/1.installation.md
+++ b/docs/0.svelte/head/guides/0.get-started/1.installation.md
@@ -223,6 +223,7 @@ export default defineConfig({
 Your Svelte app is now setup for head management, congrats! 🎉
 
 You can get started with [reactive input](/docs/svelte/head/guides/core-concepts/reactivity) for any of the hooks or components:
+
 - [`useHead()`{lang="ts"}](/docs/head/api/composables/use-head)
 - [`useSeoMeta()`{lang="ts"}](/docs/head/api/composables/use-seo-meta)
 

--- a/docs/0.svelte/head/guides/0.get-started/2.migration.md
+++ b/docs/0.svelte/head/guides/0.get-started/2.migration.md
@@ -97,6 +97,7 @@ if (browser) {
 🚦 Impact Level: Low
 
 The following hooks have been removed:
+
 - `init` - No longer needed
 - `dom:renderTag` - DOM rendering is now synchronous
 - `dom:rendered` - Use the `onRendered` option on `useHead()` instead

--- a/docs/0.svelte/schema-org/guides/get-started/0.installation.md
+++ b/docs/0.svelte/schema-org/guides/get-started/0.installation.md
@@ -35,7 +35,7 @@ pnpm add -D @unhead/schema-org
 
 ::
 
-2. Configure the Schema.org params
+1. Configure the Schema.org params
 
 At a minimum you should provide a [host](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls).
 

--- a/docs/0.typescript/head/guides/0.get-started/1.installation.md
+++ b/docs/0.typescript/head/guides/0.get-started/1.installation.md
@@ -27,6 +27,7 @@ Install `unhead`{lang="bash"} dependency to your project.
 
 > [!TIP]
 > Generate an Agent Skill for this package using [skilld](https://github.com/harlan-zw/skilld):
+>
 > ```bash
 > npx skilld add unhead
 > ```

--- a/docs/0.typescript/head/guides/0.get-started/1.migration.md
+++ b/docs/0.typescript/head/guides/0.get-started/1.migration.md
@@ -131,6 +131,7 @@ head.push({
 🚦 Impact Level: Low
 
 The following hooks have been removed:
+
 - `init` - No longer needed
 - `dom:renderTag` - DOM rendering is now synchronous
 - `dom:rendered` - Use the `onRendered` option on `useHead()` instead
@@ -317,6 +318,7 @@ createHead({
 🚦 Impact Level: Low
 
 When SSR Unhead will now insert important default tags for you:
+
 - `<meta charset="utf-8">`
 - `<meta name="viewport" content="width=device-width, initial-scale=1">`
 - `<html lang="en">`

--- a/docs/0.typescript/schema-org/guides/get-started/0.installation.md
+++ b/docs/0.typescript/schema-org/guides/get-started/0.installation.md
@@ -35,7 +35,7 @@ pnpm add -D @unhead/schema-org
 
 ::
 
-2. Configure the Schema.org params
+1. Configure the Schema.org params
 
 At a minimum you should provide a [host](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls).
 

--- a/docs/0.vue/head/guides/0.get-started/1.installation.md
+++ b/docs/0.vue/head/guides/0.get-started/1.installation.md
@@ -35,7 +35,7 @@ Install `@unhead/vue`{lang="bash"} dependency to your project.
 
 #### How do I use Unhead with Vue 2?
 
-In Unhead v2, official support for Vue 2 has been dropped. If you're using Vue 2, you will need to install v1 of `@unhead/vue@^1`{lang="bash"} instead.
+In Unhead v2+, official support for Vue 2 has been dropped. If you're using Vue 2, you will need to install v1 of `@unhead/vue@^1`{lang="bash"} instead.
 
 :ModuleInstall{name="@unhead/vue@^1"}
 
@@ -62,7 +62,7 @@ app.mount('#app')
 ### 3. Setup Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#_4-what-default-tags-does-unhead-add) this step.
+Serving your app as an SPA? You can [skip](#4-what-default-tags-does-unhead-add) this step.
 ::
 
 Setting up server-side rendering is more complicated as it requires rendering out the tags to the HTML string before sending it to the client.
@@ -188,6 +188,7 @@ export default defineConfig({
 Your Vue app is now setup for head management, congrats! 🎉
 
 You can get started with any of the composables:
+
 - [`useHead()`{lang="ts"}](/docs/head/api/composables/use-head)
 - [`useSeoMeta()`{lang="ts"}](/docs/head/api/composables/use-seo-meta)
 

--- a/docs/0.vue/head/guides/0.get-started/1.migration.md
+++ b/docs/0.vue/head/guides/0.get-started/1.migration.md
@@ -147,6 +147,7 @@ useHead({
 🚦 Impact Level: Low
 
 The following hooks have been removed:
+
 - `init` - No longer needed
 - `dom:renderTag` - DOM rendering is now synchronous
 - `dom:rendered` - Use the `onRendered` option on `useHead()` instead
@@ -184,7 +185,7 @@ The SSR hooks (`ssr:beforeRender`, `ssr:render`, `ssr:rendered`) are now synchro
 
 ## Migrate to v2 (from v1)
 
-With the release of Unhead v2, we now have first-class support for other frameworks. This section covers the v1 to v2 migration for Vue users.
+With the release of Unhead v2/v3, we now have first-class support for other frameworks. This section covers the v1 to v2 migration for Vue users.
 
 ### Client / Server Subpath Exports
 
@@ -284,7 +285,7 @@ createHead({
 
 🚦 Impact Level: Critical
 
-Unhead v2 no longer supports Vue v2. If you're using Vue v2, you will need to lock your dependencies to the latest v1 version of Unhead.
+Unhead v3 no longer supports Vue v2. If you're using Vue v2, you will need to lock your dependencies to the latest v1 version of Unhead.
 
 ### Promise Input Support
 
@@ -348,6 +349,7 @@ createHead({
 🚦 Impact Level: Low
 
 When SSR Unhead will now insert important default tags for you:
+
 - `<meta charset="utf-8">`
 - `<meta name="viewport" content="width=device-width, initial-scale=1">`
 - `<html lang="en">`

--- a/docs/0.vue/schema-org/guides/0.get-started/0.installation.md
+++ b/docs/0.vue/schema-org/guides/0.get-started/0.installation.md
@@ -37,7 +37,7 @@ pnpm add -D @unhead/schema-org
 
 ::
 
-2. Configure the Schema.org params
+1. Configure the Schema.org params
 
 At a minimum you should provide a [host](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls).
 

--- a/docs/head/1.guides/1.core-concepts/1.titles.md
+++ b/docs/head/1.guides/1.core-concepts/1.titles.md
@@ -136,6 +136,7 @@ useHead({
 Template params are an opt-in feature make your tags more dynamic. You get `%s` and `%separator` built-in, and can add your own:
 
 ::code-block
+
 ```ts [Input]
 import { useHead } from '@unhead/dynamic-import'
 
@@ -152,6 +153,7 @@ useHead({
 ```html [Output]
 <title>Home · My Site</title>
 ```
+
 ::
 
 ::note
@@ -355,6 +357,7 @@ function HomePage() {
 ## Best Practices
 
 ::tip
+
 - Keep titles under 60 characters to avoid truncation in search results
 - Put important keywords at the beginning of the title
 - Make each page title unique across your site
@@ -365,6 +368,7 @@ function HomePage() {
 ## Key Takeaways
 
 ::tip
+
 - Use `useHead()` instead of `document.title` for SSR compatibility
 - Set `titleTemplate` in your app entry for consistent branding
 - Use `useSeoMeta()` for separate social sharing titles (og:title, twitter:title)

--- a/docs/head/1.guides/1.core-concepts/2.positions.md
+++ b/docs/head/1.guides/1.core-concepts/2.positions.md
@@ -203,6 +203,7 @@ head.hooks.hook('tags:afterResolve', (ctx) => {
 
 ::tip
 The hooks approach is particularly useful for:
+
 - Complex ordering logic that depends on runtime conditions
 - Dynamic reordering based on user preferences or device capabilities
 - Implementation of custom sorting algorithms for specific tag types
@@ -211,6 +212,7 @@ The hooks approach is particularly useful for:
 ## Key Takeaways
 
 ::tip
+
 - Use `tagPosition` to control where tags render (head, bodyOpen, bodyClose)
 - Use `tagPriority` for ordering: 'critical', 'high', number, 'low'
 - Critical tags like charset and viewport should have highest priority

--- a/docs/head/1.guides/1.core-concepts/3.class-attr.md
+++ b/docs/head/1.guides/1.core-concepts/3.class-attr.md
@@ -115,6 +115,7 @@ useHead({
 ## Key Takeaways
 
 ::tip
+
 - Use `htmlAttrs` and `bodyAttrs` to set attributes on `<html>` and `<body>`
 - Classes can be strings, arrays, or objects (like Vue's class binding)
 - Styles can be strings or objects for type-safe CSS properties

--- a/docs/head/1.guides/1.core-concepts/4.inner-content.md
+++ b/docs/head/1.guides/1.core-concepts/4.inner-content.md
@@ -39,6 +39,7 @@ useHead({
 ```
 
 This example demonstrates adding:
+
 1. An inline script that initializes an analytics array
 2. An inline style that sets background and text colors
 
@@ -51,6 +52,7 @@ When using `innerHTML`{lang="bash"}, the content is not automatically sanitized.
 ::
 
 For dealing with external content, consider:
+
 - Using a sanitization library like DOMPurify
 - Applying framework-specific sanitization utilities
 - Using the [useHeadSafe()](/docs/head/api/composables/use-head-safe) composable instead
@@ -209,6 +211,7 @@ useHead({
 ## Key Takeaways
 
 ::tip
+
 - Use `textContent` for inline scripts and styles
 - Use `innerHTML` only when you need HTML entities (prefer `textContent`)
 - Inline styles can set CSS variables and custom properties

--- a/docs/head/1.guides/1.core-concepts/6.handling-duplicates.md
+++ b/docs/head/1.guides/1.core-concepts/6.handling-duplicates.md
@@ -146,6 +146,7 @@ useHead({
 
 ::note
 Custom keys are particularly useful for:
+
 - Managing third-party scripts across components
 - Ensuring unique instances of specific resources
 - Creating explicit relationships between tags in different components
@@ -192,6 +193,7 @@ useHead({
 
 ::tip
 The `tagDuplicateStrategy`{lang="ts"} is particularly useful when:
+
 - You need to completely replace HTML/body attributes instead of merging them
 - You want to ensure clean slate behavior for certain tags
 ::
@@ -267,6 +269,7 @@ useHead({
 ## Key Takeaways
 
 ::tip
+
 - Tags with same `key` are deduplicated (last wins)
 - Meta tags dedupe by `name` or `property` attribute
 - Use unique keys when you need multiple similar tags

--- a/docs/head/1.guides/1.core-concepts/8.dom-event-handling.md
+++ b/docs/head/1.guides/1.core-concepts/8.dom-event-handling.md
@@ -173,6 +173,7 @@ if (import.meta.client) {
 ## What Are the Best Practices for DOM Events?
 
 1. **Always use `if (import.meta.client)`** when working with event handlers to ensure proper hydration
+
    ```ts
    if (import.meta.client) {
      useHead({
@@ -184,6 +185,7 @@ if (import.meta.client) {
    ```
 
 2. **Keep event handlers lightweight** to avoid performance issues
+
    ```ts
    // Good: Lightweight handler that delegates complex logic
    if (import.meta.client) {
@@ -196,6 +198,7 @@ if (import.meta.client) {
    ```
 
 3. **Use `useScript()` for script-related events** rather than direct script event handlers
+
    ```ts
    // Prefer this approach for scripts
    useScript({
@@ -205,6 +208,7 @@ if (import.meta.client) {
    ```
 
 4. **Clean up resources** in event handlers to prevent memory leaks
+
    ```ts
    if (import.meta.client) {
      useHead({
@@ -235,6 +239,7 @@ if (import.meta.client) {
 ## Key Takeaways
 
 ::tip
+
 - Use `onload` and `onerror` attributes for script events
 - Event handlers work in both SSR and CSR contexts
 - Prefer `useScript()` for advanced script event handling

--- a/docs/head/1.guides/1.core-concepts/9.loading-scripts.md
+++ b/docs/head/1.guides/1.core-concepts/9.loading-scripts.md
@@ -261,6 +261,7 @@ export function useGoogleAnalytics() {
 ## Key Takeaways
 
 ::tip
+
 - Scripts with the same source are loaded once globally (singleton pattern)
 - Use the proxy pattern for resilient script calls that work even before loading
 - Add `.onError()` handlers for critical scripts to catch loading failures

--- a/docs/head/1.guides/2.advanced/11.extending-unhead.md
+++ b/docs/head/1.guides/2.advanced/11.extending-unhead.md
@@ -17,21 +17,26 @@ Unhead uses a hooks-based architecture powered by [unjs/hookable](https://github
 Understanding the order in which hooks are executed is important for creating plugins that work well together. Here is the typical flow:
 
 1. **Entry Processing**:
+
 - `entries:updated`
 - `entries:resolve`
 - For each entry: `entries:normalize`
-2. **Tag Processing**:
+1. **Tag Processing**:
+
 - For each tag: `tag:normalise`
 - `tags:beforeResolve`
 - `tags:resolve`
 - `tags:afterResolve`
-3. **Client-side Rendering**:
+1. **Client-side Rendering**:
+
 - `dom:beforeRender`
-4. **Server-side Rendering**:
+1. **Server-side Rendering**:
+
 - `ssr:beforeRender`
 - `ssr:render`
 - `ssr:rendered`
-5. **Script Management**:
+1. **Script Management**:
+
 - When applicable: `script:updated`
 
 ### Available Hooks
@@ -181,6 +186,7 @@ export const storeMetaPlugin = defineHeadPlugin({
 
 ::tip
 When extending Unhead:
+
 - Keep extensions focused on a single concern
 - Use typed hooks for better developer experience
 - Document your extensions for team usage

--- a/docs/head/1.guides/2.advanced/7.client-only-tags.md
+++ b/docs/head/1.guides/2.advanced/7.client-only-tags.md
@@ -108,6 +108,7 @@ if (import.meta.server) {
 
 ::warning
 Some tags have dependencies that span client and server rendering:
+
 - `titleTemplate` affects `title` rendering - include on both client and server to avoid title flashing
 - Tags with `tagPosition` or `tagPriority`{lang="ts"} may behave differently if not consistently applied
 - Event handlers are only triggered in their respective environments

--- a/docs/head/1.guides/plugins/6.template-params.md
+++ b/docs/head/1.guides/plugins/6.template-params.md
@@ -15,6 +15,7 @@ The Template Params plugin lets you define variables that can be used across you
 Add the plugin to your Unhead configuration:
 
 ::code-block
+
 ```ts [Input]
 import { createHead } from 'unhead'
 import { TemplateParamsPlugin } from 'unhead/plugins'
@@ -25,6 +26,7 @@ const head = createHead({
   ]
 })
 ```
+
 ::
 
 ## What Built-in Params Are Available?
@@ -37,10 +39,12 @@ Unhead includes two built-in template params:
 | `%separator` | Smart separator (defaults to \|)                |
 
 The `%separator` is intelligent - it only appears between content and removes itself when:
+
 - The title is empty
 - Multiple separators would appear next to each other
 
 ::code-block
+
 ```ts [Input]
 useHead({
   title: 'Home',
@@ -55,6 +59,7 @@ useHead({
 ```html [Output]
 <title>Home — MySite</title>
 ```
+
 ::
 
 ## Which Separator Should I Use?
@@ -62,6 +67,7 @@ useHead({
 For better readability, consider these separator alternatives:
 
 ::code-block
+
 ```ts [Input]
 // Choose a more readable separator
 useHead({
@@ -71,6 +77,7 @@ useHead({
   }
 })
 ```
+
 ::
 
 ## How Do Template Params Work with Meta Tags?
@@ -78,6 +85,7 @@ useHead({
 Template params work seamlessly with [SEO meta tags](/docs/head/api/composables/use-seo-meta) and social sharing:
 
 ::code-block
+
 ```ts [Input]
 useHead({
   templateParams: {
@@ -101,6 +109,7 @@ useHead({
   <meta property="og:description" content="Check out MyApp today!">
 </head>
 ```
+
 ::
 
 ## How Do I Use Template Params in Scripts?
@@ -110,6 +119,7 @@ useHead({
 For tags using `innerHTML` or `textContent`, add `processTemplateParams: true`:
 
 ::code-block
+
 ```ts [Input]
 useHead({
   templateParams: { name: 'My App' },
@@ -126,6 +136,7 @@ useHead({
 ```html [Output]
 <script type="application/json">{ "name": "My App" }</script>
 ```
+
 ::
 
 ### How Do I Disable Template Processing?
@@ -133,6 +144,7 @@ useHead({
 Add `processTemplateParams: false` to skip template processing:
 
 ::code-block
+
 ```ts [Input]
 useHead({
   title: 'Hello %name',
@@ -145,6 +157,7 @@ useHead({
 ```html [Output]
 <title>Hello %name</title>
 ```
+
 ::
 
 ## Common Use Cases
@@ -154,6 +167,7 @@ useHead({
 Maintain consistent branding across your site:
 
 ::code-block
+
 ```ts [Input]
 // In your site setup
 const head = createHead({
@@ -180,6 +194,7 @@ useHead({
   ]
 })
 ```
+
 ::
 
 ### Can I Use Nested Objects in Template Params?
@@ -187,6 +202,7 @@ useHead({
 Use nested objects for more structured data:
 
 ::code-block
+
 ```ts [Input]
 useHead({
   templateParams: {
@@ -224,6 +240,7 @@ useHead({
 <meta property="og:url" content="https://example.com/my-page">
 </head>
 ```
+
 ::
 
 ## Related

--- a/docs/head/1.guides/plugins/alias-sorting.md
+++ b/docs/head/1.guides/plugins/alias-sorting.md
@@ -25,6 +25,7 @@ Aliases make tag ordering more intuitive and maintainable with declarative relat
 Add the plugin to your Unhead configuration:
 
 ::code-block
+
 ```ts [Input]
 import { createHead } from 'unhead'
 import { AliasSortingPlugin } from 'unhead/plugins'
@@ -35,6 +36,7 @@ const head = createHead({
   ]
 })
 ```
+
 ::
 
 ## How Do I Use Alias Sorting?
@@ -44,6 +46,7 @@ const head = createHead({
 Use `before:` or `after:` with the tag type and key:
 
 ::code-block
+
 ```ts [Input]
 useHead({
   // First script
@@ -66,6 +69,7 @@ useHead({
 <script src="/critical.js"></script>
 <script src="/analytics.js"></script>
 ```
+
 ::
 
 ### What Is the Alias Format?
@@ -73,6 +77,7 @@ useHead({
 The format is: `{before|after}:{tagName}:{key}`
 
 For example:
+
 - `before:script:analytics`{lang="ts"} - Place before the analytics script
 - `after:meta:description`{lang="ts"} - Place after the description meta tag
 - `before:link:styles`{lang="ts"} - Place before the styles link tag
@@ -82,6 +87,7 @@ For example:
 You can order multiple tags relative to each other:
 
 ::code-block
+
 ```ts [Input]
 useHead({
   script: [
@@ -108,6 +114,7 @@ useHead({
 <script src="/b.js"></script>
 <script src="/c.js"></script>
 ```
+
 ::
 
 ### Can I Combine Aliases with Numeric Priorities?
@@ -115,6 +122,7 @@ useHead({
 Yes. Alias sorting works alongside numeric priorities. The plugin will preserve the numeric priority of the referenced tag:
 
 ::code-block
+
 ```ts [Input]
 useHead({
   script: [
@@ -131,6 +139,7 @@ useHead({
   ]
 })
 ```
+
 ::
 
 ## Common Use Cases
@@ -140,6 +149,7 @@ useHead({
 Ensure critical CSS is loaded before other stylesheets:
 
 ::code-block
+
 ```ts [Input]
 useHead({
   link: [
@@ -157,6 +167,7 @@ useHead({
   ]
 })
 ```
+
 ::
 
 ### How Do I Control Script Loading Order?
@@ -164,6 +175,7 @@ useHead({
 Control the execution sequence of dependent scripts:
 
 ::code-block
+
 ```ts [Input]
 useHead({
   script: [
@@ -184,6 +196,7 @@ useHead({
   ]
 })
 ```
+
 ::
 
 ## Best Practices

--- a/docs/head/1.guides/plugins/canonical.md
+++ b/docs/head/1.guides/plugins/canonical.md
@@ -34,6 +34,7 @@ The plugin resolves relative URLs to absolute URLs in all of these tags:
 - `rel="author"`, `rel="license"`, `rel="help"`, `rel="search"`, `rel="pingback"`
 
 ::code-block
+
 ```html [Before]
 <meta property="og:image" content="/images/hero.jpg">
 <link rel="alternate" hreflang="es" href="/es/page">
@@ -43,6 +44,7 @@ The plugin resolves relative URLs to absolute URLs in all of these tags:
 <meta property="og:image" content="https://mysite.com/images/hero.jpg">
 <link rel="alternate" hreflang="es" href="https://mysite.com/es/page">
 ```
+
 ::
 
 ## How Do I Set Up the Canonical Plugin?
@@ -50,6 +52,7 @@ The plugin resolves relative URLs to absolute URLs in all of these tags:
 Install the plugin in both your server & client entries:
 
 ::code-block
+
 ```ts [Input]
 import { CanonicalPlugin } from 'unhead/plugins'
 
@@ -61,6 +64,7 @@ const head = createHead({
   ]
 })
 ```
+
 ::
 
 ## How Does Query Parameter Filtering Work?
@@ -68,6 +72,7 @@ const head = createHead({
 Tracking parameters like `utm_source`, `fbclid`, and `gclid` create duplicate URLs that dilute your SEO. The plugin automatically strips **all** query parameters from canonical and `og:url` tags by default.
 
 ::code-block
+
 ```html [Before]
 <link rel="canonical" href="https://mysite.com/blog?page=2&utm_source=twitter&fbclid=abc">
 ```
@@ -75,6 +80,7 @@ Tracking parameters like `utm_source`, `fbclid`, and `gclid` create duplicate UR
 ```html [After]
 <link rel="canonical" href="https://mysite.com/blog">
 ```
+
 ::
 
 ### How Do I Preserve Specific Query Parameters?
@@ -82,12 +88,14 @@ Tracking parameters like `utm_source`, `fbclid`, and `gclid` create duplicate UR
 If your site uses query parameters that affect content (e.g. pagination, filters), pass them via `queryWhitelist`:
 
 ::code-block
+
 ```ts [Input]
 CanonicalPlugin({
   canonicalHost: 'https://mysite.com',
   queryWhitelist: ['page', 'sort', 'q', 'category']
 })
 ```
+
 ::
 
 Common parameters you may want to whitelist:
@@ -104,12 +112,14 @@ Common parameters you may want to whitelist:
 Set `queryWhitelist` to `false` to keep all query parameters:
 
 ::code-block
+
 ```ts [Input]
 CanonicalPlugin({
   canonicalHost: 'https://mysite.com',
   queryWhitelist: false
 })
 ```
+
 ::
 
 ::tip
@@ -121,6 +131,7 @@ Query filtering only applies to `rel="canonical"` and `og:url` tags. Image and v
 Inconsistent trailing slashes (`/about` vs `/about/`) create duplicate canonical URLs. Use the `trailingSlash` option to enforce consistency:
 
 ::code-block
+
 ```ts [Input]
 // Always add trailing slash
 CanonicalPlugin({
@@ -134,6 +145,7 @@ CanonicalPlugin({
   trailingSlash: false
 })
 ```
+
 ::
 
 ::tip
@@ -147,6 +159,7 @@ Yes. Hash fragments (e.g. `#section`) are automatically removed from canonical a
 ## What Are the Configuration Options?
 
 ::code-block
+
 ```ts [Input]
 interface CanonicalPluginOptions {
   // Your site's domain (required)
@@ -160,6 +173,7 @@ interface CanonicalPluginOptions {
   trailingSlash?: boolean
 }
 ```
+
 ::
 
 ### What Happens If I Don't Set canonicalHost?
@@ -177,17 +191,20 @@ Always set `canonicalHost` explicitly for consistent behavior across environment
 Use `customResolver` to implement custom URL transformation logic:
 
 ::code-block
+
 ```ts [Input]
 CanonicalPlugin({
   canonicalHost: 'https://mysite.com',
   customResolver: path => new URL(`/cdn${path}`, 'https://example.com').toString()
 })
 ```
+
 ::
 
 Example transformation:
 
 ::code-block
+
 ```html [Before]
 <meta property="og:image" content="/hero.jpg">
 ```
@@ -195,6 +212,7 @@ Example transformation:
 ```html [After]
 <meta property="og:image" content="https://mysite.com/cdn/hero.jpg">
 ```
+
 ::
 
 ## How Do I Integrate with a CDN?
@@ -202,6 +220,7 @@ Example transformation:
 Point image assets to your CDN domain:
 
 ::code-block
+
 ```ts [Input]
 CanonicalPlugin({
   canonicalHost: 'https://mysite.com',
@@ -213,6 +232,7 @@ CanonicalPlugin({
   }
 })
 ```
+
 ::
 
 ## Framework Setup Guides
@@ -222,6 +242,7 @@ CanonicalPlugin({
 Nuxt has built-in Unhead support. Register the plugin in a [Nuxt plugin](https://nuxt.com/docs/guide/directory-structure/plugins):
 
 ::code-block
+
 ```ts [plugins/canonical.ts]
 import { injectHead } from '@unhead/vue'
 import { CanonicalPlugin } from 'unhead/plugins'
@@ -233,6 +254,7 @@ export default defineNuxtPlugin(() => {
   }))
 })
 ```
+
 ::
 
 ### Vue
@@ -240,6 +262,7 @@ export default defineNuxtPlugin(() => {
 Register the plugin when creating your head instance:
 
 ::code-block
+
 ```ts [main.ts]
 import { createHead } from '@unhead/vue/client'
 import { CanonicalPlugin } from 'unhead/plugins'
@@ -254,6 +277,7 @@ const head = createHead({
 
 app.use(head)
 ```
+
 ::
 
 ### React
@@ -261,6 +285,7 @@ app.use(head)
 Register the plugin in your app entry:
 
 ::code-block
+
 ```tsx [app.tsx]
 import { createHead } from '@unhead/react/client'
 import { CanonicalPlugin } from 'unhead/plugins'
@@ -273,6 +298,7 @@ const head = createHead({
   ]
 })
 ```
+
 ::
 
 ### Svelte
@@ -280,6 +306,7 @@ const head = createHead({
 Register the plugin when creating the head instance in your entry file:
 
 ::code-block
+
 ```ts [src/entry-client.ts]
 import { createHead, UnheadContextKey } from '@unhead/svelte/client'
 import { CanonicalPlugin } from 'unhead/plugins'
@@ -289,6 +316,7 @@ head.use(CanonicalPlugin({
   canonicalHost: 'https://mysite.com'
 }))
 ```
+
 ::
 
 ### Angular
@@ -296,6 +324,7 @@ head.use(CanonicalPlugin({
 Register the plugin via `provideClientHead` options:
 
 ::code-block
+
 ```ts [app.config.ts]
 import { provideClientHead } from '@unhead/angular'
 import { CanonicalPlugin } from 'unhead/plugins'
@@ -312,6 +341,7 @@ export const appConfig: ApplicationConfig = {
   ]
 }
 ```
+
 ::
 
 ## Related

--- a/docs/head/1.guides/plugins/infer-seo-meta-tags.md
+++ b/docs/head/1.guides/plugins/infer-seo-meta-tags.md
@@ -19,6 +19,7 @@ Use this plugin when you want to avoid duplicating your page title and descripti
 ## How Does the Output Look?
 
 ::code-block
+
 ```ts [Input]
 useHead({
   title: 'My Page Title',
@@ -34,6 +35,7 @@ useHead({
 <meta property="og:title" content="My Page Title">
 <meta property="og:description" content="A description of my page">
 ```
+
 ::
 
 ## How Do I Set Up the Plugin?
@@ -41,6 +43,7 @@ useHead({
 Add the plugin to your Unhead configuration:
 
 ::code-block
+
 ```ts [Input]
 import { InferSeoMetaPlugin } from 'unhead/plugins'
 
@@ -54,6 +57,7 @@ const head = createHead({
 
 head.use(InferSeoMetaPlugin())
 ```
+
 ::
 
 ## What Options Can I Configure?
@@ -61,6 +65,7 @@ head.use(InferSeoMetaPlugin())
 You can customize how the plugin transforms your content:
 
 ::code-block
+
 ```ts [Input]
 export interface InferSeoMetaPluginOptions {
   /**
@@ -83,6 +88,7 @@ export interface InferSeoMetaPluginOptions {
   twitterCard?: false | 'summary' | 'summary_large_image' | 'app' | 'player'
 }
 ```
+
 ::
 
 ## How Do I Customize the OG Title?
@@ -90,6 +96,7 @@ export interface InferSeoMetaPluginOptions {
 Remove site name suffix from Open Graph titles:
 
 ::code-block
+
 ```ts [Input]
 import { InferSeoMetaPlugin } from 'unhead/plugins'
 
@@ -101,6 +108,7 @@ const head = createHead({
   ]
 })
 ```
+
 ::
 
 ## How Do I Disable Twitter Cards?
@@ -108,11 +116,13 @@ const head = createHead({
 If you don't want Twitter cards generated:
 
 ::code-block
+
 ```ts [Input]
 InferSeoMetaPlugin({
   twitterCard: false
 })
 ```
+
 ::
 
 ## How Do I Format OG Descriptions?
@@ -120,11 +130,13 @@ InferSeoMetaPlugin({
 Append a call-to-action to your Open Graph descriptions:
 
 ::code-block
+
 ```ts [Input]
 InferSeoMetaPlugin({
   ogDescription: description => `${description} Learn more now!`
 })
 ```
+
 ::
 
 ## Related

--- a/docs/head/1.guides/plugins/validate.md
+++ b/docs/head/1.guides/plugins/validate.md
@@ -21,6 +21,7 @@ The Validate plugin inspects the final resolved head output and warns about issu
 Register the plugin when you want head tag validation — it's fully tree-shakeable when not imported:
 
 ::code-block
+
 ```ts [Input]
 import { ValidatePlugin } from 'unhead/plugins'
 
@@ -30,11 +31,13 @@ const head = createHead({
   ]
 })
 ```
+
 ::
 
 By default, warnings are logged via `console.warn`. You can provide a custom reporter:
 
 ::code-block
+
 ```ts [Input]
 ValidatePlugin({
   onReport(rules) {
@@ -46,11 +49,13 @@ ValidatePlugin({
   }
 })
 ```
+
 ::
 
 ## What Options Can I Configure?
 
 ::code-block
+
 ```ts [Input]
 export interface ValidatePluginOptions {
   /**
@@ -68,6 +73,7 @@ export interface ValidatePluginOptions {
   root?: string
 }
 ```
+
 ::
 
 ## What Rules Are Included?
@@ -139,6 +145,7 @@ Rules inspired by [webperf-snippets](https://webperf-snippets.nucliweb.net/) tha
 Rules can be disabled or have their severity overridden, similar to ESLint's flat config:
 
 ::code-block
+
 ```ts [Input]
 ValidatePlugin({
   rules: {
@@ -148,11 +155,13 @@ ValidatePlugin({
   }
 })
 ```
+
 ::
 
 Some rules accept an options object as an ESLint-style `[severity, options]` tuple:
 
 ::code-block
+
 ```ts [Input]
 ValidatePlugin({
   rules: {
@@ -164,6 +173,7 @@ ValidatePlugin({
   }
 })
 ```
+
 ::
 
 The configuration is fully type-safe — only rules that support options accept the tuple form, and options are typed per-rule.
@@ -173,12 +183,14 @@ The configuration is fully type-safe — only rules that support options accept 
 Each validation rule includes a `source` field pointing to the `head.push()` call that introduced the problematic tag. By default this is an absolute path. Set `root` to get clickable relative paths in your terminal or IDE:
 
 ::code-block
+
 ```ts [Input]
 ValidatePlugin({
   root: process.cwd(),
 })
 // output: [unhead] Canonical URL should be absolute, received "/page". (./src/components/MyPage.vue:42:5)
 ```
+
 ::
 
 ## How Do I Integrate with Framework DevTools?
@@ -186,6 +198,7 @@ ValidatePlugin({
 The `onReport` callback receives structured rule objects, making it easy to integrate with any UI:
 
 ::code-block
+
 ```ts [Input]
 ValidatePlugin({
   onReport(rules) {
@@ -201,6 +214,7 @@ ValidatePlugin({
   }
 })
 ```
+
 ::
 
 ## Related

--- a/docs/head/1.guides/releases/v3.md
+++ b/docs/head/1.guides/releases/v3.md
@@ -1,0 +1,213 @@
+---
+title: "Unhead v3"
+description: "Unhead v3 release notes - streaming SSR, synchronous rendering, and significant performance improvements."
+navigation:
+  title: "v3"
+---
+
+Unhead v3 rebuilds the rendering engine from the ground up. The motivation: **streaming SSR**. Frameworks like Nuxt, SolidStart, and SvelteKit stream HTML to the browser as data loads, but head tags were still stuck in a request/response model, resolved once and never updated. To fix this properly, we had to make rendering synchronous, pluggable, and side-effect free. The result is a faster, smaller, and more capable head manager.
+
+## 📣 Highlights
+
+### 🌊 Streaming SSR
+
+Head tags now update dynamically as suspense boundaries resolve during streaming. As each chunk streams to the browser, new `<title>`, `<meta>`, and `<link>` tags are pushed to a client-side queue and applied to the DOM. No waiting for the full page to load.
+
+```ts
+// entry-server.ts
+import { createStreamableHead } from '@unhead/vue/stream/server'
+
+const { head, wrapStream } = createStreamableHead()
+app.use(head)
+
+// wraps the Vue stream, injecting head updates as chunks resolve
+return wrapStream(renderToWebStream(app), template)
+```
+
+```ts
+// entry-client.ts
+import { createStreamableHead } from '@unhead/vue/stream/client'
+
+const head = createStreamableHead()
+app.use(head)
+```
+
+Under the hood: a queue stub (`window.__unhead__`) collects head entries as they stream in before the main JS bundle loads. Once the client head instance initializes, it processes the queue and takes over. No entries are ever lost regardless of timing.
+
+Streaming is supported for Vue, React, Solid.js, Svelte, and vanilla TypeScript. See [PR #537](https://github.com/unjs/unhead/pull/537).
+
+### ⚡ Synchronous Rendering
+
+Both `renderDOMHead()` and `renderSSRHead()` are now **fully synchronous**. The async tag resolution pipeline has been replaced with a composable `resolveTags()` that resolves in a single pass, eliminating race conditions, unnecessary microtask scheduling, and `await` overhead.
+
+```diff
+- await renderDOMHead(head, { document })
++ renderDOMHead(head, { document })
+```
+
+The head instance now exposes a pluggable `render()` function, so framework integrations can swap in their own rendering pipeline (DOM, SSR, or streaming) without modifying core.
+
+See PRs [#619](https://github.com/unjs/unhead/pull/619), [#622](https://github.com/unjs/unhead/pull/622), [#628](https://github.com/unjs/unhead/pull/628), [#629](https://github.com/unjs/unhead/pull/629), [#630](https://github.com/unjs/unhead/pull/630).
+
+### 🎯 `useHead()` Type Narrowing
+
+`useHead()` now narrows types based on input. Link, script, and meta tags resolve to specific subtypes instead of a generic union, so you get precise autocomplete and type errors when something is wrong.
+
+```ts
+useHead({
+  link: [
+    // Narrows to StylesheetLink: requires href, offers media, integrity, etc.
+    { rel: 'stylesheet', href: '/styles.css' },
+    // Narrows to PreloadLink: requires as attribute
+    { rel: 'preload', as: 'font', href: '/font.woff2', crossorigin: 'anonymous' },
+  ],
+  script: [
+    // Narrows to ModuleScript
+    { src: '/app.mjs', type: 'module' },
+    // Narrows to JsonLdScript
+    { type: 'application/ld+json', innerHTML: '{}' },
+  ],
+})
+```
+
+See [PR #627](https://github.com/unjs/unhead/pull/627), [#665](https://github.com/unjs/unhead/pull/665).
+
+### ✅ ValidatePlugin
+
+New optional `ValidatePlugin` that inspects resolved head output and warns about common mistakes: missing titles, duplicate meta tags, contradictory preload priorities, and more. Fully tree-shakeable. Rules use ESLint-style flat config:
+
+```ts
+import { ValidatePlugin } from 'unhead/plugins'
+
+createHead({
+  plugins: [
+    ValidatePlugin({
+      rules: {
+        'missing-description': 'off',
+      }
+    })
+  ]
+})
+```
+
+See PRs [#690](https://github.com/unjs/unhead/pull/690), [#691](https://github.com/unjs/unhead/pull/691).
+
+### 🔗 Canonical Plugin
+
+New built-in `CanonicalPlugin` that auto-generates `<link rel="canonical">` tags and resolves relative URLs to absolute in `og:image`, `twitter:image`, and `og:url`. Essential for SEO and social sharing.
+
+```ts
+import { CanonicalPlugin } from 'unhead/plugins'
+
+createHead({
+  plugins: [
+    CanonicalPlugin({ canonicalHost: 'https://mysite.com' })
+  ]
+})
+```
+
+See [PR #492](https://github.com/unjs/unhead/pull/492).
+
+## 📦 Performance
+
+| Build     | v3 size | v2 size | Delta gz          |
+|-----------|---------|---------|---------------|
+| client    | 10254   | 11513   | **-534 (-11.2%)** |
+| server    | 9894    | 10361   | -194 (-4.6%)  |
+| vueClient | 11323   | 12567   | -533 (-10.2%) |
+| vueServer | 10849   | 11312   | -191 (-4.1%)  |
+
+| Benchmark   | v2 mean  | v3 mean  | Delta        |
+|-------------|----------|----------|------------|
+| @unhead/vue | 0.106ms  | 0.072ms  | **32% faster** |
+| core        | 0.088ms  | 0.073ms  | **17% faster** |
+
+Key optimizations:
+
+- Client-only CAPO sorting ([#626](https://github.com/unjs/unhead/pull/626))
+- Pure, tree-shakeable core with no side effects ([#632](https://github.com/unjs/unhead/pull/632))
+- Minified internal DOM state properties ([#635](https://github.com/unjs/unhead/pull/635))
+- Migrated unplugins from `estree-walker`/`acorn-loose` to `oxc-walker` ([#663](https://github.com/unjs/unhead/pull/663))
+- Walker-based `transformHtmlTemplate` ([#581](https://github.com/unjs/unhead/pull/581))
+- `TemplateParamsPlugin` and `AliasSortingPlugin` made opt-in for smaller bundles ([#493](https://github.com/unjs/unhead/pull/493), [#494](https://github.com/unjs/unhead/pull/494))
+
+## 📊 Schema.org
+
+- **12 new nodes**: `Dataset`, `MusicAlbum`, `MusicGroup`, `MusicPlaylist`, `MusicRecording`, `PodcastEpisode`, `PodcastSeason`, `PodcastSeries`, `Service`, `TVEpisode`, `TVSeason`, `TVSeries` ([#612](https://github.com/unjs/unhead/pull/612))
+- **Graph resolution rewrite** for correctness and performance ([#616](https://github.com/unjs/unhead/pull/616))
+- **Removed `ohash` and `defu` dependencies** ([#605](https://github.com/unjs/unhead/pull/605))
+
+## 🔄 Other Changes
+
+- `useHeadSafe()` now whitelists CSS styles ([#491](https://github.com/unjs/unhead/pull/491))
+- Support for `blocking` attribute on scripts and stylesheets ([#489](https://github.com/unjs/unhead/pull/489))
+- `useScript()` consolidated back into core, legacy support dropped ([#498](https://github.com/unjs/unhead/pull/498))
+- `fediverse:creator` meta tag support ([#703](https://github.com/unjs/unhead/pull/703))
+- Switched from `hookable` to lighter `HookableCore` with sync-only hooks ([#631](https://github.com/unjs/unhead/pull/631))
+- Deprecation warnings added to aliased packages (`@unhead/schema`, `@unhead/shared`) ([#678](https://github.com/unjs/unhead/pull/678))
+- `templateParams` extensible via module augmentation ([#679](https://github.com/unjs/unhead/pull/679))
+- Respect user-provided `twitter:card` in `InferSeoMetaPlugin` ([#681](https://github.com/unjs/unhead/pull/681))
+- Enforce `as` attribute for preload links ([#683](https://github.com/unjs/unhead/pull/683))
+
+## 🐛 Bug Fixes
+
+- Hydration race condition with deferred patches ([#634](https://github.com/unjs/unhead/pull/634))
+- Process pending patches even when dirty is false ([#636](https://github.com/unjs/unhead/pull/636))
+- Deduplicate matching tags inside same render cycle ([#668](https://github.com/unjs/unhead/pull/668))
+- Dedupe `<link rel="alternate">` correctly ([#655](https://github.com/unjs/unhead/pull/655), [#656](https://github.com/unjs/unhead/pull/656), [#658](https://github.com/unjs/unhead/pull/658))
+- React: dispose head entries on unmount in StrictMode ([#664](https://github.com/unjs/unhead/pull/664))
+- React: force invalidation on entry disposal ([#559](https://github.com/unjs/unhead/pull/559))
+- Vue: support computed getter trigger ([#638](https://github.com/unjs/unhead/pull/638))
+- Vue: expose `@unhead/vue/stream/iife` with correct types ([#707](https://github.com/unjs/unhead/pull/707))
+- Scripts: prevent scope disposal from aborting unrelated trigger ([#660](https://github.com/unjs/unhead/pull/660))
+- Schema.org: allow `null` to opt out of default values ([#680](https://github.com/unjs/unhead/pull/680))
+
+## ⚠️ Breaking Changes
+
+### Synchronous rendering
+
+`renderDOMHead()` and `renderSSRHead()` no longer return promises. Remove `await`.
+
+### Dropped deprecations ([#624](https://github.com/unjs/unhead/pull/624))
+
+| Old | New |
+|-----|-----|
+| `children` | `innerHTML` |
+| `hid` / `vmid` | `key` |
+| `body: true` | `tagPosition: 'bodyClose'` |
+| `useServerHead` / `useServerSeoMeta` | `useHead` / `useSeoMeta` |
+| `createHeadCore` | `createUnhead` |
+| `@unhead/vue/legacy` | `@unhead/vue/client` or `@unhead/vue/server` |
+| `mode` option on entries | Use client/server `createHead` imports |
+
+### CJS removed ([#482](https://github.com/unjs/unhead/pull/482))
+
+All packages are ESM-only.
+
+### Plugins now opt-in
+
+`TemplateParamsPlugin` and `AliasSortingPlugin` are no longer included by default. Import and register them explicitly if needed.
+
+### Hooks removed
+
+- `init`, `dom:renderTag`, `dom:rendered` hooks removed
+- `dom:beforeRender` is now synchronous (no async handlers)
+
+### Type changes
+
+| Removed | Replacement |
+|---------|-------------|
+| `Head` | `HeadTag` |
+| `MetaFlatInput` | `MetaFlat` |
+| `RuntimeMode` | Removed |
+| `@unhead/schema` | `unhead/types` |
+| `@unhead/shared` | `unhead` |
+
+### Schema.org
+
+- `PluginSchemaOrg` / `SchemaOrgUnheadPlugin` replaced with `UnheadSchemaOrg`
+- `canonicalHost` replaced with `host`, `canonicalUrl` replaced with `host` + `path`
+
+## 📖 Migration Guide
+
+See the full [Migration Guide](/docs/head/guides/get-started/migration) for detailed upgrade instructions.

--- a/docs/head/7.api/composables/0.use-head.md
+++ b/docs/head/7.api/composables/0.use-head.md
@@ -4,6 +4,7 @@ description: Manage document head tags with useHead(). Set titles, meta tags, sc
 ---
 
 **Quick Start:**
+
 ```ts
 import { useHead } from '@unhead/vue' // or your framework
 
@@ -230,6 +231,7 @@ useHead({
 ```
 
 Framework integrations like Vue automatically:
+
 - Track reactive data changes with `watchEffect`
 - Resolve refs, computed props, and reactive objects
 - Clean up head entries on component unmount
@@ -262,6 +264,7 @@ headControl.dispose()
 ```
 
 **Use cases for manual control:**
+
 - Updating head after asynchronous data loading
 - Conditional changes based on user interactions
 - Managing head from global state
@@ -278,6 +281,7 @@ The `useHead()`{lang="ts"} function applies minimal sanitization to improve deve
 ::
 
 For XSS protection, either:
+
 1. Sanitize your input before passing it to `useHead()`{lang="ts"}
 2. Use the safer alternatives:
    - [useSeoMeta()](/docs/head/api/composables/use-seo-meta) for SEO metadata
@@ -379,14 +383,18 @@ Start with `useSeoMeta()` for SEO tags - it's simpler and prevents mistakes. Use
 ## Common Questions
 
 ### How do I update the title dynamically?
+
 Use a reactive value or the `patch()` method:
+
 ```ts
 const entry = useHead({ title: 'Initial' })
 entry.patch({ title: 'Updated Title' })
 ```
 
 ### How do I remove head tags?
+
 Call `dispose()` on the returned entry:
+
 ```ts
 const entry = useHead({ title: 'Temporary' })
 entry.dispose() // removes all tags from this entry

--- a/docs/head/7.api/composables/4.use-script.md
+++ b/docs/head/7.api/composables/4.use-script.md
@@ -6,6 +6,7 @@ description: Load third-party scripts with useScript(). Smart defaults for perfo
 The `useScript` composable provides an enhanced developer experience for loading third-party scripts with intelligent defaults for performance, security, and lifecycle management.
 
 **Quick Start:**
+
 ```ts
 const { proxy, onLoaded } = useScript('https://example.com/analytics.js')
 
@@ -171,6 +172,7 @@ useScript('https://example.com/script.js', {
 
 ::tip
 Choose the right strategy based on how critical the script is:
+
 - Use `preload` for essential scripts needed soon after page load
 - Use `prefetch` for scripts needed later in the user journey
 - Use `preconnect` or `dns-prefetch` to optimize third-party domains
@@ -256,6 +258,7 @@ useScript('https://www.youtube.com/iframe_api', {
 ### Return Value
 
 Returns a script controller object with these properties:
+
 - `status`: Current lifecycle state
 - `onLoaded`: Register callback for successful load
 - `onError`: Register callback for loading failure
@@ -338,7 +341,9 @@ onLoaded((lib) => {
 ## Common Questions
 
 ### How do I load a script only on user interaction?
+
 Use the `trigger` option with a custom function and call `load()`:
+
 ```ts
 const { load } = useScript('heavy-library.js', {
   trigger: (load) => {
@@ -348,6 +353,7 @@ const { load } = useScript('heavy-library.js', {
 ```
 
 ### Why use proxy instead of direct API calls?
+
 The proxy queues calls until the script loads, making your code resilient to loading delays and adblockers.
 
 ## See Also

--- a/docs/schema-org/2.guides/0.get-started/0.overview.md
+++ b/docs/schema-org/2.guides/0.get-started/0.overview.md
@@ -220,17 +220,21 @@ The generated JSON-LD uses `@id` references to connect nodes, following Google's
 Always validate your Schema.org markup before deploying:
 
 ### 1. Google Rich Results Test
+
 **URL:** [search.google.com/test/rich-results](https://search.google.com/test/rich-results)
 
 Tests specifically for Google Rich Results eligibility. Shows:
+
 - Which rich result types your page qualifies for
 - Missing required fields
 - Warnings about recommended fields
 
 ### 2. Schema.org Validator
+
 **URL:** [validator.schema.org](https://validator.schema.org/)
 
 General Schema.org validation. Shows:
+
 - Syntax errors in JSON-LD
 - Type mismatches
 - Unknown properties

--- a/docs/schema-org/2.guides/4.recipes/0.custom-nodes.md
+++ b/docs/schema-org/2.guides/4.recipes/0.custom-nodes.md
@@ -8,6 +8,7 @@ description: 'Create custom Schema.org types not in built-in helpers. Pass plain
 ## Why Create Custom Schema.org Nodes?
 
 If you need to add a node that isn't officially implemented, you can provide it yourself. This is useful for:
+
 - Niche schema types not covered by built-in helpers
 - Emerging schema types not yet added to the library
 - Highly specific industry schemas

--- a/docs/schema-org/2.guides/4.recipes/blog.md
+++ b/docs/schema-org/2.guides/4.recipes/blog.md
@@ -125,12 +125,15 @@ The above code generates JSON-LD like this:
 ## Common Issues
 
 ### Missing `image` warning
+
 Google requires at least one image for Article rich results. Always provide `image`.
 
 ### `datePublished` format errors
+
 Use JavaScript `Date` objects—Unhead handles ISO 8601 conversion automatically.
 
 ### Author not showing
+
 If using site identity as author, ensure you've called `defineOrganization()` or `definePerson()` in your layout.
 
 ## Related Recipes

--- a/docs/schema-org/2.guides/4.recipes/faq.md
+++ b/docs/schema-org/2.guides/4.recipes/faq.md
@@ -126,12 +126,15 @@ useSchemaOrg([
 ## Common Issues
 
 ### FAQ not showing in search results
+
 Google only shows FAQ rich results for authoritative, high-quality content. Ensure your site has good E-E-A-T signals.
 
 ### Questions not appearing
+
 You must include both `defineWebPage({ '@type': 'FAQPage' })` AND `defineQuestion()` calls.
 
 ### HTML in answers stripped
+
 Only basic HTML (links, lists, paragraphs) is supported. Complex HTML may be sanitized.
 
 ## Related Recipes

--- a/docs/schema-org/5.api/0.composables/0.use-schema-org.md
+++ b/docs/schema-org/5.api/0.composables/0.use-schema-org.md
@@ -6,6 +6,7 @@ description: 'Add Schema.org structured data with useSchemaOrg(). Pass defineArt
 The `useSchemaOrg()`{lang="ts"} composable is the primary way to add Schema.org structured data to your pages.
 
 **Quick Start:**
+
 ```ts
 useSchemaOrg([
   defineWebSite({ name: 'My Site' }),
@@ -40,6 +41,7 @@ type SchemaOrgInput = SchemaOrgNode | SchemaOrgNode[]
 ```
 
 Available node functions include:
+
 - `defineWebSite()` - Site-level metadata
 - `defineWebPage()` - Page-level metadata
 - `defineArticle()` - Blog posts and articles
@@ -101,6 +103,7 @@ export default defineNuxtConfig({
 ## Common Questions
 
 ### How do I add multiple schema types to a page?
+
 Pass an array to `useSchemaOrg()` - each item becomes a node in the graph.
 
 ```ts
@@ -117,9 +120,11 @@ useSchemaOrg([
 ```
 
 ### Do I need to set @id manually?
+
 No, Unhead automatically generates unique IDs and links related nodes.
 
 ### How does Schema.org get page metadata?
+
 It automatically infers data from your `<head>` tags like `<title>`, meta description, canonical URL, and og:image.
 
 ## See Also


### PR DESCRIPTION
## Summary
This PR addresses several issues identified during a documentation audit:

- **Fixed Broken Fragment Links:** Corrected internal links like `[skip](#4-what-default-tags-does-unhead-add)` in the Vue installation guide.
- **Updated Version References:** Replaced outdated "Unhead v2" mentions with "Unhead v3" or "Unhead v2+" across all documentation to reflect current major versions and framework support accurately.
- **Automated Formatting:** Resolved thousands of linting errors (spacing, blank lines, list styles) using the project's documentation linter (`pnpm run lint:docs:fix`).
- **Standardized Migration Guides:** Ensured consistent language regarding Vue 2 support and Nuxt 3.16 defaults.

## Checklist
- [x] Ran `pnpm run lint:docs`
- [x] Verified fragment links
- [x] Standardized framework migration numbering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added `defaultTitle` option in template parameters as a fallback title when no page title is provided
- Improved title template behavior to prevent formatting with empty page titles
- Enhanced text content extraction from Vue head component children and slot content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->