### PR TITLE
test(schema-org): add client-side dispose lifecycle tests

### DIFF
--- a/packages/schema-org/test/e2e/dispose-client.test.ts
+++ b/packages/schema-org/test/e2e/dispose-client.test.ts
@@ -1,6 +1,5 @@
 import { defineWebPage, defineWebSite, UnheadSchemaOrg, useSchemaOrg } from '@unhead/schema-org'
-import { useHead } from 'unhead'
-import { createHead as createClientHead, renderDOMHead } from 'unhead/client'
+import { createHead as createClientHead } from 'unhead/client'
 import { createHead as createServerHead, renderSSRHead } from 'unhead/server'
 import { describe, expect, it } from 'vitest'
 import { useDom } from '../../../unhead/test/fixtures'
@@ -9,7 +8,6 @@ describe('schema.org client dispose (#577)', () => {
   it('clears schema-org from DOM when entry is disposed (manual render)', async () => {
     const dom = useDom()
     const csrHead = createClientHead({
-      disableDefaults: true,
       plugins: [UnheadSchemaOrg({ host: 'https://example.com' })],
       document: dom.window.document,
     })
@@ -40,7 +38,6 @@ describe('schema.org client dispose (#577)', () => {
   it('fully clears schema-org from DOM when all entries disposed (auto render)', async () => {
     const dom = useDom()
     const csrHead = createClientHead({
-      disableDefaults: true,
       plugins: [UnheadSchemaOrg({ host: 'https://example.com' })],
       document: dom.window.document,
     })
@@ -63,7 +60,6 @@ describe('schema.org client dispose (#577)', () => {
   it('re-mount after dispose shows new schema data', async () => {
     const dom = useDom()
     const csrHead = createClientHead({
-      disableDefaults: true,
       plugins: [UnheadSchemaOrg({ host: 'https://example.com' })],
       document: dom.window.document,
     })
@@ -109,7 +105,6 @@ describe('schema.org client dispose (#577)', () => {
     // Hydrate on client
     const dom = useDom(data)
     const csrHead = createClientHead({
-      disableDefaults: true,
       plugins: [UnheadSchemaOrg({ host: 'https://example.com' })],
       document: dom.window.document,
     })


### PR DESCRIPTION
## Summary
- Adds e2e tests verifying schema-org JSON-LD is correctly removed from the DOM when entries are disposed on the client
- Covers: partial dispose (one of multiple entries), full dispose, re-mount after dispose, and SSR hydration + dispose
- Confirms #577 is resolved by the schema-org graph rework (graph resets each render cycle, only active entries contribute nodes)

Closes #577

## Test plan
- [x] All 4 new tests pass on current main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating schema.org JSON-LD DOM behavior in client-rendered and hydrated SSR scenarios: clearing a single entry preserves other schema, disposing the last entry removes JSON-LD output completely (including graph payload), remounting with new data replaces old schema, and hydrating then disposing clears only the corresponding hydrated schema while keeping others intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->