### PR TITLE
fix: proper script `importmap` & `speculationrules` handling

### DIFF
--- a/docs/head/1.guides/1.core-concepts/2.positions.md
+++ b/docs/head/1.guides/1.core-concepts/2.positions.md
@@ -61,13 +61,25 @@ All tags are given a weight with the lower the number, the higher the priority.
 [Capo.js](https://rviscomi.github.io/capo.js/) weights are automatically applied to tags to avoid [Critical Request Chains](https://web.dev/critical-request-chains/). As
 well as default weights to avoid site stability issues:
 
+- **-30**: `<meta http-equiv="content-security-policy" ...>`{lang="html"}
 - **-20**: `<meta charset ...>`{lang="html"}
+- **-15**: `<meta name="viewport" ...>`{lang="html"}
 - **-10**: `<base>`{lang="html"}
-- **0**: `<meta http-equiv="content-security-policy" ...>`{lang="html"}
 - **10**: `<title>`{lang="html"}
 - **20**: `<link rel="preconnect" ...>`{lang="html"}
+- **30**: `<script async ...>`{lang="html"}
+- **40**: `<style>@import ...</style>`{lang="html"}
+- **50**: `<script type="importmap">`{lang="html"}, sync `<script>`{lang="html"} (inline or `src`)
+- **60**: `<style>`{lang="html"}, `<link rel="stylesheet" ...>`{lang="html"}
+- **70**: `<link rel="preload" ...>`{lang="html"}, `<link rel="modulepreload" ...>`{lang="html"}
+- **80**: `<script defer ...>`{lang="html"}, `<script type="module" ...>`{lang="html"}
+- **90**: `<script type="speculationrules">`{lang="html"}, `<link rel="prefetch" ...>`{lang="html"}, `<link rel="dns-prefetch" ...>`{lang="html"}, `<link rel="prerender" ...>`{lang="html"}
 
 All other tags have a default priority of `100`{lang="bash"}.
+
+::note
+`<script type="importmap">`{lang="html"} is pinned to the sync-script weight (50) so it is always emitted before `modulepreload`, `preload`, `defer` and `module` scripts as required by the HTML spec — only one importmap is rendered per document.
+::
 
 Escaping out of these default weights can be accomplished by setting the `tagPriority`{lang="bash"} property.
 

--- a/docs/head/1.guides/1.core-concepts/2.positions.md
+++ b/docs/head/1.guides/1.core-concepts/2.positions.md
@@ -67,9 +67,10 @@ well as default weights to avoid site stability issues:
 - **-10**: `<base>`{lang="html"}
 - **10**: `<title>`{lang="html"}
 - **20**: `<link rel="preconnect" ...>`{lang="html"}
+- **25**: `<script type="importmap">`{lang="html"}
 - **30**: `<script async ...>`{lang="html"}
 - **40**: `<style>@import ...</style>`{lang="html"}
-- **50**: `<script type="importmap">`{lang="html"}, sync `<script>`{lang="html"} (inline or `src`)
+- **50**: sync `<script>`{lang="html"} (inline or `src`)
 - **60**: `<style>`{lang="html"}, `<link rel="stylesheet" ...>`{lang="html"}
 - **70**: `<link rel="preload" ...>`{lang="html"}, `<link rel="modulepreload" ...>`{lang="html"}
 - **80**: `<script defer ...>`{lang="html"}, `<script type="module" ...>`{lang="html"}
@@ -78,7 +79,7 @@ well as default weights to avoid site stability issues:
 All other tags have a default priority of `100`{lang="bash"}.
 
 ::note
-`<script type="importmap">`{lang="html"} is pinned to the sync-script weight (50) so it is always emitted before `modulepreload`, `preload`, `defer` and `module` scripts as required by the HTML spec — only one importmap is rendered per document.
+`<script type="importmap">`{lang="html"} is pinned at weight 25 so it is always emitted before async scripts, module scripts and `modulepreload` as required by the HTML spec. Multiple importmaps are allowed — browsers merge them into a single global import map — so unhead does not force-dedupe them. Use an explicit `key` if you want last-wins replacement instead of merging.
 ::
 
 Escaping out of these default weights can be accomplished by setting the `tagPriority`{lang="bash"} property.

--- a/packages/unhead/src/server/sort.ts
+++ b/packages/unhead/src/server/sort.ts
@@ -6,7 +6,7 @@ const TAG_WEIGHTS = { base: -10, title: 10 } as const
 const CAPO_WEIGHTS = {
   meta: { 'content-security-policy': -30, 'charset': -20, 'viewport': -15 },
   link: { 'preconnect': 20, 'stylesheet': 60, 'preload': 70, 'modulepreload': 70, 'prefetch': 90, 'dns-prefetch': 90, 'prerender': 90 },
-  script: { async: 30, defer: 80, sync: 50 },
+  script: { async: 30, defer: 80, sync: 50, speculationrules: 90 },
   style: { imported: 40, sync: 60 },
 } as const
 const ImportStyleRe = /@import/
@@ -30,7 +30,13 @@ export function capoTagWeight(tag: HeadTag): number {
   }
   else if (tag.tag === 'script') {
     const type = String(tag.props.type)
-    if (isTruthy(tag.props.async))
+    if (type === 'importmap')
+      // must precede modules and modulepreload per HTML spec
+      weight = CAPO_WEIGHTS.script.sync
+    else if (type === 'speculationrules')
+      // performance hint, belongs late in head alongside prefetch/prerender
+      weight = CAPO_WEIGHTS.script.speculationrules
+    else if (isTruthy(tag.props.async))
       weight = CAPO_WEIGHTS.script.async
     else if ((tag.props.src && !isTruthy(tag.props.defer) && !isTruthy(tag.props.async) && type !== 'module' && !type.endsWith('json')) || (tag.innerHTML && !type.endsWith('json')))
       weight = CAPO_WEIGHTS.script.sync

--- a/packages/unhead/src/server/sort.ts
+++ b/packages/unhead/src/server/sort.ts
@@ -40,7 +40,7 @@ export function capoTagWeight(tag: HeadTag): number {
       weight = CAPO_WEIGHTS.script.speculationrules
     else if (isTruthy(tag.props.async))
       weight = CAPO_WEIGHTS.script.async
-    else if ((tag.props.src && !isTruthy(tag.props.defer) && !isTruthy(tag.props.async) && type !== 'module' && !type.endsWith('json')) || (tag.innerHTML && !type.endsWith('json')))
+    else if ((tag.props.src && !isTruthy(tag.props.defer) && !isTruthy(tag.props.async) && type !== 'module' && !type.endsWith('json')) || ((tag.innerHTML || tag.textContent) && !type.endsWith('json')))
       weight = CAPO_WEIGHTS.script.sync
     else if ((isTruthy(tag.props.defer) && tag.props.src && !isTruthy(tag.props.async)) || type === 'module')
       weight = CAPO_WEIGHTS.script.defer

--- a/packages/unhead/src/server/sort.ts
+++ b/packages/unhead/src/server/sort.ts
@@ -6,7 +6,7 @@ const TAG_WEIGHTS = { base: -10, title: 10 } as const
 const CAPO_WEIGHTS = {
   meta: { 'content-security-policy': -30, 'charset': -20, 'viewport': -15 },
   link: { 'preconnect': 20, 'stylesheet': 60, 'preload': 70, 'modulepreload': 70, 'prefetch': 90, 'dns-prefetch': 90, 'prerender': 90 },
-  script: { async: 30, defer: 80, sync: 50, speculationrules: 90 },
+  script: { importmap: 25, async: 30, defer: 80, sync: 50, speculationrules: 90 },
   style: { imported: 40, sync: 60 },
 } as const
 const ImportStyleRe = /@import/
@@ -31,8 +31,10 @@ export function capoTagWeight(tag: HeadTag): number {
   else if (tag.tag === 'script') {
     const type = String(tag.props.type)
     if (type === 'importmap')
-      // must precede modules and modulepreload per HTML spec
-      weight = CAPO_WEIGHTS.script.sync
+      // parse-time directive, not a loadable resource: placed between
+      // preconnect (20) and async scripts (30) so it precedes every module
+      // script (including `<script type="module" async>`) per HTML spec
+      weight = CAPO_WEIGHTS.script.importmap
     else if (type === 'speculationrules')
       // performance hint, belongs late in head alongside prefetch/prerender
       weight = CAPO_WEIGHTS.script.speculationrules

--- a/packages/unhead/src/types/schema/script.ts
+++ b/packages/unhead/src/types/schema/script.ts
@@ -292,9 +292,9 @@ export interface ImportMapConfig {
 }
 
 /**
- * Import map
+ * Import map. Requires either `textContent` (recommended) or `innerHTML`.
  */
-export type ImportMapScript = ScriptBase & NoLoadableScriptProps & DataScriptTextContent<string | ImportMapConfig> & {
+export type ImportMapScript = ScriptBase & NoLoadableScriptProps & {
   /**
    * This attribute indicates the type of script represented.
    * Required discriminant for import map scripts.
@@ -302,7 +302,18 @@ export type ImportMapScript = ScriptBase & NoLoadableScriptProps & DataScriptTex
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
    */
   type: 'importmap'
-}
+} & (
+  | {
+    /** Import map content as a string or ImportMapConfig object (auto-serialized). */
+    textContent: string | ImportMapConfig
+    innerHTML?: never
+  }
+  | {
+    textContent?: never
+    /** Import map content as a string or ImportMapConfig object (auto-serialized). */
+    innerHTML: string | ImportMapConfig
+  }
+)
 
 // ============================================================================
 // Application JSON Script

--- a/packages/unhead/src/types/schema/script.ts
+++ b/packages/unhead/src/types/schema/script.ts
@@ -294,7 +294,7 @@ export interface ImportMapConfig {
 /**
  * Import map
  */
-export type ImportMapScript = ScriptBase & NoLoadableScriptProps & {
+export type ImportMapScript = ScriptBase & NoLoadableScriptProps & DataScriptTextContent<string | ImportMapConfig> & {
   /**
    * This attribute indicates the type of script represented.
    * Required discriminant for import map scripts.
@@ -302,12 +302,6 @@ export type ImportMapScript = ScriptBase & NoLoadableScriptProps & {
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type
    */
   type: 'importmap'
-  /**
-   * Sets the textContent of an element.
-   * Can be a string or an ImportMapConfig object that will be serialized to JSON.
-   */
-  textContent: string | ImportMapConfig
-  innerHTML?: never
 }
 
 // ============================================================================

--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -18,9 +18,6 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
     if (altKey)
       return `alternate:${altKey}`
   }
-  // importmap is unique per document per HTML spec
-  if (t === 'script' && props.type === 'importmap')
-    return 'script:importmap'
 
   if (props.charset)
     return 'charset'

--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -18,6 +18,9 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
     if (altKey)
       return `alternate:${altKey}`
   }
+  // importmap is unique per document per HTML spec
+  if (t === 'script' && props.type === 'importmap')
+    return 'script:importmap'
 
   if (props.charset)
     return 'charset'

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -57,7 +57,7 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
     else if (TagConfigKeys.has(prop)) {
       if ((prop === 'textContent' || prop === 'innerHTML') && typeof value === 'object') {
         const type = input.type || 'application/json'
-        if (type.endsWith('json') || type === 'speculationrules') {
+        if (type.endsWith('json') || type === 'speculationrules' || type === 'importmap') {
           tag.props.type = input.type = type
           tag[prop] = JSON.stringify(value)
         }

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -82,7 +82,8 @@ export function sanitizeTags(tags: HeadTag[]): HeadTag[] {
     if (tag === 'meta' && !props.content && !props['http-equiv'] && !props.charset)
       return false
     if (tag === 'script' && innerHTML) {
-      t.innerHTML = String(props.type).endsWith('json')
+      const type = String(props.type)
+      t.innerHTML = type.endsWith('json') || type === 'importmap' || type === 'speculationrules'
         ? (typeof innerHTML === 'string' ? innerHTML : JSON.stringify(innerHTML)).replace(LT_RE, '\\u003C')
         : typeof innerHTML === 'string' ? innerHTML.replace(SCRIPT_END_RE, '<\\/script') : innerHTML
       t._d = dedupeKey(t)

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -81,11 +81,16 @@ export function sanitizeTags(tags: HeadTag[]): HeadTag[] {
       return false
     if (tag === 'meta' && !props.content && !props['http-equiv'] && !props.charset)
       return false
-    if (tag === 'script' && innerHTML) {
+    if (tag === 'script' && (innerHTML || t.textContent)) {
       const type = String(props.type)
-      t.innerHTML = type.endsWith('json') || type === 'importmap' || type === 'speculationrules'
-        ? (typeof innerHTML === 'string' ? innerHTML : JSON.stringify(innerHTML)).replace(LT_RE, '\\u003C')
-        : typeof innerHTML === 'string' ? innerHTML.replace(SCRIPT_END_RE, '<\\/script') : innerHTML
+      const isJsonLike = type.endsWith('json') || type === 'importmap' || type === 'speculationrules'
+      const escape = (content: unknown): unknown => isJsonLike
+        ? (typeof content === 'string' ? content : JSON.stringify(content)).replace(LT_RE, '\\u003C')
+        : typeof content === 'string' ? content.replace(SCRIPT_END_RE, '<\\/script') : content
+      if (innerHTML)
+        t.innerHTML = escape(innerHTML) as typeof innerHTML
+      if (t.textContent)
+        t.textContent = escape(t.textContent) as typeof t.textContent
       t._d = dedupeKey(t)
     }
     return true

--- a/packages/unhead/test/unit/plugins/capo.test.ts
+++ b/packages/unhead/test/unit/plugins/capo.test.ts
@@ -176,7 +176,8 @@ describe('capo', () => {
     head.push({
       script: [{
         type: 'importmap',
-        innerHTML: JSON.stringify({ imports: { '#entry': '/entry.js' } }),
+        // raw object exercises the normalize auto-serialization path
+        textContent: { imports: { '#entry': '/entry.js' } },
       }],
     })
 
@@ -185,6 +186,9 @@ describe('capo', () => {
     // IMPORTMAP must come first
     expect(scriptAndLinkTags[0].tag).toEqual('script')
     expect(scriptAndLinkTags[0].props.type).toEqual('importmap')
+    // normalize should have serialized the object to a JSON string
+    expect(typeof scriptAndLinkTags[0].textContent).toBe('string')
+    expect(scriptAndLinkTags[0].textContent).toContain('#entry')
     // MODULEPRELOAD
     expect(scriptAndLinkTags[1].tag).toEqual('link')
     expect(scriptAndLinkTags[1].props.rel).toEqual('modulepreload')
@@ -198,7 +202,8 @@ describe('capo', () => {
     head.push({
       script: [{
         type: 'speculationrules',
-        innerHTML: JSON.stringify({ prefetch: [{ source: 'list', urls: ['/next'] }] }),
+        // raw object exercises the normalize auto-serialization path
+        textContent: { prefetch: [{ source: 'list', urls: ['/next'] }] },
       }],
     })
     head.push({
@@ -225,5 +230,30 @@ describe('capo', () => {
     // speculationrules (90) last, after modules
     expect(scriptAndLinkTags[3].tag).toEqual('script')
     expect(scriptAndLinkTags[3].props.type).toEqual('speculationrules')
+  })
+
+  it('importmap precedes async module scripts', async () => {
+    const head = createServerHeadWithContext()
+    // async module scripts must not sort before importmap per HTML spec:
+    // importmap must be declared before any module script, async or not.
+    head.push({
+      script: [{
+        src: 'entry.js',
+        type: 'module',
+        async: true,
+      }],
+    })
+    head.push({
+      script: [{
+        type: 'importmap',
+        innerHTML: JSON.stringify({ imports: { '#entry': '/entry.js' } }),
+      }],
+    })
+
+    const resolvedTags = resolveTags(head)
+    const scriptTags = resolvedTags.filter(t => t.tag === 'script')
+    expect(scriptTags[0].props.type).toEqual('importmap')
+    expect(scriptTags[1].props.type).toEqual('module')
+    expect(scriptTags[1].props.async).toEqual(true)
   })
 })

--- a/packages/unhead/test/unit/plugins/capo.test.ts
+++ b/packages/unhead/test/unit/plugins/capo.test.ts
@@ -157,4 +157,73 @@ describe('capo', () => {
     expect(resolvedTags[16].tag).toEqual('meta')
     expect(resolvedTags[16].props.name).toEqual('description')
   })
+
+  it('importmap precedes modulepreload and module scripts', async () => {
+    const head = createServerHeadWithContext()
+    // push in reverse order to prove sorting, not insertion order
+    head.push({
+      script: [{
+        src: 'entry.js',
+        type: 'module',
+      }],
+    })
+    head.push({
+      link: [{
+        rel: 'modulepreload',
+        href: 'preloaded.js',
+      }],
+    })
+    head.push({
+      script: [{
+        type: 'importmap',
+        innerHTML: JSON.stringify({ imports: { '#entry': '/entry.js' } }),
+      }],
+    })
+
+    const resolvedTags = resolveTags(head)
+    const scriptAndLinkTags = resolvedTags.filter(t => t.tag === 'script' || t.tag === 'link')
+    // IMPORTMAP must come first
+    expect(scriptAndLinkTags[0].tag).toEqual('script')
+    expect(scriptAndLinkTags[0].props.type).toEqual('importmap')
+    // MODULEPRELOAD
+    expect(scriptAndLinkTags[1].tag).toEqual('link')
+    expect(scriptAndLinkTags[1].props.rel).toEqual('modulepreload')
+    // MODULE SCRIPT
+    expect(scriptAndLinkTags[2].tag).toEqual('script')
+    expect(scriptAndLinkTags[2].props.type).toEqual('module')
+  })
+
+  it('speculationrules sorts late alongside prefetch/prerender', async () => {
+    const head = createServerHeadWithContext()
+    head.push({
+      script: [{
+        type: 'speculationrules',
+        innerHTML: JSON.stringify({ prefetch: [{ source: 'list', urls: ['/next'] }] }),
+      }],
+    })
+    head.push({
+      link: [{ rel: 'stylesheet', href: 'styles.css' }],
+    })
+    head.push({
+      script: [{ src: 'sync.js' }],
+    })
+    head.push({
+      script: [{ src: 'module.js', type: 'module' }],
+    })
+
+    const resolvedTags = resolveTags(head)
+    const scriptAndLinkTags = resolvedTags.filter(t => t.tag === 'script' || t.tag === 'link')
+    // sync script (50) first
+    expect(scriptAndLinkTags[0].tag).toEqual('script')
+    expect(scriptAndLinkTags[0].props.src).toEqual('sync.js')
+    // stylesheet (60)
+    expect(scriptAndLinkTags[1].tag).toEqual('link')
+    expect(scriptAndLinkTags[1].props.rel).toEqual('stylesheet')
+    // module script (80)
+    expect(scriptAndLinkTags[2].tag).toEqual('script')
+    expect(scriptAndLinkTags[2].props.type).toEqual('module')
+    // speculationrules (90) last, after modules
+    expect(scriptAndLinkTags[3].tag).toEqual('script')
+    expect(scriptAndLinkTags[3].props.type).toEqual('speculationrules')
+  })
 })

--- a/packages/unhead/test/unit/plugins/capo.test.ts
+++ b/packages/unhead/test/unit/plugins/capo.test.ts
@@ -256,4 +256,24 @@ describe('capo', () => {
     expect(scriptTags[1].props.type).toEqual('module')
     expect(scriptTags[1].props.async).toEqual(true)
   })
+
+  it('inline script with textContent sorts in the sync bucket', async () => {
+    const head = createServerHeadWithContext()
+    // inline scripts can use textContent (recommended, XSS-safe) instead of
+    // innerHTML; they should still sort in the sync-script bucket (50), not
+    // fall through to the default 100.
+    head.push({
+      script: [{ src: 'prefetch.js', async: true }],
+    })
+    head.push({
+      script: [{ textContent: 'console.log("inline")' }],
+    })
+
+    const resolvedTags = resolveTags(head)
+    const scriptTags = resolvedTags.filter(t => t.tag === 'script')
+    // async (30) should come before sync inline (50)
+    expect(scriptTags[0].props.src).toEqual('prefetch.js')
+    expect(scriptTags[0].props.async).toEqual(true)
+    expect(scriptTags[1].textContent).toEqual('console.log("inline")')
+  })
 })

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -720,22 +720,67 @@ describe('dedupe', () => {
     expect(headTags).not.toContain('feed-v1.xml')
   })
 
-  it('importmap is unique per document', async () => {
+  it('multiple distinct importmaps render so the browser can merge them', async () => {
     const head = createServerHeadWithContext()
+    // Per HTML spec, browsers merge multiple importmaps into a single global
+    // import map. Unhead must not silently drop any, otherwise entries get lost.
     head.push({
       script: [{
         type: 'importmap',
-        innerHTML: JSON.stringify({ imports: { '#entry': '/v1.js' } }),
+        textContent: { imports: { '#entry': '/entry.js' } },
       }],
     })
     head.push({
       script: [{
         type: 'importmap',
-        innerHTML: JSON.stringify({ imports: { '#entry': '/v2.js' } }),
+        textContent: { imports: { '#helper': '/helper.js' } },
       }],
     })
     const { headTags } = await renderSSRHead(head)
-    // Only the latest importmap should render per HTML spec
+    // Both importmaps should render so the browser can merge them
+    expect(headTags.split('type="importmap"').length).toBe(3)
+    expect(headTags).toContain('/entry.js')
+    expect(headTags).toContain('/helper.js')
+  })
+
+  it('identical importmaps still collapse via content-based dedupe', async () => {
+    const head = createServerHeadWithContext()
+    const map = { imports: { '#entry': '/entry.js' } }
+    head.push({
+      script: [{
+        type: 'importmap',
+        textContent: map,
+      }],
+    })
+    head.push({
+      script: [{
+        type: 'importmap',
+        textContent: map,
+      }],
+    })
+    const { headTags } = await renderSSRHead(head)
+    // Exact duplicates are deduped by content-based key
+    expect(headTags.split('type="importmap"').length).toBe(2)
+  })
+
+  it('importmaps with the same key collapse to last-wins', async () => {
+    const head = createServerHeadWithContext()
+    head.push({
+      script: [{
+        key: 'base-map',
+        type: 'importmap',
+        textContent: { imports: { '#entry': '/v1.js' } },
+      }],
+    })
+    head.push({
+      script: [{
+        key: 'base-map',
+        type: 'importmap',
+        textContent: { imports: { '#entry': '/v2.js' } },
+      }],
+    })
+    const { headTags } = await renderSSRHead(head)
+    // Users who want "replace, not merge" can opt in via `key`
     expect(headTags.split('type="importmap"').length).toBe(2)
     expect(headTags).toContain('/v2.js')
     expect(headTags).not.toContain('/v1.js')

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -719,4 +719,25 @@ describe('dedupe', () => {
     expect(headTags).toContain('feed-v2.xml')
     expect(headTags).not.toContain('feed-v1.xml')
   })
+
+  it('importmap is unique per document', async () => {
+    const head = createServerHeadWithContext()
+    head.push({
+      script: [{
+        type: 'importmap',
+        innerHTML: JSON.stringify({ imports: { '#entry': '/v1.js' } }),
+      }],
+    })
+    head.push({
+      script: [{
+        type: 'importmap',
+        innerHTML: JSON.stringify({ imports: { '#entry': '/v2.js' } }),
+      }],
+    })
+    const { headTags } = await renderSSRHead(head)
+    // Only the latest importmap should render per HTML spec
+    expect(headTags.split('type="importmap"').length).toBe(2)
+    expect(headTags).toContain('/v2.js')
+    expect(headTags).not.toContain('/v1.js')
+  })
 })

--- a/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
+++ b/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
@@ -213,17 +213,20 @@ describe('useHeadSafe edge cases', () => {
       expect(ctx.headTags).toBe('')
     })
 
-    it('preserves HTML in JSON values (safe in ld+json context)', async () => {
+    it('escapes `<` in JSON values consistently for textContent and innerHTML', async () => {
+      // Defense-in-depth: the `\u003C` escape applies to all `<` characters
+      // in JSON-like script content, not only `</script>`. This matches the
+      // long-standing innerHTML behavior so textContent and innerHTML produce
+      // identical SSR output for ld+json/importmap/speculationrules scripts.
       const ctx = await safeRender({
         script: [{
           type: 'application/ld+json',
           textContent: '{"name":"<img onerror=alert(1)>"}',
         }],
       })
-      // ld+json content is NOT parsed as HTML by browsers, so HTML in values is safe
-      // The important thing is that </script> is escaped (tested above)
       expect(ctx.headTags).toContain('application/ld+json')
-      expect(ctx.headTags).toContain('"name":"<img onerror=alert(1)>"')
+      expect(ctx.headTags).toContain('\\u003Cimg onerror=alert(1)>')
+      expect(ctx.headTags).not.toContain('"<img')
     })
   })
 

--- a/packages/unhead/test/unit/server/xss.test.ts
+++ b/packages/unhead/test/unit/server/xss.test.ts
@@ -351,6 +351,34 @@ describe('xss', () => {
       <link rel="stylesheet" href="vbscript:alert(1)">"
     `)
   })
+  it('importmap textContent is escaped like JSON types', async () => {
+    const head = createServerHeadWithContext()
+    // textContent is the recommended path for json-like scripts; the
+    // `\u003C` escape must apply to textContent too, not just innerHTML.
+    head.push({
+      script: [{
+        type: 'importmap',
+        textContent: '{"imports":{"</script><script>alert(1)</script>":"/x.js"}}',
+      }],
+    })
+    const ctx = renderSSRHead(head)
+    expect(ctx.headTags).toContain('\\u003C')
+    expect(ctx.headTags).not.toMatch(/<\/script><script>alert/)
+  })
+
+  it('speculationrules textContent is escaped like JSON types', async () => {
+    const head = createServerHeadWithContext()
+    head.push({
+      script: [{
+        type: 'speculationrules',
+        textContent: '{"prefetch":[{"urls":["</script><script>alert(1)</script>"]}]}',
+      }],
+    })
+    const ctx = renderSSRHead(head)
+    expect(ctx.headTags).toContain('\\u003C')
+    expect(ctx.headTags).not.toMatch(/<\/script><script>alert/)
+  })
+
   it('style tag', async () => {
     // body {color: red;}</style><script>alert('XSS')</script><style>
     const head = createServerHeadWithContext()


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`<script type="importmap">` and `<script type="speculationrules">` mostly worked by accident and required casts like `type: 'importmap' as unknown as 'application/json'` alongside manual `tagPriority` hints. This PR aligns typing, normalization, escaping, capo sort and dedupe so both tags work cleanly with just `{ type, innerHTML }` or `{ type, textContent }`.

**importmap**

- `ImportMapScript` now uses `DataScriptTextContent<string | ImportMapConfig>`, so both `innerHTML` and `textContent` are accepted (string or config object) — no more casts.
- `normalize.ts` auto-`JSON.stringify`s objects passed for `importmap`.
- `resolve.ts` applies the `\u003C` escape to importmap content, matching JSON-type scripts.
- `sort.ts` pins importmap at the sync-script weight (50) so it is always emitted before `modulepreload` (70) and `module` scripts (80) as required by the HTML spec.
- `dedupe.ts` treats importmap as unique per document (HTML spec allows only one).

**speculationrules**

- `resolve.ts` applies the `\u003C` escape to speculationrules content alongside JSON types.
- `sort.ts` pins speculationrules at weight 90, alongside `<link rel=prefetch>` / `rel=prerender`, instead of accidentally landing in the sync-script bucket (50).

**Docs**

- `docs/head/1.guides/1.core-concepts/2.positions.md` — replaced the incomplete capo weight list with the full table. Fixes the incorrect CSP entry (`0` → `-30`) and adds viewport, async/sync/defer/module scripts, importmap, speculationrules, stylesheets, preloads and the prefetch tier.

**Tests**

- `test/unit/plugins/capo.test.ts` — importmap-before-modulepreload-and-modules ordering; speculationrules-sorted-late alongside prefetch.
- `test/unit/server/deduping.test.ts` — two importmap pushes collapse to the last one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Import Maps handling: explicit ordering, SSR dedupe, and configurable replacement (merge vs last‑wins)
  * Added Speculation Rules scripts with proper priority
  * Import Maps accept either textContent or innerHTML and are safely serialized/escaped for output

* **Documentation**
  * Updated head tag priority ordering and notes on Import Maps placement and replacement behavior

* **Tests**
  * Added unit and XSS regression tests covering ordering, dedupe, serialization, and escaping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->