### PR TITLE
fix(types): prevent string widening in SpeculationRules nested types

### DIFF
--- a/packages/unhead/src/types/schema/struct/speculationRules.ts
+++ b/packages/unhead/src/types/schema/struct/speculationRules.ts
@@ -1,13 +1,42 @@
 import type { ReferrerPolicy } from '../shared'
 
 export interface SpeculationRules {
-  prefetch?: readonly (SpeculationRuleList | SpeculationRuleDocument)[]
-  prerender?: readonly (SpeculationRuleList | SpeculationRuleDocument)[]
+  prefetch?: readonly SpeculationRule[]
+  prerender?: readonly SpeculationRule[]
 }
 
-export interface SpeculationRuleBase {
+/**
+ * A single speculation rule entry.
+ *
+ * List rules provide explicit `urls`; document rules provide a `where` selector.
+ * Both shapes share the same interface so TypeScript doesn't require exact
+ * literal `source` values, which avoids widening issues inside `useHead`.
+ *
+ * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md
+ */
+export interface SpeculationRule {
   /**
-   * A hint about how likely the user is to navigate to the URL
+   * The rule source type.
+   *
+   * `'list'` for explicit URL lists, `'document'` for selector-based rules.
+   *
+   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md
+   */
+  source?: 'list' | 'document' | (string & Record<never, never>)
+  /**
+   * Explicit URLs to speculate on (list rules).
+   *
+   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#list-rules
+   */
+  urls?: readonly string[]
+  /**
+   * Selector conditions for document rules.
+   *
+   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#document-rules
+   */
+  where?: SpeculationRuleWhere
+  /**
+   * A hint about how likely the user is to navigate to the URL.
    *
    * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#scores
    */
@@ -17,36 +46,26 @@ export interface SpeculationRuleBase {
    *
    * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#using-the-documents-base-url-for-external-speculation-rule-sets
    */
-  relative_to?: 'document'
+  relative_to?: 'document' | (string & Record<never, never>)
   /**
-   * Assertions in the rule about the capabilities of the user agent while executing them.
+   * Assertions about user agent capabilities required to execute the rule.
    *
    * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#requirements
    */
-  requires?: readonly 'anonymous-client-ip-when-cross-origin'[]
+  requires?: readonly ('anonymous-client-ip-when-cross-origin' | (string & Record<never, never>))[]
   /**
-   * Indicating where the page expects the prerendered content to be activated.
+   * Where the page expects the prerendered content to be activated.
    *
    * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#window-name-targeting-hints
    */
-  target_hint?: '_blank' | '_self' | '_parent' | '_top'
+  target_hint?: '_blank' | '_self' | '_parent' | '_top' | (string & Record<never, never>)
   /**
-   * The policy to use for the speculative request.
+   * The referrer policy for the speculative request.
    *
    * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#explicit-referrer-policy
    */
   referrer_policy?: ReferrerPolicy
 }
 
-export interface SpeculationRuleList extends SpeculationRuleBase {
-  source: 'list'
-  urls: readonly string[]
-}
-
 export type SpeculationRuleFn = 'and' | 'or' | 'href_matches' | 'selector_matches' | 'not'
 export type SpeculationRuleWhere = Partial<Record<SpeculationRuleFn, readonly Partial<(Record<SpeculationRuleFn, (Partial<Record<SpeculationRuleFn, string>>) | string>)>[]>>
-
-export interface SpeculationRuleDocument extends SpeculationRuleBase {
-  source: 'document'
-  where: SpeculationRuleWhere
-}


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When using `useHead` with speculation rules, TypeScript widens nested literal values like `source: 'list'` and `requires: ['anonymous-client-ip-when-cross-origin']` to `string`, which fails to match the discriminated union of `SpeculationRuleList | SpeculationRuleDocument`. This causes a type error that falls through to `ApplicationJsonScript`.

Merges `SpeculationRuleBase`, `SpeculationRuleList`, and `SpeculationRuleDocument` into a single `SpeculationRule` interface. Discrimination is now structural (`urls` vs `where` presence) rather than relying on literal `source` values. Fields that previously required exact literals (`source`, `requires`, `relative_to`, `target_hint`) now use the `(string & Record<never, never>)` pattern already established throughout the codebase for autocomplete with flexible matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated the structure of `prefetch` and `prerender` configuration in speculation rules to use a unified interface supporting both list and document-based rules.
  * Expanded field value options to support custom values in addition to predefined options for speculative loading rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->