### PR TITLE
fix(bundler): disable SSRStaticReplace in vite dev mode

### DIFF
--- a/packages/bundler/src/unplugin/SSRStaticReplace.ts
+++ b/packages/bundler/src/unplugin/SSRStaticReplace.ts
@@ -8,12 +8,15 @@ const JS_RE = /\.(?:c|m)?js$/
 
 export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() => {
   let ssr = false
+  let enabled = true
 
   return {
     name: 'unhead:ssr-static-replace',
     enforce: 'pre',
 
     transformInclude(id) {
+      if (!enabled)
+        return false
       if (!UNHEAD_MODULE_RE.test(id))
         return false
       return JS_RE.test(id)
@@ -42,6 +45,14 @@ export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() 
     },
     vite: {
       apply(_config: UserConfig, env: ConfigEnv): boolean {
+        // In dev mode (serve), both SSR and client environments share the same
+        // vite dev server. Statically replacing head.ssr would force one value
+        // for both environments, breaking SSR renders. Only apply during builds
+        // where SSR and client are separate passes.
+        if (env.command === 'serve') {
+          enabled = false
+          return true
+        }
         if (env.isSsrBuild)
           ssr = true
         return true

--- a/packages/bundler/test/ssrStaticReplace.test.ts
+++ b/packages/bundler/test/ssrStaticReplace.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { SSRStaticReplace } from '../src/unplugin/SSRStaticReplace'
+
+function createPlugin(env: { isSsrBuild?: boolean, command?: string } = {}) {
+  const plugin = SSRStaticReplace.vite({}) as any
+  // simulate vite calling apply()
+  plugin.apply({}, { isSsrBuild: env.isSsrBuild ?? false, command: env.command ?? 'build' })
+  return plugin
+}
+
+function transform(plugin: any, code: string, id: string) {
+  if (plugin.transformInclude && !plugin.transformInclude(id))
+    return undefined
+  return plugin.transform(code, id)
+}
+
+const UNHEAD_MODULE_ID = '/node_modules/@unhead/vue/dist/index.mjs'
+const USER_MODULE_ID = '/src/app.js'
+
+describe('ssrStaticReplace', () => {
+  it('only transforms unhead modules', () => {
+    const plugin = createPlugin()
+    expect(plugin.transformInclude(UNHEAD_MODULE_ID)).toBe(true)
+    expect(plugin.transformInclude(USER_MODULE_ID)).toBe(false)
+    expect(plugin.transformInclude('/node_modules/unhead/dist/index.mjs')).toBe(true)
+    expect(plugin.transformInclude('/src/components/Head.vue')).toBe(false)
+  })
+
+  it('replaces head.ssr with false for client builds', () => {
+    const plugin = createPlugin({ isSsrBuild: false, command: 'build' })
+    const result = transform(plugin, 'if (head.ssr) { doServerThing() }', UNHEAD_MODULE_ID)
+    expect(result?.code).toContain('if (false)')
+  })
+
+  it('replaces head.ssr with true for SSR builds', () => {
+    const plugin = createPlugin({ isSsrBuild: true, command: 'build' })
+    const result = transform(plugin, 'if (head.ssr) { doServerThing() }', UNHEAD_MODULE_ID)
+    expect(result?.code).toContain('if (true)')
+  })
+
+  it('should not apply in dev mode (vite serve)', () => {
+    const plugin = createPlugin({ isSsrBuild: false, command: 'serve' })
+    // in dev mode, head.ssr should NOT be statically replaced because both
+    // SSR and client environments share the same vite dev server. The runtime
+    // value of head.ssr must be preserved so SSR renders use head.push()
+    // while client renders use clientUseHead().
+    const result = transform(plugin, 'if (head.ssr) { doServerThing() }', UNHEAD_MODULE_ID)
+    expect(result).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

In vite dev mode, SSR and client environments share the same dev server, but `SSRStaticReplace` was rewriting `head.ssr` to `false` for both, forcing `useHead` down the `clientUseHead` path during SSR renders. That broke reactive ref resolution in SSR because `clientUseHead` relies on Vue watchers rather than synchronous `head.push`.

Fix disables the static replacement in dev mode so the runtime `head.ssr` value is preserved and each environment behaves correctly. Unit tests cover client builds, SSR builds, and dev mode.