### PR TITLE
chore(bench): add vue client seo bundle size and perf benchmarks

### DIFF
--- a/bench/bundle/src/vue-client/minimal-seo.ts
+++ b/bench/bundle/src/vue-client/minimal-seo.ts
@@ -1,0 +1,22 @@
+import { useSeoMeta } from '@unhead/vue'
+import { createHead } from '@unhead/vue/client'
+
+// Realistic SEO usage — what most apps actually write.
+const head = createHead()
+
+useSeoMeta({
+  title: 'Test',
+  titleTemplate: '%s | Site',
+  description: 'Test description',
+  ogTitle: 'Test',
+  ogDescription: 'Test description',
+  ogImage: '/og.png',
+  ogType: 'website',
+  ogSiteName: 'Site',
+  twitterCard: 'summary_large_image',
+  twitterTitle: 'Test',
+  twitterDescription: 'Test description',
+  twitterImage: '/og.png',
+}, {
+  head,
+})

--- a/bench/bundle/vue-client-seo-build.config.ts
+++ b/bench/bundle/vue-client-seo-build.config.ts
@@ -1,0 +1,53 @@
+// Baseline: builds the realistic useSeoMeta source WITHOUT the Unhead Vite plugin.
+// Pair with `vue-client-seo-plugin-build.config.ts` (same source, transforms applied)
+// to measure what the unified Vite plugin actually saves.
+import fs from 'node:fs'
+import path from 'node:path'
+import zlib from 'node:zlib'
+import { defineBuildConfig } from 'unbuild'
+
+const packagesDir = path.resolve(__dirname, '../../packages')
+
+export default defineBuildConfig({
+  entries: [
+    'src/vue-client/minimal-seo',
+  ],
+  outDir: 'dist/vue-client-seo',
+  failOnWarn: false,
+  rollup: {
+    inlineDependencies: true,
+    esbuild: {
+      treeShaking: true,
+      minify: true,
+    },
+    alias: {
+      entries: [
+        { find: '@unhead/vue/client', replacement: path.join(packagesDir, 'vue/dist/client.mjs') },
+        { find: '@unhead/vue', replacement: path.join(packagesDir, 'vue/dist/index.mjs') },
+        { find: 'unhead/client', replacement: path.join(packagesDir, 'unhead/dist/client.mjs') },
+        { find: 'unhead/server', replacement: path.join(packagesDir, 'unhead/dist/server.mjs') },
+        { find: 'unhead/plugins', replacement: path.join(packagesDir, 'unhead/dist/plugins.mjs') },
+        { find: 'unhead/scripts', replacement: path.join(packagesDir, 'unhead/dist/scripts.mjs') },
+        { find: 'unhead/utils', replacement: path.join(packagesDir, 'unhead/dist/utils.mjs') },
+        { find: 'unhead/types', replacement: path.join(packagesDir, 'unhead/dist/types.mjs') },
+        { find: 'unhead/parser', replacement: path.join(packagesDir, 'unhead/dist/parser.mjs') },
+        { find: 'unhead/minify', replacement: path.join(packagesDir, 'unhead/dist/minify.mjs') },
+        { find: /^unhead$/, replacement: path.join(packagesDir, 'unhead/dist/index.mjs') },
+      ],
+    },
+  },
+  externals: [
+    'hookable',
+    'vue',
+  ],
+  declaration: false,
+  hooks: {
+    'build:done': () => {
+      const file = path.resolve(__dirname, 'dist/vue-client-seo/vue-client/minimal-seo.mjs')
+      const contents = fs.readFileSync(file)
+      const size = contents.length
+      const compressed = zlib.gzipSync(contents).length
+      console.log(`VUE CLIENT SEO (baseline) Size: ${size} bytes (${Math.round(size / 102.4) / 10} kB) gzipped: ${compressed} bytes (${Math.round(compressed / 102.4) / 10} kB)`)
+    },
+  },
+})

--- a/bench/bundle/vue-client-seo-plugin-build.config.ts
+++ b/bench/bundle/vue-client-seo-plugin-build.config.ts
@@ -1,0 +1,64 @@
+// With Unhead Vite plugin: same source as `vue-client-seo-build.config.ts` but
+// runs every UseSeoMetaTransform + SSRStaticReplace + TreeshakeServerComposables
+// via unplugin's rollup adapter before bundling. Measures the bundle savings
+// the unified `@unhead/{framework}/vite` plugin actually delivers.
+import fs from 'node:fs'
+import path from 'node:path'
+import zlib from 'node:zlib'
+import { defineBuildConfig } from 'unbuild'
+import { SSRStaticReplace } from '../../packages/bundler/src/unplugin/SSRStaticReplace'
+import { TreeshakeServerComposables } from '../../packages/bundler/src/unplugin/TreeshakeServerComposables'
+import { UseSeoMetaTransform } from '../../packages/bundler/src/unplugin/UseSeoMetaTransform'
+
+const packagesDir = path.resolve(__dirname, '../../packages')
+
+export default defineBuildConfig({
+  entries: [
+    'src/vue-client/minimal-seo',
+  ],
+  outDir: 'dist/vue-client-seo-plugin',
+  failOnWarn: false,
+  rollup: {
+    inlineDependencies: true,
+    esbuild: {
+      treeShaking: true,
+      minify: true,
+    },
+    alias: {
+      entries: [
+        { find: '@unhead/vue/client', replacement: path.join(packagesDir, 'vue/dist/client.mjs') },
+        { find: '@unhead/vue', replacement: path.join(packagesDir, 'vue/dist/index.mjs') },
+        { find: 'unhead/client', replacement: path.join(packagesDir, 'unhead/dist/client.mjs') },
+        { find: 'unhead/server', replacement: path.join(packagesDir, 'unhead/dist/server.mjs') },
+        { find: 'unhead/plugins', replacement: path.join(packagesDir, 'unhead/dist/plugins.mjs') },
+        { find: 'unhead/scripts', replacement: path.join(packagesDir, 'unhead/dist/scripts.mjs') },
+        { find: 'unhead/utils', replacement: path.join(packagesDir, 'unhead/dist/utils.mjs') },
+        { find: 'unhead/types', replacement: path.join(packagesDir, 'unhead/dist/types.mjs') },
+        { find: 'unhead/parser', replacement: path.join(packagesDir, 'unhead/dist/parser.mjs') },
+        { find: 'unhead/minify', replacement: path.join(packagesDir, 'unhead/dist/minify.mjs') },
+        { find: /^unhead$/, replacement: path.join(packagesDir, 'unhead/dist/index.mjs') },
+      ],
+    },
+  },
+  externals: [
+    'hookable',
+    'vue',
+  ],
+  declaration: false,
+  hooks: {
+    'rollup:options': (ctx, config) => {
+      config.plugins.unshift(
+        UseSeoMetaTransform.rollup({}),
+        TreeshakeServerComposables.rollup({}),
+        SSRStaticReplace.rollup({}),
+      )
+    },
+    'build:done': () => {
+      const file = path.resolve(__dirname, 'dist/vue-client-seo-plugin/vue-client/minimal-seo.mjs')
+      const contents = fs.readFileSync(file)
+      const size = contents.length
+      const compressed = zlib.gzipSync(contents).length
+      console.log(`VUE CLIENT SEO (with Unhead Vite plugin) Size: ${size} bytes (${Math.round(size / 102.4) / 10} kB) gzipped: ${compressed} bytes (${Math.round(compressed / 102.4) / 10} kB)`)
+    },
+  },
+})

--- a/bench/use-seo-meta-perf-transformed.bench.ts
+++ b/bench/use-seo-meta-perf-transformed.bench.ts
@@ -1,0 +1,36 @@
+// Hand-written equivalent of what the unified Vite plugin's `UseSeoMetaTransform`
+// emits when it rewrites `useSeoMeta({...})` into raw `useHead({ meta: [...] })`.
+// Compare against `use-seo-meta-perf.bench.ts` to see the runtime win from the
+// build-time transform.
+import { createHead, renderSSRHead } from 'unhead/server'
+import { bench, describe } from 'vitest'
+import { useHead } from '../packages/unhead/src'
+
+describe('use seo meta (vite plugin transformed)', () => {
+  bench('x50 ssr', async () => {
+    const head = createHead()
+    const page = {
+      title: 'Home',
+      description: 'Home page description',
+      image: 'https://nuxtjs.org/meta_0.png',
+    }
+    for (const i in Array.from({ length: 1000 })) {
+      useHead(head, {
+        title: `${page.title}-${i} | Nuxt`,
+        meta: [
+          { name: 'description', content: `${page.description} ${i}` },
+          { property: 'og:image', content: `${page.image}?${i}` },
+          { property: 'og:image:alt', content: `${page.image}?${i}` },
+          { property: 'og:site_name', content: 'Nuxt' },
+          { property: 'og:type', content: 'website' },
+        ],
+      }, {
+        head,
+      })
+    }
+    renderSSRHead(head)
+  }, {
+    iterations: 1000,
+    time: 1000,
+  })
+})

--- a/packages/bundler/src/unplugin/SSRStaticReplace.ts
+++ b/packages/bundler/src/unplugin/SSRStaticReplace.ts
@@ -8,12 +8,15 @@ const JS_RE = /\.(?:c|m)?js$/
 
 export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() => {
   let ssr = false
+  let enabled = true
 
   return {
     name: 'unhead:ssr-static-replace',
     enforce: 'pre',
 
     transformInclude(id) {
+      if (!enabled)
+        return false
       if (!UNHEAD_MODULE_RE.test(id))
         return false
       return JS_RE.test(id)
@@ -42,6 +45,14 @@ export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() 
     },
     vite: {
       apply(_config: UserConfig, env: ConfigEnv): boolean {
+        // In dev mode (serve), both SSR and client environments share the same
+        // vite dev server. Statically replacing head.ssr would force one value
+        // for both environments, breaking SSR renders. Only apply during builds
+        // where SSR and client are separate passes.
+        if (env.command === 'serve') {
+          enabled = false
+          return true
+        }
         if (env.isSsrBuild)
           ssr = true
         return true

--- a/packages/bundler/test/ssrStaticReplace.test.ts
+++ b/packages/bundler/test/ssrStaticReplace.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { SSRStaticReplace } from '../src/unplugin/SSRStaticReplace'
+
+function createPlugin(env: { isSsrBuild?: boolean, command?: string } = {}) {
+  const plugin = SSRStaticReplace.vite({}) as any
+  // simulate vite calling apply()
+  plugin.apply({}, { isSsrBuild: env.isSsrBuild ?? false, command: env.command ?? 'build' })
+  return plugin
+}
+
+function transform(plugin: any, code: string, id: string) {
+  if (plugin.transformInclude && !plugin.transformInclude(id))
+    return undefined
+  return plugin.transform(code, id)
+}
+
+const UNHEAD_MODULE_ID = '/node_modules/@unhead/vue/dist/index.mjs'
+const USER_MODULE_ID = '/src/app.js'
+
+describe('ssrStaticReplace', () => {
+  it('only transforms unhead modules', () => {
+    const plugin = createPlugin()
+    expect(plugin.transformInclude(UNHEAD_MODULE_ID)).toBe(true)
+    expect(plugin.transformInclude(USER_MODULE_ID)).toBe(false)
+    expect(plugin.transformInclude('/node_modules/unhead/dist/index.mjs')).toBe(true)
+    expect(plugin.transformInclude('/src/components/Head.vue')).toBe(false)
+  })
+
+  it('replaces head.ssr with false for client builds', () => {
+    const plugin = createPlugin({ isSsrBuild: false, command: 'build' })
+    const result = transform(plugin, 'if (head.ssr) { doServerThing() }', UNHEAD_MODULE_ID)
+    expect(result?.code).toContain('if (false)')
+  })
+
+  it('replaces head.ssr with true for SSR builds', () => {
+    const plugin = createPlugin({ isSsrBuild: true, command: 'build' })
+    const result = transform(plugin, 'if (head.ssr) { doServerThing() }', UNHEAD_MODULE_ID)
+    expect(result?.code).toContain('if (true)')
+  })
+
+  it('should not apply in dev mode (vite serve)', () => {
+    const plugin = createPlugin({ isSsrBuild: false, command: 'serve' })
+    // in dev mode, head.ssr should NOT be statically replaced because both
+    // SSR and client environments share the same vite dev server. The runtime
+    // value of head.ssr must be preserved so SSR renders use head.push()
+    // while client renders use clientUseHead().
+    const result = transform(plugin, 'if (head.ssr) { doServerThing() }', UNHEAD_MODULE_ID)
+    expect(result).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore

### 📚 Description

Adds benchmark configs to measure `useSeoMeta` bundle size with and without the Unhead Vite plugin transforms (UseSeoMetaTransform, SSRStaticReplace, TreeshakeServerComposables). Also includes a transformed variant of the SSR performance benchmark to compare runtime cost of pre-transformed `useHead` calls vs runtime `useSeoMeta` resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for SSR static replacement optimization, verifying correct behavior in both build and development environments.

* **Chores**
  * Added performance benchmarking infrastructure to evaluate SEO metadata handling and bundling efficiency.
  * Added multiple build configurations to measure optimization impact across different scenarios.
  * Optimized SSR transformation behavior to skip processing during development mode, improving local development server performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->