### PR TITLE
fix(legacy): restore exports for v2 migration

### DIFF
--- a/packages/unhead/build.config.ts
+++ b/packages/unhead/build.config.ts
@@ -63,6 +63,7 @@ export default defineBuildConfig({
     { input: 'src/scripts/index', name: 'scripts' },
     { input: 'src/utils', name: 'utils' },
     { input: 'src/plugins/index', name: 'plugins' },
+    { input: 'src/legacy/index', name: 'legacy' },
     { input: 'src/minify/index', name: 'minify' },
     { input: 'src/parser/index', name: 'parser' },
     { input: 'src/stream/vite', name: 'stream/vite' },

--- a/packages/unhead/package.json
+++ b/packages/unhead/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/plugins.d.ts",
       "default": "./dist/plugins.mjs"
     },
+    "./legacy": {
+      "types": "./dist/legacy.d.ts",
+      "default": "./dist/legacy.mjs"
+    },
     "./minify": {
       "types": "./dist/minify.d.ts",
       "default": "./dist/minify.mjs"
@@ -85,6 +89,9 @@
     "*": {
       "plugins": [
         "dist/plugins.d.ts"
+      ],
+      "legacy": [
+        "dist/legacy.d.ts"
       ],
       "minify": [
         "dist/minify.d.ts"

--- a/packages/unhead/src/legacy/index.ts
+++ b/packages/unhead/src/legacy/index.ts
@@ -1,4 +1,4 @@
-import type { CreateClientHeadOptions, CreateServerHeadOptions, ResolvableHead, Unhead } from '../types'
+import type { CreateClientHeadOptions, CreateServerHeadOptions, HeadPluginInput, ResolvableHead, Unhead } from '../types'
 import { createHead as _createClientHead } from '../client'
 import { AliasSortingPlugin } from '../plugins/aliasSorting'
 import { defineHeadPlugin } from '../plugins/defineHeadPlugin'
@@ -49,7 +49,7 @@ export const DeprecationsPlugin = /* @__PURE__ */ defineHeadPlugin({
  * The full v2 migration plugin set applied by the legacy `createHead`/`createServerHead`.
  * Export so users with a custom `createHead` can opt into one-line v2 compatibility.
  */
-export const legacyPlugins = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
+export const legacyPlugins: HeadPluginInput[] = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
 
 export const activeHead: { value: Unhead<any> | null } = { value: null }
 

--- a/packages/unhead/src/legacy/index.ts
+++ b/packages/unhead/src/legacy/index.ts
@@ -8,8 +8,8 @@ import { createHead as _createServerHead } from '../server'
 import { createUnhead } from '../unhead'
 
 /**
- * Maps unhead v1 tag props (`children`, `hid`, `vmid`, `body`) to their v3 equivalents
- * (`innerHTML`, `key`, `tagPosition`).
+ * Maps unhead v1/v2 tag props (`children`, `hid`, `vmid`, `body`, `renderPriority`) to their
+ * v3 equivalents (`innerHTML`, `key`, `tagPosition`, `tagPriority`).
  *
  * Intended as a temporary migration aid. Remove once all call sites use the v3 API.
  */
@@ -30,9 +30,15 @@ export const DeprecationsPlugin = /* @__PURE__ */ defineHeadPlugin({
           tag.key = tag.props.vmid
           delete tag.props.vmid
         }
-        if (tag.props.body) {
-          tag.tagPosition = 'bodyClose'
+        if ('body' in tag.props) {
+          if (tag.props.body) {
+            tag.tagPosition = 'bodyClose'
+          }
           delete tag.props.body
+        }
+        if (tag.props.renderPriority != null) {
+          tag.tagPriority = tag.props.renderPriority
+          delete tag.props.renderPriority
         }
       }
     },

--- a/packages/unhead/src/legacy/index.ts
+++ b/packages/unhead/src/legacy/index.ts
@@ -54,7 +54,7 @@ export function createHead<T extends Record<string, any> = ResolvableHead>(optio
   })
 }
 
-export function createServerHead<T extends Record<string, any> = ResolvableHead>(options: Omit<CreateServerHeadOptions, 'propsResolver'> = {}): Unhead<T> {
+export function createServerHead<T extends Record<string, any> = ResolvableHead>(options: Omit<CreateServerHeadOptions, 'propResolvers'> = {}): Unhead<T> {
   return activeHead.value = _createServerHead<T>({
     ...options,
     plugins: [...LEGACY_PLUGINS, ...(options.plugins || [])],

--- a/packages/unhead/src/legacy/index.ts
+++ b/packages/unhead/src/legacy/index.ts
@@ -1,0 +1,64 @@
+import type { CreateClientHeadOptions, CreateServerHeadOptions, ResolvableHead, Unhead } from '../types'
+import { createHead as _createClientHead } from '../client'
+import { AliasSortingPlugin } from '../plugins/aliasSorting'
+import { defineHeadPlugin } from '../plugins/defineHeadPlugin'
+import { PromisesPlugin } from '../plugins/promises'
+import { TemplateParamsPlugin } from '../plugins/templateParams'
+import { createHead as _createServerHead } from '../server'
+import { createUnhead } from '../unhead'
+
+/**
+ * Maps unhead v1 tag props (`children`, `hid`, `vmid`, `body`) to their v3 equivalents
+ * (`innerHTML`, `key`, `tagPosition`).
+ *
+ * Intended as a temporary migration aid. Remove once all call sites use the v3 API.
+ */
+export const DeprecationsPlugin = /* @__PURE__ */ defineHeadPlugin({
+  key: 'deprecations',
+  hooks: {
+    'entries:normalize': ({ tags }) => {
+      for (const tag of tags) {
+        if (tag.props.children) {
+          tag.innerHTML = tag.props.children
+          delete tag.props.children
+        }
+        if (tag.props.hid) {
+          tag.key = tag.props.hid
+          delete tag.props.hid
+        }
+        if (tag.props.vmid) {
+          tag.key = tag.props.vmid
+          delete tag.props.vmid
+        }
+        if (tag.props.body) {
+          tag.tagPosition = 'bodyClose'
+          delete tag.props.body
+        }
+      }
+    },
+  },
+})
+
+const LEGACY_PLUGINS = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
+
+export const activeHead: { value: Unhead<any> | null } = { value: null }
+
+export function getActiveHead<T extends Record<string, any> = ResolvableHead>(): Unhead<T> | null {
+  return activeHead.value
+}
+
+export function createHead<T extends Record<string, any> = ResolvableHead>(options: CreateClientHeadOptions = {}): Unhead<T> {
+  return activeHead.value = _createClientHead<T>({
+    ...options,
+    plugins: [...LEGACY_PLUGINS, ...(options.plugins || [])],
+  })
+}
+
+export function createServerHead<T extends Record<string, any> = ResolvableHead>(options: Omit<CreateServerHeadOptions, 'propsResolver'> = {}): Unhead<T> {
+  return activeHead.value = _createServerHead<T>({
+    ...options,
+    plugins: [...LEGACY_PLUGINS, ...(options.plugins || [])],
+  })
+}
+
+export const createHeadCore = createUnhead

--- a/packages/unhead/src/legacy/index.ts
+++ b/packages/unhead/src/legacy/index.ts
@@ -39,7 +39,11 @@ export const DeprecationsPlugin = /* @__PURE__ */ defineHeadPlugin({
   },
 })
 
-const LEGACY_PLUGINS = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
+/**
+ * The full v2 migration plugin set applied by the legacy `createHead`/`createServerHead`.
+ * Export so users with a custom `createHead` can opt into one-line v2 compatibility.
+ */
+export const legacyPlugins = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
 
 export const activeHead: { value: Unhead<any> | null } = { value: null }
 
@@ -50,14 +54,14 @@ export function getActiveHead<T extends Record<string, any> = ResolvableHead>():
 export function createHead<T extends Record<string, any> = ResolvableHead>(options: CreateClientHeadOptions = {}): Unhead<T> {
   return activeHead.value = _createClientHead<T>({
     ...options,
-    plugins: [...LEGACY_PLUGINS, ...(options.plugins || [])],
+    plugins: [...legacyPlugins, ...(options.plugins || [])],
   })
 }
 
 export function createServerHead<T extends Record<string, any> = ResolvableHead>(options: Omit<CreateServerHeadOptions, 'propResolvers'> = {}): Unhead<T> {
   return activeHead.value = _createServerHead<T>({
     ...options,
-    plugins: [...LEGACY_PLUGINS, ...(options.plugins || [])],
+    plugins: [...legacyPlugins, ...(options.plugins || [])],
   })
 }
 

--- a/packages/unhead/test/unit/plugins/deprecations.test.ts
+++ b/packages/unhead/test/unit/plugins/deprecations.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { DeprecationsPlugin } from '../../../src/legacy'
+import { renderSSRHead } from '../../../src/server'
+import { createServerHeadWithContext } from '../../util'
+
+describe('deprecationsPlugin', () => {
+  it('maps v1/v2 tag props to v3 equivalents', async () => {
+    const head = createServerHeadWithContext({ plugins: [DeprecationsPlugin] })
+    head.push({
+      script: [
+        // @ts-expect-error legacy v2 prop
+        { children: 'console.log(1)', hid: 'analytics' },
+      ],
+      meta: [
+        // @ts-expect-error legacy v2 prop
+        { name: 'description', content: 'a', vmid: 'desc' },
+      ],
+      noscript: [
+        // @ts-expect-error legacy v2 prop
+        { textContent: 'fallback', body: true, renderPriority: 5 },
+      ],
+    })
+
+    const { headTags, bodyTags } = await renderSSRHead(head)
+
+    expect(headTags).toContain('<script>console.log(1)</script>')
+    expect(headTags).toContain('<meta name="description" content="a">')
+    expect(bodyTags).toContain('<noscript')
+    expect(headTags).not.toMatch(/hid=|vmid=|body=|renderPriority=/)
+  })
+
+  it('strips body prop without moving tag when body is falsy', async () => {
+    const head = createServerHeadWithContext({ plugins: [DeprecationsPlugin] })
+    head.push({
+      script: [
+        // @ts-expect-error legacy v2 prop
+        { src: '/keep-in-head.js', body: false },
+      ],
+    })
+
+    const { headTags, bodyTags } = await renderSSRHead(head)
+
+    expect(headTags).toContain('<script src="/keep-in-head.js"></script>')
+    expect(headTags).not.toContain('body="false"')
+    expect(bodyTags).not.toContain('keep-in-head.js')
+  })
+
+  it('dedupes tags by hid across separate entries', async () => {
+    const head = createServerHeadWithContext({ plugins: [DeprecationsPlugin] })
+    head.push({
+      meta: [
+        // @ts-expect-error legacy v2 prop
+        { name: 'description', content: 'first', hid: 'desc' },
+      ],
+    })
+    head.push({
+      meta: [
+        // @ts-expect-error legacy v2 prop
+        { name: 'description', content: 'second', hid: 'desc' },
+      ],
+    })
+
+    const { headTags } = await renderSSRHead(head)
+
+    expect(headTags).toContain('content="second"')
+    expect(headTags).not.toContain('content="first"')
+  })
+})

--- a/packages/vue/src/legacy.ts
+++ b/packages/vue/src/legacy.ts
@@ -8,7 +8,11 @@ import { createHead as _createServerHead } from './server'
 export * from './client'
 export { createHead as createClientHead } from './client'
 
-const LEGACY_PLUGINS = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
+/**
+ * The full v2 migration plugin set applied by the legacy `createHead`/`createServerHead`.
+ * Export so users with a custom `createHead` can opt into one-line v2 compatibility.
+ */
+export const legacyPlugins = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
 
 /**
  * Creates a client `VueHeadClient` with the v2 migration plugin set pre-registered so that
@@ -19,7 +23,7 @@ const LEGACY_PLUGINS = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin
 export function createHead(options: CreateClientHeadOptions = {}): VueHeadClient<UseHeadInput, boolean> {
   return _createClientHead({
     ...options,
-    plugins: [...LEGACY_PLUGINS, ...(options.plugins || [])],
+    plugins: [...legacyPlugins, ...(options.plugins || [])],
   })
 }
 
@@ -30,6 +34,6 @@ export function createHead(options: CreateClientHeadOptions = {}): VueHeadClient
 export function createServerHead(options: Omit<CreateServerHeadOptions, 'propResolvers'> = {}): VueHeadClient<UseHeadInput, SSRHeadPayload> {
   return _createServerHead({
     ...options,
-    plugins: [...LEGACY_PLUGINS, ...(options.plugins || [])],
+    plugins: [...legacyPlugins, ...(options.plugins || [])],
   })
 }

--- a/packages/vue/src/legacy.ts
+++ b/packages/vue/src/legacy.ts
@@ -1,31 +1,35 @@
 import type { CreateClientHeadOptions, CreateServerHeadOptions, SSRHeadPayload } from 'unhead/types'
 import type { UseHeadInput, VueHeadClient } from './types'
 import { DeprecationsPlugin } from 'unhead/legacy'
+import { AliasSortingPlugin, PromisesPlugin, TemplateParamsPlugin } from 'unhead/plugins'
 import { createHead as _createClientHead } from './client'
 import { createHead as _createServerHead } from './server'
 
 export * from './client'
 export { createHead as createClientHead } from './client'
 
+const LEGACY_PLUGINS = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
+
 /**
- * Creates a client `VueHeadClient` with the v2 {@link DeprecationsPlugin} pre-registered so that
- * tag props (`children`, `hid`, `vmid`, `body`) continue to work during the migration to v3.
+ * Creates a client `VueHeadClient` with the v2 migration plugin set pre-registered so that
+ * tag props (`children`, `hid`, `vmid`, `body`), promise resolution, template params, and
+ * alias sorting continue to work during the migration to v3.
  */
 /* @__NO_SIDE_EFFECTS__ */
 export function createHead(options: CreateClientHeadOptions = {}): VueHeadClient<UseHeadInput, boolean> {
   return _createClientHead({
     ...options,
-    plugins: [DeprecationsPlugin, ...(options.plugins || [])],
+    plugins: [...LEGACY_PLUGINS, ...(options.plugins || [])],
   })
 }
 
 /**
- * Creates a server `VueHeadClient` with the v2 {@link DeprecationsPlugin} pre-registered.
+ * Creates a server `VueHeadClient` with the v2 migration plugin set pre-registered.
  */
 /* @__NO_SIDE_EFFECTS__ */
-export function createServerHead(options: Omit<CreateServerHeadOptions, 'propsResolver'> = {}): VueHeadClient<UseHeadInput, SSRHeadPayload> {
+export function createServerHead(options: Omit<CreateServerHeadOptions, 'propResolvers'> = {}): VueHeadClient<UseHeadInput, SSRHeadPayload> {
   return _createServerHead({
     ...options,
-    plugins: [DeprecationsPlugin, ...(options.plugins || [])],
+    plugins: [...LEGACY_PLUGINS, ...(options.plugins || [])],
   })
 }

--- a/packages/vue/src/legacy.ts
+++ b/packages/vue/src/legacy.ts
@@ -1,4 +1,4 @@
-import type { CreateClientHeadOptions, CreateServerHeadOptions, SSRHeadPayload } from 'unhead/types'
+import type { CreateClientHeadOptions, CreateServerHeadOptions, HeadPluginInput, SSRHeadPayload } from 'unhead/types'
 import type { UseHeadInput, VueHeadClient } from './types'
 import { DeprecationsPlugin } from 'unhead/legacy'
 import { AliasSortingPlugin, PromisesPlugin, TemplateParamsPlugin } from 'unhead/plugins'
@@ -12,7 +12,7 @@ export { createHead as createClientHead } from './client'
  * The full v2 migration plugin set applied by the legacy `createHead`/`createServerHead`.
  * Export so users with a custom `createHead` can opt into one-line v2 compatibility.
  */
-export const legacyPlugins = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
+export const legacyPlugins: HeadPluginInput[] = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
 
 /**
  * Creates a client `VueHeadClient` with the v2 migration plugin set pre-registered so that

--- a/packages/vue/src/legacy.ts
+++ b/packages/vue/src/legacy.ts
@@ -1,2 +1,31 @@
-console.warn('[unhead] `@unhead/vue/legacy` is deprecated. Import from `@unhead/vue/client` or `@unhead/vue/server` instead.')
+import type { CreateClientHeadOptions, CreateServerHeadOptions, SSRHeadPayload } from 'unhead/types'
+import type { UseHeadInput, VueHeadClient } from './types'
+import { DeprecationsPlugin } from 'unhead/legacy'
+import { createHead as _createClientHead } from './client'
+import { createHead as _createServerHead } from './server'
+
 export * from './client'
+export { createHead as createClientHead } from './client'
+
+/**
+ * Creates a client `VueHeadClient` with the v2 {@link DeprecationsPlugin} pre-registered so that
+ * tag props (`children`, `hid`, `vmid`, `body`) continue to work during the migration to v3.
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export function createHead(options: CreateClientHeadOptions = {}): VueHeadClient<UseHeadInput, boolean> {
+  return _createClientHead({
+    ...options,
+    plugins: [DeprecationsPlugin, ...(options.plugins || [])],
+  })
+}
+
+/**
+ * Creates a server `VueHeadClient` with the v2 {@link DeprecationsPlugin} pre-registered.
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export function createServerHead(options: Omit<CreateServerHeadOptions, 'propsResolver'> = {}): VueHeadClient<UseHeadInput, SSRHeadPayload> {
+  return _createServerHead({
+    ...options,
+    plugins: [DeprecationsPlugin, ...(options.plugins || [])],
+  })
+}

--- a/test/exports/unhead.yaml
+++ b/test/exports/unhead.yaml
@@ -11,6 +11,14 @@
   createDomRenderer: function
   createHead: function
   renderDOMHead: function
+./legacy:
+  activeHead: object
+  createHead: function
+  createHeadCore: function
+  createServerHead: function
+  DeprecationsPlugin: object
+  getActiveHead: function
+  legacyPlugins: object
 ./minify:
   minifyCSS: function
   minifyJS: function

--- a/test/exports/vue.yaml
+++ b/test/exports/vue.yaml
@@ -21,7 +21,10 @@
 ./components:
   Head: object
 ./legacy:
+  createClientHead: function
   createHead: function
+  createServerHead: function
+  legacyPlugins: object
   renderDOMHead: function
   VueHeadMixin: object
 ./plugins:


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The legacy entry points (`unhead/legacy` and `@unhead/vue/legacy`) had regressed to emitting a deprecation warning only, leaving v2 consumers without the `createHead` / `createServerHead` APIs they rely on during migration. This restores the legacy factories (plus `getActiveHead` and `createHeadCore` on the core entry) with `DeprecationsPlugin` and the other v2 plugins pre-registered so v1/v2 tag props (`children`, `hid`, `vmid`, `body`) keep working. Also adds `./legacy` to the `unhead` package `exports` and `build.config.ts` so the subpath is actually published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a legacy entrypoint to provide v1→v3 migration support and published a package subpath for it.
  * New legacy-friendly client/server factories that auto-apply migration plugins and expose the latest head instance.
  * Replaced a runtime deprecation warning with a legacy compatibility implementation in the Vue package.

* **Tests**
  * Added unit tests covering legacy prop mappings, body handling, and deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->