### PR TITLE
fix(vue): make HeadStream hydration-safe with data-allow-mismatch

### DIFF
--- a/examples/vite-ssr-vue-streaming/index.html
+++ b/examples/vite-ssr-vue-streaming/index.html
@@ -114,5 +114,5 @@
     </style>
     <script type="module" src="/src/entry-client.ts"></script>
   </head>
-  <body></body>
+  <body><div id="app"><!--app-html--></div></body>
 </html>

--- a/examples/vite-ssr-vue-streaming/src/App.vue
+++ b/examples/vite-ssr-vue-streaming/src/App.vue
@@ -3,8 +3,5 @@ import { RouterView } from 'vue-router'
 </script>
 
 <template>
-  <div id="app">
-    <RouterView />
-  </div>
+  <RouterView />
 </template>
-

--- a/examples/vite-ssr-vue-streaming/src/entry-client.ts
+++ b/examples/vite-ssr-vue-streaming/src/entry-client.ts
@@ -8,7 +8,6 @@ const head = createStreamableHead()!
 app.use(head)
 app.mixin(VueHeadMixin)
 
-// Wait until router is ready before mounting to ensure hydration match
 router.isReady().then(() => {
   app.mount('#app')
 })

--- a/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
+++ b/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
@@ -234,13 +234,17 @@ test.describe('Vue Streaming SSR with Unhead', () => {
     test('HeadStream scripts carry data-allow-mismatch for hydration safety', async ({ page }) => {
       await page.goto('/')
       await expect(page.locator('.newsletter')).toBeVisible({ timeout: 10000 })
-      const unsafe = await page.evaluate(() => {
+      const { total, unsafe } = await page.evaluate(() => {
         const nodes = Array.from(document.querySelectorAll('script'))
-        return nodes
+        const updateScripts = nodes
           .filter(n => (n.textContent || '').includes('window.__unhead__.push'))
-          .filter(n => !n.hasAttribute('data-allow-mismatch'))
-          .length
+        return {
+          total: updateScripts.length,
+          unsafe: updateScripts.filter(n => !n.hasAttribute('data-allow-mismatch')).length,
+        }
       })
+      // Guard must not be vacuous: at least one streamed update must have rendered.
+      expect(total).toBeGreaterThan(0)
       expect(unsafe).toBe(0)
     })
 

--- a/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
+++ b/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
@@ -228,29 +228,41 @@ test.describe('Vue Streaming SSR with Unhead', () => {
       await expect(page).toHaveTitle('StreamShop - Ready!')
     })
 
-    test('no unexpected console errors during streaming and hydration', async ({ page }) => {
-      const errors: string[] = []
+    // Regression guard for the HeadStream hydration model: every script
+    // that carries a streamed head update must have `data-allow-mismatch` so
+    // Vue tolerates the inner-text difference between server and client.
+    test('HeadStream scripts carry data-allow-mismatch for hydration safety', async ({ page }) => {
+      await page.goto('/')
+      await expect(page.locator('.newsletter')).toBeVisible({ timeout: 10000 })
+      const unsafe = await page.evaluate(() => {
+        const nodes = Array.from(document.querySelectorAll('script'))
+        return nodes
+          .filter(n => (n.textContent || '').includes('window.__unhead__.push'))
+          .filter(n => !n.hasAttribute('data-allow-mismatch'))
+          .length
+      })
+      expect(unsafe).toBe(0)
+    })
+
+    test('no unexpected console errors or hydration warnings', async ({ page }) => {
+      const issues: string[] = []
       page.on('console', msg => {
-        if (msg.type() === 'error') {
-          errors.push(msg.text())
-        }
+        if (msg.type() === 'error' || msg.type() === 'warning')
+          issues.push(`[${msg.type()}] ${msg.text()}`)
       })
 
       await page.goto('/')
       await expect(page.locator('.newsletter')).toBeVisible({ timeout: 10000 })
-
-      // Wait for hydration
       await page.waitForTimeout(500)
 
-      // Filter out expected non-critical errors
-      const criticalErrors = errors.filter(e =>
-        !e.includes('favicon') &&
-        !e.includes('Hydration') &&
-        !e.includes('mismatch') &&
-        !e.includes('WebSocket') &&
-        !e.includes('vite')
+      // No filter for hydration/mismatch: the symmetric HeadStream +
+      // `<!--app-html-->` outlet pattern must produce a clean hydration.
+      const critical = issues.filter(e =>
+        !e.includes('favicon')
+        && !e.includes('WebSocket')
+        && !e.includes('vite'),
       )
-      expect(criticalErrors).toHaveLength(0)
+      expect(critical, critical.join('\n')).toHaveLength(0)
     })
   })
 })

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -7,6 +7,8 @@ import { DEFAULT_STREAM_KEY } from './client'
 const LT_RE = /</g
 const GT_RE = />/g
 const AMP_RE = /&/g
+// Canonical Vite SSR outlet markers. Either form is accepted.
+const OUTLET_RE = /<!--\s*(?:app-html|ssr-outlet)\s*-->/
 
 // Conservative ASCII identifier: must be a safe `window.<name>` accessor.
 // Disallows anything that could break out of the dot-notation sink used by
@@ -227,6 +229,10 @@ function safeJsonStringify(obj: any): string {
  * 3. Streams the app content
  * 4. Writes the closing HTML (with body tags)
  *
+ * Per-suspense head updates ride inside the framework's own stream via
+ * the framework-specific `HeadStream` component (injected by the streaming
+ * Vite plugin). This function only owns the shell / end envelope.
+ *
  * @param head - The Unhead instance
  * @param stream - The app's ReadableStream (from renderToWebStream, etc.)
  * @param template - Full HTML template
@@ -336,16 +342,30 @@ export function prepareStreamingTemplate(
     // (e.g. scripts injected by Vite plugins via transformIndexHtml with
     // injectTo: 'body'). Without preserving this, anything plugins inject
     // into the body silently disappears in streaming mode.
-    const bodyInterior = template.substring(bodyEnd, bodyCloseStart)
+    let bodyInterior = template.substring(bodyEnd, bodyCloseStart)
     const endPart = template.substring(bodyCloseStart)
 
     const shellParsed = parseHtmlForIndexes(`${shellPart}</body></html>`)
-    const shell = applyHeadToHtml(shellParsed, {
+    let shell = applyHeadToHtml(shellParsed, {
       htmlAttrs: ssr.htmlAttrs,
       headTags: bootstrapScript + ssr.headTags,
       bodyAttrs: ssr.bodyAttrs,
       bodyTags: '',
     }).replace('</body></html>', '')
+
+    // If the template marks an explicit SSR outlet (canonical Vite pattern),
+    // split the body interior at that marker so the app stream lands inside
+    // it instead of before it. This lets a template wrap the stream in
+    // `<div id="app"><!--app-html--></div>` without creating a hydration
+    // container mismatch.
+    const outletMatch = bodyInterior.match(OUTLET_RE)
+    if (outletMatch) {
+      const outletIndex = outletMatch.index!
+      const beforeOutlet = bodyInterior.substring(0, outletIndex)
+      const afterOutlet = bodyInterior.substring(outletIndex + outletMatch[0].length)
+      shell = shell + beforeOutlet
+      bodyInterior = afterOutlet
+    }
 
     return {
       shell,

--- a/packages/unhead/test/streaming/streaming.test.ts
+++ b/packages/unhead/test/streaming/streaming.test.ts
@@ -698,6 +698,37 @@ describe('streaming SSR', () => {
       expect(end).toBe('</body></html>')
     })
 
+    it('splits shell/end at the <!--app-html--> outlet marker', () => {
+      const { head } = createStreamableHead()
+      head.push({ title: 'Outlet' })
+
+      // Canonical Vite SSR template: an explicit outlet inside a wrapper div.
+      const template = '<html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+      const { shell, end } = prepareStreamingTemplate(head, template)
+
+      // Wrapper opening must be in the shell so the app stream lands inside it.
+      expect(shell).toContain('<div id="app">')
+      expect(shell).not.toContain('<!--app-html-->')
+      // Wrapper close (and everything after the outlet) belongs to the end part.
+      expect(end.startsWith('</div>')).toBe(true)
+      expect(end).toContain('</body></html>')
+
+      // Round trip: the outlet marker is consumed, not duplicated.
+      const fullHtml = `${shell}STREAM${end}`
+      expect(fullHtml).not.toContain('<!--app-html-->')
+      expect(fullHtml).toContain('<div id="app">STREAM</div>')
+    })
+
+    it('also accepts <!--ssr-outlet--> as an outlet marker', () => {
+      const { head } = createStreamableHead()
+      const template = '<html><head></head><body><main><!-- ssr-outlet --></main></body></html>'
+      const { shell, end } = prepareStreamingTemplate(head, template)
+
+      expect(shell).toContain('<main>')
+      expect(shell).not.toContain('ssr-outlet')
+      expect(end.startsWith('</main>')).toBe(true)
+    })
+
     it('places head bodyTags after preserved body content', () => {
       const { head } = createStreamableHead()
       head.push({

--- a/packages/unhead/test/streaming/streaming.test.ts
+++ b/packages/unhead/test/streaming/streaming.test.ts
@@ -721,6 +721,17 @@ describe('streaming SSR', () => {
 
     it('also accepts <!--ssr-outlet--> as an outlet marker', () => {
       const { head } = createStreamableHead()
+      // No-space canonical form, matching the documented Vite marker.
+      const template = '<html><head></head><body><main><!--ssr-outlet--></main></body></html>'
+      const { shell, end } = prepareStreamingTemplate(head, template)
+
+      expect(shell).toContain('<main>')
+      expect(shell).not.toContain('ssr-outlet')
+      expect(end.startsWith('</main>')).toBe(true)
+    })
+
+    it('tolerates whitespace inside the outlet marker', () => {
+      const { head } = createStreamableHead()
       const template = '<html><head></head><body><main><!-- ssr-outlet --></main></body></html>'
       const { shell, end } = prepareStreamingTemplate(head, template)
 

--- a/packages/vue/src/stream/client.ts
+++ b/packages/vue/src/stream/client.ts
@@ -1,18 +1,25 @@
 import type { CreateStreamableClientHeadOptions, UnheadStreamQueue } from 'unhead/stream/client'
 import type { UseHeadInput, VueHeadClient } from '../types'
 import { createStreamableHead as _createStreamableHead } from 'unhead/stream/client'
-import { defineComponent } from 'vue'
+import { defineComponent, h } from 'vue'
 import { vueInstall } from '../install'
 import { VueResolver } from '../resolver'
 import { VueHeadMixin } from '../VueHeadMixin'
 
 /**
- * Client-side HeadStream - renders nothing (script already executed during SSR streaming)
+ * Client-side counterpart to the server `HeadStream`. Always emits a
+ * `<script data-allow-mismatch="children">` with empty `innerHTML`. The
+ * matching vnode type on both sides lets Vue hydrate the node; the
+ * `data-allow-mismatch` attribute silences the inner-content difference
+ * between the server-emitted streaming patch and this empty client vnode.
+ *
+ * The already-executed server script stays in the DOM after hydration — it's
+ * inert (scripts only execute on parse) and the placeholder is cheap.
  */
 export const HeadStream = defineComponent({
   name: 'HeadStream',
   setup() {
-    return () => null
+    return () => h('script', { 'data-allow-mismatch': 'children' })
   },
 })
 

--- a/packages/vue/src/stream/server.ts
+++ b/packages/vue/src/stream/server.ts
@@ -12,21 +12,28 @@ import { vueInstall } from '../install'
 import { VueResolver } from '../resolver'
 
 /**
- * Streaming script component - outputs inline script with current head state.
- * The Vite plugin with streaming: true auto-injects this.
+ * Emits a `<script data-allow-mismatch="children">` whose `innerHTML` is the
+ * pending head-update JS (if any). The client counterpart renders an identical
+ * `<script data-allow-mismatch="children">` with empty innerHTML: symmetric
+ * vnode types let Vue's hydrator match the node, and `data-allow-mismatch`
+ * silences the inner-content difference.
+ *
+ * The Vite plugin injects one `<HeadStream />` at the top of every SFC
+ * `<template>` that uses `useHead` / `useSeoMeta`.
  */
 export const HeadStream = defineComponent({
   name: 'HeadStream',
   setup() {
     const head = injectHead()
     return () => {
-      // Skip if shell hasn't been rendered yet - entries will be captured in shell
+      // Before `wrapStream` has captured the shell, entries belong to the
+      // initial render and are serialized by the shell, not re-emitted into
+      // the tree. Emit an empty placeholder so the client vnode tree stays in
+      // sync.
       if (!(head as any)._shellRendered?.())
-        return null
+        return h('script', { 'data-allow-mismatch': 'children' })
       const update = renderSSRHeadSuspenseChunk(head)
-      if (!update)
-        return null
-      return h('script', { innerHTML: update })
+      return h('script', { 'data-allow-mismatch': 'children', 'innerHTML': update || '' })
     }
   },
 })
@@ -55,10 +62,7 @@ export interface VueStreamableHeadContext extends Omit<WebStreamableHeadContext<
  *   app.mixin(VueHeadMixin)
  *   router.push(url)
  *
- *   // Create stream first - Vue starts rendering synchronously
  *   const vueStream = renderToWebStream(app)
- *
- *   // Wait for router - by now Vue's sync render has pushed head entries
  *   await router.isReady()
  *
  *   return wrapStream(vueStream, template)
@@ -75,17 +79,16 @@ export function createStreamableHead(
   const vueHead = head as VueHeadClient<any, SSRHeadPayload>
   vueHead.install = vueInstall(vueHead)
 
-  // Track shell render state - HeadStream skips entries until shell is rendered
+  // HeadStream flips from "empty placeholder" to "pending suspense-chunk JS"
+  // once `wrapStream` has captured the shell state.
   let shellRendered = false
   ;(vueHead as any)._shellRendered = () => shellRendered
 
   return {
     head: vueHead,
     wrapStream: (stream: ReadableStream<Uint8Array>, template: string) => {
-      // Capture shell state before clearing entries
       const preRenderedState = vueHead.render()
       vueHead.entries.clear()
-      // Mark shell as rendered so HeadStream starts outputting streaming updates
       shellRendered = true
       return coreWrapStream(vueHead, stream, template, preRenderedState)
     },

--- a/packages/vue/src/stream/server.ts
+++ b/packages/vue/src/stream/server.ts
@@ -19,7 +19,7 @@ import { VueResolver } from '../resolver'
  * silences the inner-content difference.
  *
  * The Vite plugin injects one `<HeadStream />` at the top of every SFC
- * `<template>` that uses `useHead` / `useSeoMeta`.
+ * `<template>` that uses `useHead` / `useSeoMeta` / `useHeadSafe`.
  */
 export const HeadStream = defineComponent({
   name: 'HeadStream',

--- a/packages/vue/src/stream/vite.ts
+++ b/packages/vue/src/stream/vite.ts
@@ -8,60 +8,28 @@ const SCRIPT_RE = /<script[^>]*>/i
 const FILTER_RE = /\.vue$/
 
 /**
- * Transforms Vue SFC code to inject HeadStream components for streaming SSR support.
+ * Transforms Vue SFC code to inject `<HeadStream />` components for streaming
+ * SSR support. One is added as the first child of each SFC `<template>` that
+ * uses `useHead` / `useSeoMeta` / `useHeadSafe`; an import is inserted into
+ * `<script>`.
  *
- * @param code - The source code to transform
- * @param id - The file path/id being transformed
- * @param isSSR - Whether the code is being transformed for SSR
- * @param s - MagicString instance for code manipulation
- * @returns `true` if transformations were applied, `false` otherwise
- *
- * @example
- * ```vue
- * // Input code:
- * <script setup>
- * import { useHead } from '@unhead/vue'
- *
- * useHead({
- *   title: 'My Page'
- * })
- * </script>
- *
- * <template>
- *   <div>Hello World</div>
- * </template>
- *
- * // Transformed output:
- * <script setup>
- * import { useHead } from '@unhead/vue'
- * import { HeadStream } from '@unhead/vue/stream/server' // or /client
- *
- * useHead({
- *   title: 'My Page'
- * })
- * </script>
- *
- * <template>
- *   <HeadStream /><div>Hello World</div>
- * </template>
- * ```
+ * On the server `HeadStream` emits a `<script data-allow-mismatch="children">`
+ * containing the pending head-update JS; on the client it emits an identical
+ * empty `<script>`. Symmetric vnode types + `data-allow-mismatch` make Vue's
+ * hydrator silently tolerate the inner-content difference.
  */
 function transform(code: string, id: string, isSSR: boolean, s: MagicString): boolean {
-  // Only transform files that use head composables
   if (!code.includes('useHead') && !code.includes('useSeoMeta') && !code.includes('useHeadSafe'))
     return false
 
-  // Find the template section
   const templateMatch = code.match(TEMPLATE_RE)
   if (!templateMatch)
     return false
 
   const templateStart = templateMatch.index! + templateMatch[0].length
 
-  // Inject HeadStream at the start of template content
   s.appendRight(templateStart, '<HeadStream />')
 
-  // Add import for HeadStream
   const importPath = `@unhead/vue/stream/${isSSR ? 'server' : 'client'}`
   const scriptMatch = code.match(SCRIPT_RE)
   if (!scriptMatch)
@@ -105,13 +73,9 @@ function transform(code: string, id: string, isSSR: boolean, s: MagicString): bo
 }
 
 /**
- * Vite plugin for Vue streaming SSR support.
- * Automatically injects HeadStream components into Vue SFC templates.
- *
- * @returns Vite plugin configuration object with:
- *   - `name`: Plugin identifier
- *   - `enforce`: Plugin execution order ('pre')
- *   - `transform`: Transform hook for processing .vue files
+ * Vite plugin for Vue streaming SSR support. Automatically injects
+ * `<HeadStream />` into Vue SFC templates for components that use head
+ * composables.
  *
  * @example
  * ```ts
@@ -120,8 +84,8 @@ function transform(code: string, id: string, isSSR: boolean, s: MagicString): bo
  *
  * export default {
  *   plugins: [
- *     unheadVuePlugin()
- *   ]
+ *     unheadVuePlugin(),
+ *   ],
  * }
  * ```
  */

--- a/packages/vue/test/streaming.test.ts
+++ b/packages/vue/test/streaming.test.ts
@@ -132,58 +132,66 @@ describe('vue streaming SSR', () => {
   })
 
   describe('headStream component', () => {
-    it('renders script tag with head updates via Vue SSR', async () => {
+    it('emits <script data-allow-mismatch="children"> with update content after shell', async () => {
       const { head } = createStreamableHead()
       await renderSSRHeadShell(head, '<html><head></head><body>')
-      // Mark shell as rendered for HeadStream to work (normally done by wrapStream)
       ;(head as any)._shellRendered = () => true
-
       head.push({ title: 'Streamed Title' })
 
-      // Create a minimal app that provides head and renders HeadStream
       const App = defineComponent({
         setup() {
           return () => h(HeadStream)
         },
       })
-
       const app = createSSRApp(App)
       app.provide('usehead', head)
-
       const html = await renderToString(app)
 
-      expect(html).toContain('<script>')
+      expect(html).toContain('data-allow-mismatch="children"')
       expect(html).toContain('window.__unhead__.push')
       expect(html).toContain('Streamed Title')
-      expect(html).toContain('</script>')
     })
 
-    it('renders null when no updates', async () => {
+    it('emits empty placeholder script when no updates are pending', async () => {
       const { head } = createStreamableHead()
       await renderSSRHeadShell(head, '<html><head></head><body>')
-
-      // No new entries pushed
+      ;(head as any)._shellRendered = () => true
 
       const App = defineComponent({
         setup() {
           return () => h(HeadStream)
         },
       })
-
       const app = createSSRApp(App)
       app.provide('usehead', head)
-
       const html = await renderToString(app)
 
-      expect(html).toBe('<!---->') // Vue SSR comment for null render
+      // Symmetric with the client vnode so Vue's hydrator matches.
+      expect(html).toBe('<script data-allow-mismatch="children"></script>')
+    })
+
+    it('emits empty placeholder before shell is rendered', async () => {
+      const { head } = createStreamableHead()
+      head.push({ title: 'Shell Title' })
+      // _shellRendered defaults to false: HeadStream must not leak shell-time
+      // entries back into the tree.
+
+      const App = defineComponent({
+        setup() {
+          return () => h(HeadStream)
+        },
+      })
+      const app = createSSRApp(App)
+      app.provide('usehead', head)
+      const html = await renderToString(app)
+
+      expect(html).toBe('<script data-allow-mismatch="children"></script>')
     })
 
     it('properly escapes script content to prevent XSS', async () => {
       const { head } = createStreamableHead()
       await renderSSRHeadShell(head, '<html><head></head><body>')
-      // Mark shell as rendered for HeadStream to work (normally done by wrapStream)
       ;(head as any)._shellRendered = () => true
-
       head.push({ title: '</script><script>alert("xss")</script>' })
 
       const App = defineComponent({
@@ -191,15 +199,12 @@ describe('vue streaming SSR', () => {
           return () => h(HeadStream)
         },
       })
-
       const app = createSSRApp(App)
       app.provide('usehead', head)
-
       const html = await renderToString(app)
 
-      // Should not contain unescaped closing script tag
-      expect(html).not.toContain('</script><script>')
-      expect(html).toContain('\\u003c') // Escaped <
+      expect(html).not.toContain('</script><script>alert')
+      expect(html).toContain('\\u003c')
     })
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

No existing issue. Surfaced while wiring streaming SSR into Nuxt; every streamed suspense boundary produced a Vue hydration warning.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`HeadStream` emitted a `<script>` on the server but `null` on the client, giving Vue asymmetric vnode trees and a hydration mismatch warning for every streamed suspense boundary. Both sides now render `<script data-allow-mismatch="children">`: matching vnode types let Vue's hydrator align the nodes, and `data-allow-mismatch` tells Vue to ignore the expected inner-content difference between the server's pending-update patch and the client's empty placeholder. The server-side script is already executed at parse time, so leaving it in the DOM post-hydration is inert.

Also splits the Vite streaming template at the canonical `<!--app-html-->` / `<!--ssr-outlet-->` marker so the app stream lands inside the user's `<div id="app">` outlet instead of before it, fixing a container mismatch when templates follow the standard Vite SSR pattern.

The `vite-ssr-vue-streaming` example is updated to the standard outlet layout, and its Playwright spec now hard-fails on any hydration/mismatch warning rather than filtering them out. A new regression test asserts every streamed head-update script carries `data-allow-mismatch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SSR streaming with outlet-marker support and a stable client mount point.
  * Head streaming now emits a safe placeholder script to align server/client hydration.

* **Bug Fixes**
  * App mounts immediately for faster startup.
  * Hydration mismatch checks tightened to reduce false positives.

* **Tests**
  * Expanded streaming tests, added DOM/console regression checks, and tightened XSS assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->