### PR TITLE
fix(vue): symmetric HeadStream vnodes for clean streaming hydration

### DIFF
--- a/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
+++ b/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
@@ -228,6 +228,24 @@ test.describe('Vue Streaming SSR with Unhead', () => {
       await expect(page).toHaveTitle('StreamShop - Ready!')
     })
 
+    // Regression guard for the HeadStream hydration model: every script
+    // that carries a streamed head update must have `data-allow-mismatch` so
+    // Vue tolerates the inner-text difference between server and client.
+    test('HeadStream scripts carry data-allow-mismatch for hydration safety', async ({ page }) => {
+      await page.goto('/')
+      await expect(page.locator('.newsletter')).toBeVisible({ timeout: 10000 })
+      const { total, unsafe } = await page.evaluate(() => {
+        const updateScripts = Array.from(document.querySelectorAll('script'))
+          .filter(n => (n.textContent || '').includes('window.__unhead__.push'))
+        return {
+          total: updateScripts.length,
+          unsafe: updateScripts.filter(n => !n.hasAttribute('data-allow-mismatch')).length,
+        }
+      })
+      expect(total).toBeGreaterThan(0)
+      expect(unsafe).toBe(0)
+    })
+
     test('no unexpected console errors during streaming and hydration', async ({ page }) => {
       const errors: string[] = []
       page.on('console', msg => {

--- a/packages/vue/src/stream/client.ts
+++ b/packages/vue/src/stream/client.ts
@@ -1,18 +1,25 @@
 import type { CreateStreamableClientHeadOptions, UnheadStreamQueue } from 'unhead/stream/client'
 import type { UseHeadInput, VueHeadClient } from '../types'
 import { createStreamableHead as _createStreamableHead } from 'unhead/stream/client'
-import { defineComponent } from 'vue'
+import { defineComponent, h } from 'vue'
 import { vueInstall } from '../install'
 import { VueResolver } from '../resolver'
 import { VueHeadMixin } from '../VueHeadMixin'
 
 /**
- * Client-side HeadStream - renders nothing (script already executed during SSR streaming)
+ * Client-side counterpart to the server `HeadStream`. Always emits a
+ * `<script data-allow-mismatch="children">` with empty `innerHTML`. The
+ * matching vnode type on both sides lets Vue hydrate the node; the
+ * `data-allow-mismatch` attribute silences the inner-content difference
+ * between the server-emitted streaming patch and this empty client vnode.
+ *
+ * The already-executed server script stays in the DOM after hydration — it's
+ * inert (scripts only execute on parse) and the placeholder is cheap.
  */
 export const HeadStream = defineComponent({
   name: 'HeadStream',
   setup() {
-    return () => null
+    return () => h('script', { 'data-allow-mismatch': 'children' })
   },
 })
 

--- a/packages/vue/src/stream/server.ts
+++ b/packages/vue/src/stream/server.ts
@@ -12,21 +12,28 @@ import { vueInstall } from '../install'
 import { VueResolver } from '../resolver'
 
 /**
- * Streaming script component - outputs inline script with current head state.
- * The Vite plugin with streaming: true auto-injects this.
+ * Emits a `<script data-allow-mismatch="children">` whose `innerHTML` is the
+ * pending head-update JS (if any). The client counterpart renders an identical
+ * `<script data-allow-mismatch="children">` with empty innerHTML: symmetric
+ * vnode types let Vue's hydrator match the node, and `data-allow-mismatch`
+ * silences the inner-content difference.
+ *
+ * The Vite plugin injects one `<HeadStream />` at the top of every SFC
+ * `<template>` that uses `useHead` / `useSeoMeta`.
  */
 export const HeadStream = defineComponent({
   name: 'HeadStream',
   setup() {
     const head = injectHead()
     return () => {
-      // Skip if shell hasn't been rendered yet - entries will be captured in shell
+      // Before `wrapStream` has captured the shell, entries belong to the
+      // initial render and are serialized by the shell, not re-emitted into
+      // the tree. Emit an empty placeholder so the client vnode tree stays in
+      // sync.
       if (!(head as any)._shellRendered?.())
-        return null
+        return h('script', { 'data-allow-mismatch': 'children' })
       const update = renderSSRHeadSuspenseChunk(head)
-      if (!update)
-        return null
-      return h('script', { innerHTML: update })
+      return h('script', { 'data-allow-mismatch': 'children', 'innerHTML': update || '' })
     }
   },
 })
@@ -55,10 +62,7 @@ export interface VueStreamableHeadContext extends Omit<WebStreamableHeadContext<
  *   app.mixin(VueHeadMixin)
  *   router.push(url)
  *
- *   // Create stream first - Vue starts rendering synchronously
  *   const vueStream = renderToWebStream(app)
- *
- *   // Wait for router - by now Vue's sync render has pushed head entries
  *   await router.isReady()
  *
  *   return wrapStream(vueStream, template)
@@ -75,17 +79,16 @@ export function createStreamableHead(
   const vueHead = head as VueHeadClient<any, SSRHeadPayload>
   vueHead.install = vueInstall(vueHead)
 
-  // Track shell render state - HeadStream skips entries until shell is rendered
+  // HeadStream flips from "empty placeholder" to "pending suspense-chunk JS"
+  // once `wrapStream` has captured the shell state.
   let shellRendered = false
   ;(vueHead as any)._shellRendered = () => shellRendered
 
   return {
     head: vueHead,
     wrapStream: (stream: ReadableStream<Uint8Array>, template: string) => {
-      // Capture shell state before clearing entries
       const preRenderedState = vueHead.render()
       vueHead.entries.clear()
-      // Mark shell as rendered so HeadStream starts outputting streaming updates
       shellRendered = true
       return coreWrapStream(vueHead, stream, template, preRenderedState)
     },

--- a/packages/vue/src/stream/vite.ts
+++ b/packages/vue/src/stream/vite.ts
@@ -8,60 +8,28 @@ const SCRIPT_RE = /<script[^>]*>/i
 const FILTER_RE = /\.vue$/
 
 /**
- * Transforms Vue SFC code to inject HeadStream components for streaming SSR support.
+ * Transforms Vue SFC code to inject `<HeadStream />` components for streaming
+ * SSR support. One is added as the first child of each SFC `<template>` that
+ * uses `useHead` / `useSeoMeta` / `useHeadSafe`; an import is inserted into
+ * `<script>`.
  *
- * @param code - The source code to transform
- * @param id - The file path/id being transformed
- * @param isSSR - Whether the code is being transformed for SSR
- * @param s - MagicString instance for code manipulation
- * @returns `true` if transformations were applied, `false` otherwise
- *
- * @example
- * ```vue
- * // Input code:
- * <script setup>
- * import { useHead } from '@unhead/vue'
- *
- * useHead({
- *   title: 'My Page'
- * })
- * </script>
- *
- * <template>
- *   <div>Hello World</div>
- * </template>
- *
- * // Transformed output:
- * <script setup>
- * import { useHead } from '@unhead/vue'
- * import { HeadStream } from '@unhead/vue/stream/server' // or /client
- *
- * useHead({
- *   title: 'My Page'
- * })
- * </script>
- *
- * <template>
- *   <HeadStream /><div>Hello World</div>
- * </template>
- * ```
+ * On the server `HeadStream` emits a `<script data-allow-mismatch="children">`
+ * containing the pending head-update JS; on the client it emits an identical
+ * empty `<script>`. Symmetric vnode types + `data-allow-mismatch` make Vue's
+ * hydrator silently tolerate the inner-content difference.
  */
 function transform(code: string, id: string, isSSR: boolean, s: MagicString): boolean {
-  // Only transform files that use head composables
   if (!code.includes('useHead') && !code.includes('useSeoMeta') && !code.includes('useHeadSafe'))
     return false
 
-  // Find the template section
   const templateMatch = code.match(TEMPLATE_RE)
   if (!templateMatch)
     return false
 
   const templateStart = templateMatch.index! + templateMatch[0].length
 
-  // Inject HeadStream at the start of template content
   s.appendRight(templateStart, '<HeadStream />')
 
-  // Add import for HeadStream
   const importPath = `@unhead/vue/stream/${isSSR ? 'server' : 'client'}`
   const scriptMatch = code.match(SCRIPT_RE)
   if (!scriptMatch)
@@ -105,13 +73,9 @@ function transform(code: string, id: string, isSSR: boolean, s: MagicString): bo
 }
 
 /**
- * Vite plugin for Vue streaming SSR support.
- * Automatically injects HeadStream components into Vue SFC templates.
- *
- * @returns Vite plugin configuration object with:
- *   - `name`: Plugin identifier
- *   - `enforce`: Plugin execution order ('pre')
- *   - `transform`: Transform hook for processing .vue files
+ * Vite plugin for Vue streaming SSR support. Automatically injects
+ * `<HeadStream />` into Vue SFC templates for components that use head
+ * composables.
  *
  * @example
  * ```ts
@@ -120,8 +84,8 @@ function transform(code: string, id: string, isSSR: boolean, s: MagicString): bo
  *
  * export default {
  *   plugins: [
- *     unheadVuePlugin()
- *   ]
+ *     unheadVuePlugin(),
+ *   ],
  * }
  * ```
  */

--- a/packages/vue/test/streaming.test.ts
+++ b/packages/vue/test/streaming.test.ts
@@ -132,58 +132,66 @@ describe('vue streaming SSR', () => {
   })
 
   describe('headStream component', () => {
-    it('renders script tag with head updates via Vue SSR', async () => {
+    it('emits <script data-allow-mismatch="children"> with update content after shell', async () => {
       const { head } = createStreamableHead()
       await renderSSRHeadShell(head, '<html><head></head><body>')
-      // Mark shell as rendered for HeadStream to work (normally done by wrapStream)
       ;(head as any)._shellRendered = () => true
-
       head.push({ title: 'Streamed Title' })
 
-      // Create a minimal app that provides head and renders HeadStream
       const App = defineComponent({
         setup() {
           return () => h(HeadStream)
         },
       })
-
       const app = createSSRApp(App)
       app.provide('usehead', head)
-
       const html = await renderToString(app)
 
-      expect(html).toContain('<script>')
+      expect(html).toContain('data-allow-mismatch="children"')
       expect(html).toContain('window.__unhead__.push')
       expect(html).toContain('Streamed Title')
-      expect(html).toContain('</script>')
     })
 
-    it('renders null when no updates', async () => {
+    it('emits empty placeholder script when no updates are pending', async () => {
       const { head } = createStreamableHead()
       await renderSSRHeadShell(head, '<html><head></head><body>')
-
-      // No new entries pushed
+      ;(head as any)._shellRendered = () => true
 
       const App = defineComponent({
         setup() {
           return () => h(HeadStream)
         },
       })
-
       const app = createSSRApp(App)
       app.provide('usehead', head)
-
       const html = await renderToString(app)
 
-      expect(html).toBe('<!---->') // Vue SSR comment for null render
+      // Symmetric with the client vnode so Vue's hydrator matches.
+      expect(html).toBe('<script data-allow-mismatch="children"></script>')
+    })
+
+    it('emits empty placeholder before shell is rendered', async () => {
+      const { head } = createStreamableHead()
+      head.push({ title: 'Shell Title' })
+      // _shellRendered defaults to false: HeadStream must not leak shell-time
+      // entries back into the tree.
+
+      const App = defineComponent({
+        setup() {
+          return () => h(HeadStream)
+        },
+      })
+      const app = createSSRApp(App)
+      app.provide('usehead', head)
+      const html = await renderToString(app)
+
+      expect(html).toBe('<script data-allow-mismatch="children"></script>')
     })
 
     it('properly escapes script content to prevent XSS', async () => {
       const { head } = createStreamableHead()
       await renderSSRHeadShell(head, '<html><head></head><body>')
-      // Mark shell as rendered for HeadStream to work (normally done by wrapStream)
       ;(head as any)._shellRendered = () => true
-
       head.push({ title: '</script><script>alert("xss")</script>' })
 
       const App = defineComponent({
@@ -191,15 +199,12 @@ describe('vue streaming SSR', () => {
           return () => h(HeadStream)
         },
       })
-
       const app = createSSRApp(App)
       app.provide('usehead', head)
-
       const html = await renderToString(app)
 
-      // Should not contain unescaped closing script tag
-      expect(html).not.toContain('</script><script>')
-      expect(html).toContain('\\u003c') // Escaped <
+      expect(html).not.toContain('</script><script>alert')
+      expect(html).toContain('\\u003c')
     })
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Streaming head updates were emitted as `<script innerHTML="...">` vnodes on the server but as `null` on the client, producing vnode-type hydration mismatches in `@unhead/vue`'s streaming mode.

`HeadStream` now emits a symmetric `<script data-allow-mismatch="children">` on both server and client. Server fills `innerHTML` with the pending suspense-chunk payload (or empty before the shell renders); client renders an empty script. Matching vnode types + `data-allow-mismatch` let Vue's hydrator silence the inner-text diff cleanly.

Scope is intentionally narrow: only the `HeadStream` component and its tests change here. The related `prepareStreamingTemplate` outlet-split + example shell changes will follow in a separate PR.

### ✅ Test plan

- `pnpm -F @unhead/vue test` (147 passed)
- `pnpm -C examples/vite-ssr-vue-streaming test` — new Playwright regression guard asserts every `window.__unhead__.push` script carries `data-allow-mismatch`, and that at least one such script was injected (non-vacuous)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue SSR streaming hydration by ensuring proper script element matching between server and client, preventing hydration mismatches in streaming scenarios.

* **Tests**
  * Added regression test for hydration script validation.
  * Updated streaming test cases to verify new placeholder behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->