### PR TITLE
fix(bundler): preserve useSeoMeta import when sibling call is untransformable

### DIFF
--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -97,6 +97,9 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
       const importRewrites = new Map<any, Set<string>>()
       // Track if seoMeta is referenced as a value (not just called), keyed by original imported name
       const valueReferenced = new Set<string>()
+      // Track useSeoMeta/useServerSeoMeta calls that could not be transformed (e.g. dynamic first
+      // arg, spread properties). The original import must be preserved alongside the useHead rewrite.
+      const untransformedCallees = new Set<string>()
 
       walk(ast.program, {
         scopeTracker,
@@ -142,8 +145,11 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
             return
 
           const properties = node.arguments[0]?.properties
-          if (!properties)
+          if (!properties) {
+            if (importDecl)
+              untransformedCallees.add(originalName)
             return
+          }
 
           let output: string[] | false = []
           const title = properties.find((property: any) => property.key?.name === 'title')
@@ -255,6 +261,9 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
               importRewrites.get(importDecl)!.add(originalName)
             }
           }
+          else if (importDecl) {
+            untransformedCallees.add(originalName)
+          }
         },
       })
 
@@ -268,8 +277,9 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
             const importedName = spec.imported.name
             if (transformedNames.has(importedName)) {
               newSpecifiers.add(importedName.includes('Server') ? 'useServerHead' : 'useHead')
-              // Keep original import if it's still referenced as a value
-              if (valueReferenced.has(importedName))
+              // Keep original import if it's still referenced as a value or called in a form we
+              // couldn't statically transform (dynamic first arg, spread properties, etc.).
+              if (valueReferenced.has(importedName) || untransformedCallees.has(importedName))
                 newSpecifiers.add(importedName)
             }
             else {

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { UseSeoMetaTransform } from '../src/unplugin/UseSeoMetaTransform'
 
 const USE_SERVER_HEAD_RE = /useServerHead/
@@ -12,6 +12,30 @@ async function transform(code: string | string[], id = 'some-id.js', opts: any =
     id,
   )
   return res?.code
+}
+
+// Executes the transform output in a sandboxed scope. Only names that the
+// rewritten `import { ... } from 'unhead'` actually lists get bound to spies;
+// anything else the code calls surfaces as a real `ReferenceError`. This
+// reproduces the original bug where `useSeoMeta` was stripped from the import
+// but still referenced by an untransformable call site.
+function runTransformed(code: string): { imported: string[], useHead: ReturnType<typeof vi.fn>, useSeoMeta: ReturnType<typeof vi.fn> } {
+  const importMatch = code.match(/^import\s*\{([^}]*)\}\s*from\s*['"]unhead['"][^\n]*\n?/m)
+  const imported = importMatch
+    ? importMatch[1].split(',').map(s => s.trim()).filter(Boolean)
+    : []
+  const body = importMatch ? code.replace(importMatch[0], '') : code
+  const spies: Record<string, ReturnType<typeof vi.fn>> = {
+    useHead: vi.fn(),
+    useSeoMeta: vi.fn(),
+    useServerHead: vi.fn(),
+    useServerSeoMeta: vi.fn(),
+  }
+  const params = imported.filter(name => name in spies)
+  const args = params.map(name => spies[name])
+  // eslint-disable-next-line no-new-func
+  new Function(...params, body)(...args)
+  return { imported, useHead: spies.useHead, useSeoMeta: spies.useSeoMeta }
 }
 
 describe('useSeoMetaTransform', () => {
@@ -38,6 +62,62 @@ describe('useSeoMetaTransform', () => {
         'console.log(useSeoMeta(meta))',
       ]),
     ).not.toBeDefined()
+  })
+
+  it('keeps original import when a sibling call is untransformable', async () => {
+    // One static call gets rewritten to useHead, another uses a dynamic first arg
+    // and must stay as useSeoMeta(...). The import must keep both names.
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'const meta = {}',
+      'useSeoMeta({ title: \'Hello\', description: \'World\' })',
+      'useSeoMeta(meta, { tagPriority: 10 })',
+    ])
+    expect(code).toMatchInlineSnapshot(`
+      "import { useHead, useSeoMeta } from 'unhead'
+      const meta = {}
+      useHead({
+        title: 'Hello',
+        meta: [
+          { name: 'description', content: 'World' },
+        ]
+      })
+      useSeoMeta(meta, { tagPriority: 10 })"
+    `)
+  })
+
+  it('keeps original import when a spread-property call is untransformable', async () => {
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'const extra = { description: \'d\' }',
+      'useSeoMeta({ title: \'Hello\', description: \'World\' })',
+      'useSeoMeta({ title: \'Dyn\', ...extra })',
+    ])
+    expect(code).toContain('import { useHead, useSeoMeta } from')
+    expect(code).toContain('useSeoMeta({ title: \'Dyn\', ...extra })')
+  })
+
+  it('transformed code runs without ReferenceError when a sibling call is untransformable', async () => {
+    // Regression for a bug where the bundler rewrote `useSeoMeta -> useHead`
+    // for the transformable call but stripped `useSeoMeta` from the import,
+    // leaving the untransformable call site dangling (`ReferenceError:
+    // useSeoMeta is not defined`) at runtime.
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'const meta = { description: \'dynamic\' }',
+      'useSeoMeta({ title: \'Static\', description: \'Static desc\' })',
+      'useSeoMeta(meta, { tagPriority: 10 })',
+    ])
+    expect(code).toBeDefined()
+
+    const { useHead, useSeoMeta } = runTransformed(code!)
+    expect(useHead).toHaveBeenCalledTimes(1)
+    expect(useHead).toHaveBeenCalledWith({
+      title: 'Static',
+      meta: [{ name: 'description', content: 'Static desc' }],
+    })
+    expect(useSeoMeta).toHaveBeenCalledTimes(1)
+    expect(useSeoMeta).toHaveBeenCalledWith({ description: 'dynamic' }, { tagPriority: 10 })
   })
 
   it('statically replaces where possible', async () => {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`UseSeoMetaTransform` stripped `useSeoMeta` from the import as soon as any call got rewritten to `useHead`, so an untransformable sibling call (dynamic first arg, spread properties) threw `ReferenceError: useSeoMeta is not defined` at runtime. This PR tracks untransformable call sites and keeps the original named import when either a value reference or an untransformable call still needs it, with a sandboxed e2e test that only binds names the rewritten import declares so regressions surface as real `ReferenceError`s rather than slipping past snapshot assertions.