### PR TITLE
fix(unhead): split streaming template at SSR outlet marker

### DIFF
--- a/examples/vite-ssr-vue-streaming/index.html
+++ b/examples/vite-ssr-vue-streaming/index.html
@@ -114,5 +114,5 @@
     </style>
     <script type="module" src="/src/entry-client.ts"></script>
   </head>
-  <body></body>
+  <body><div id="app"><!--app-html--></div></body>
 </html>

--- a/examples/vite-ssr-vue-streaming/src/App.vue
+++ b/examples/vite-ssr-vue-streaming/src/App.vue
@@ -3,8 +3,5 @@ import { RouterView } from 'vue-router'
 </script>
 
 <template>
-  <div id="app">
-    <RouterView />
-  </div>
+  <RouterView />
 </template>
-

--- a/examples/vite-ssr-vue-streaming/src/entry-client.ts
+++ b/examples/vite-ssr-vue-streaming/src/entry-client.ts
@@ -8,7 +8,6 @@ const head = createStreamableHead()!
 app.use(head)
 app.mixin(VueHeadMixin)
 
-// Wait until router is ready before mounting to ensure hydration match
 router.isReady().then(() => {
   app.mount('#app')
 })

--- a/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
+++ b/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
@@ -246,29 +246,25 @@ test.describe('Vue Streaming SSR with Unhead', () => {
       expect(unsafe).toBe(0)
     })
 
-    test('no unexpected console errors during streaming and hydration', async ({ page }) => {
-      const errors: string[] = []
+    test('no unexpected console errors or hydration warnings', async ({ page }) => {
+      const issues: string[] = []
       page.on('console', msg => {
-        if (msg.type() === 'error') {
-          errors.push(msg.text())
-        }
+        if (msg.type() === 'error' || msg.type() === 'warning')
+          issues.push(`[${msg.type()}] ${msg.text()}`)
       })
 
       await page.goto('/')
       await expect(page.locator('.newsletter')).toBeVisible({ timeout: 10000 })
-
-      // Wait for hydration
       await page.waitForTimeout(500)
 
-      // Filter out expected non-critical errors
-      const criticalErrors = errors.filter(e =>
-        !e.includes('favicon') &&
-        !e.includes('Hydration') &&
-        !e.includes('mismatch') &&
-        !e.includes('WebSocket') &&
-        !e.includes('vite')
+      // No filter for hydration/mismatch: the symmetric HeadStream +
+      // `<!--app-html-->` outlet pattern must produce a clean hydration.
+      const critical = issues.filter(e =>
+        !e.includes('favicon')
+        && !e.includes('WebSocket')
+        && !e.includes('vite'),
       )
-      expect(criticalErrors).toHaveLength(0)
+      expect(critical, critical.join('\n')).toHaveLength(0)
     })
   })
 })

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -7,6 +7,8 @@ import { DEFAULT_STREAM_KEY } from './client'
 const LT_RE = /</g
 const GT_RE = />/g
 const AMP_RE = /&/g
+// Canonical Vite SSR outlet markers. Either form is accepted.
+const OUTLET_RE = /<!--\s*(?:app-html|ssr-outlet)\s*-->/
 
 // Conservative ASCII identifier: must be a safe `window.<name>` accessor.
 // Disallows anything that could break out of the dot-notation sink used by
@@ -227,6 +229,10 @@ function safeJsonStringify(obj: any): string {
  * 3. Streams the app content
  * 4. Writes the closing HTML (with body tags)
  *
+ * Per-suspense head updates ride inside the framework's own stream via
+ * the framework-specific `HeadStream` component (injected by the streaming
+ * Vite plugin). This function only owns the shell / end envelope.
+ *
  * @param head - The Unhead instance
  * @param stream - The app's ReadableStream (from renderToWebStream, etc.)
  * @param template - Full HTML template
@@ -336,16 +342,30 @@ export function prepareStreamingTemplate(
     // (e.g. scripts injected by Vite plugins via transformIndexHtml with
     // injectTo: 'body'). Without preserving this, anything plugins inject
     // into the body silently disappears in streaming mode.
-    const bodyInterior = template.substring(bodyEnd, bodyCloseStart)
+    let bodyInterior = template.substring(bodyEnd, bodyCloseStart)
     const endPart = template.substring(bodyCloseStart)
 
     const shellParsed = parseHtmlForIndexes(`${shellPart}</body></html>`)
-    const shell = applyHeadToHtml(shellParsed, {
+    let shell = applyHeadToHtml(shellParsed, {
       htmlAttrs: ssr.htmlAttrs,
       headTags: bootstrapScript + ssr.headTags,
       bodyAttrs: ssr.bodyAttrs,
       bodyTags: '',
     }).replace('</body></html>', '')
+
+    // If the template marks an explicit SSR outlet (canonical Vite pattern),
+    // split the body interior at that marker so the app stream lands inside
+    // it instead of before it. This lets a template wrap the stream in
+    // `<div id="app"><!--app-html--></div>` without creating a hydration
+    // container mismatch.
+    const outletMatch = bodyInterior.match(OUTLET_RE)
+    if (outletMatch) {
+      const outletIndex = outletMatch.index!
+      const beforeOutlet = bodyInterior.substring(0, outletIndex)
+      const afterOutlet = bodyInterior.substring(outletIndex + outletMatch[0].length)
+      shell = shell + beforeOutlet
+      bodyInterior = afterOutlet
+    }
 
     return {
       shell,

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -7,8 +7,22 @@ import { DEFAULT_STREAM_KEY } from './client'
 const LT_RE = /</g
 const GT_RE = />/g
 const AMP_RE = /&/g
-// Canonical Vite SSR outlet markers. Either form is accepted.
-const OUTLET_RE = /<!--\s*(?:app-html|ssr-outlet)\s*-->/
+// Default SSR outlet markers. `<!--app-html-->` is the convention used
+// across this repo's `vite-ssr-*` examples and docs; `<!--ssr-outlet-->`
+// is the placeholder shown in Vite's SSR guide. Users with a custom
+// marker should pass `outlet` via StreamingTemplateOptions.
+const DEFAULT_OUTLET_RE = /<!--\s*(?:app-html|ssr-outlet)\s*-->/
+
+function resolveOutletPattern(outlet: RegExp | string | false | undefined): RegExp | null {
+  if (outlet === false)
+    return null
+  if (outlet == null)
+    return DEFAULT_OUTLET_RE
+  if (outlet instanceof RegExp)
+    return outlet
+  // Escape regex metacharacters in literal string
+  return new RegExp(outlet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+}
 
 // Conservative ASCII identifier: must be a safe `window.<name>` accessor.
 // Disallows anything that could break out of the dot-notation sink used by
@@ -250,13 +264,14 @@ export function wrapStream(
   stream: ReadableStream<Uint8Array>,
   template: string,
   preRenderedState?: SSRHeadPayload,
+  options?: StreamingTemplateOptions,
 ): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder()
 
   return new ReadableStream<Uint8Array>({
     async start(controller) {
       try {
-        const { shell, end } = prepareStreamingTemplate(head, template, preRenderedState)
+        const { shell, end } = prepareStreamingTemplate(head, template, preRenderedState, options)
         controller.enqueue(encoder.encode(shell))
 
         const reader = stream.getReader()
@@ -280,6 +295,30 @@ export function wrapStream(
       }
     },
   })
+}
+
+/**
+ * Options shared by `wrapStream` and `prepareStreamingTemplate`.
+ */
+export interface StreamingTemplateOptions {
+  /**
+   * SSR outlet marker to split the body interior at. When the template marks
+   * an outlet (e.g. `<div id="app"><!--app-html--></div>`), the shell is
+   * extended up to the marker so the app stream lands *inside* the outlet's
+   * wrapper element instead of before it, avoiding a hydration container
+   * mismatch.
+   *
+   * - `RegExp` / `string`: match and split at the first occurrence.
+   *   Strings are treated as literal (metachars escaped).
+   * - `false`: disable outlet splitting entirely.
+   *
+   * The default matches `<!--app-html-->` (convention used across this repo's
+   * Vite SSR examples and docs) and `<!--ssr-outlet-->` (from Vite's SSR
+   * guide).
+   *
+   * @default /<!--\s*(?:app-html|ssr-outlet)\s*-->/
+   */
+  outlet?: RegExp | string | false
 }
 
 /**
@@ -325,7 +364,9 @@ export function prepareStreamingTemplate(
   head: Unhead<any>,
   template: string,
   preRenderedState?: SSRHeadPayload,
+  options?: StreamingTemplateOptions,
 ): StreamingTemplateParts {
+  const outletRe = resolveOutletPattern(options?.outlet)
   const ssr = preRenderedState ?? head.render() as SSRHeadPayload
   if (!preRenderedState) {
     head.entries.clear()
@@ -353,18 +394,16 @@ export function prepareStreamingTemplate(
       bodyTags: '',
     }).replace('</body></html>', '')
 
-    // If the template marks an explicit SSR outlet (canonical Vite pattern),
-    // split the body interior at that marker so the app stream lands inside
-    // it instead of before it. This lets a template wrap the stream in
-    // `<div id="app"><!--app-html--></div>` without creating a hydration
-    // container mismatch.
-    const outletMatch = bodyInterior.match(OUTLET_RE)
+    // If the template marks an explicit SSR outlet, split the body interior
+    // at that marker so the app stream lands inside it instead of before it.
+    // This lets a template wrap the stream in e.g.
+    // `<div id="app"><!--app-html--></div>` without a hydration container
+    // mismatch.
+    const outletMatch = outletRe ? bodyInterior.match(outletRe) : null
     if (outletMatch) {
       const outletIndex = outletMatch.index!
-      const beforeOutlet = bodyInterior.substring(0, outletIndex)
-      const afterOutlet = bodyInterior.substring(outletIndex + outletMatch[0].length)
-      shell = shell + beforeOutlet
-      bodyInterior = afterOutlet
+      shell = shell + bodyInterior.substring(0, outletIndex)
+      bodyInterior = bodyInterior.substring(outletIndex + outletMatch[0].length)
     }
 
     return {

--- a/packages/unhead/test/streaming/streaming.test.ts
+++ b/packages/unhead/test/streaming/streaming.test.ts
@@ -717,5 +717,55 @@ describe('streaming SSR', () => {
       expect(userIdx).toBeGreaterThan(pluginIdx)
       expect(closeIdx).toBeGreaterThan(userIdx)
     })
+
+    describe('outlet splitting', () => {
+      const outletTemplate = '<html><head></head><body><div id="app"><!--ssr-outlet--></div></body></html>'
+
+      it('splits the body interior at the default outlet marker', () => {
+        const { head } = createStreamableHead()
+        const { shell, end } = prepareStreamingTemplate(head, outletTemplate)
+
+        // Shell extends up to and into the outlet wrapper, consuming the marker.
+        expect(shell).toContain('<div id="app">')
+        expect(shell).not.toContain('ssr-outlet')
+        // End closes the wrapper after the streamed app content.
+        expect(end.startsWith('</div>')).toBe(true)
+      })
+
+      it('accepts a custom marker via `outlet` option', () => {
+        const { head } = createStreamableHead()
+        const template = '<html><head></head><body><div id="app"><!--custom-outlet--></div></body></html>'
+        const { shell, end } = prepareStreamingTemplate(head, template, undefined, {
+          outlet: '<!--custom-outlet-->',
+        })
+
+        expect(shell).toContain('<div id="app">')
+        expect(shell).not.toContain('custom-outlet')
+        expect(end.startsWith('</div>')).toBe(true)
+      })
+
+      it('accepts a RegExp marker via `outlet` option', () => {
+        const { head } = createStreamableHead()
+        const template = '<html><head></head><body><div id="app"><!--APP--></div></body></html>'
+        const { shell } = prepareStreamingTemplate(head, template, undefined, {
+          outlet: /<!--APP-->/,
+        })
+
+        expect(shell).toContain('<div id="app">')
+        expect(shell).not.toContain('<!--APP-->')
+      })
+
+      it('disables outlet splitting when `outlet: false`', () => {
+        const { head } = createStreamableHead()
+        const { shell, end } = prepareStreamingTemplate(head, outletTemplate, undefined, {
+          outlet: false,
+        })
+
+        // Outlet marker stays in the end part; shell ends at <body>.
+        expect(shell).not.toContain('<div id="app">')
+        expect(end).toContain('<div id="app">')
+        expect(end).toContain('<!--ssr-outlet-->')
+      })
+    })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #748

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Under a template using the canonical Vite SSR pattern (`<div id="app"><!--app-html--></div>`), the streaming app output landed *before* the hydration container instead of inside it, producing a container-level hydration mismatch.

`prepareStreamingTemplate` now detects `<!--app-html-->` / `<!--ssr-outlet-->` and splits the body interior at the marker so the app stream lands inside the outlet's wrapper element.

- `examples/vite-ssr-vue-streaming` switches to `<div id="app"><!--app-html--></div>`; `App.vue` no longer owns the hydration wrapper.
- Playwright's hydration-warnings test no longer masks `Hydration`/`mismatch` strings so real regressions surface.

> Depends on #748 (symmetric `HeadStream` vnodes) — this branch is stacked on top.

### ✅ Test plan

- `pnpm -F unhead test`
- `pnpm -C examples/vite-ssr-vue-streaming test` — existing hydration tests run against the new outlet-based template with the stricter console-warning filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering and hydration handling for Vue applications using streaming.
  * Enhanced outlet marker detection for better template streaming support.
  * Fixed HeadStream component to properly emit during hydration with mismatch tolerance.

* **Tests**
  * Updated hydration and streaming regression tests to verify proper DOM marker handling and console error filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->