### PR TITLE
fix(vue): batch streamed head updates via self-deleting inline scripts

### DIFF
--- a/examples/vite-ssr-vue-streaming/index.html
+++ b/examples/vite-ssr-vue-streaming/index.html
@@ -114,5 +114,5 @@
     </style>
     <script type="module" src="/src/entry-client.ts"></script>
   </head>
-  <body></body>
+  <body><div id="app"><!--app-html--></div></body>
 </html>

--- a/examples/vite-ssr-vue-streaming/src/App.vue
+++ b/examples/vite-ssr-vue-streaming/src/App.vue
@@ -3,8 +3,6 @@ import { RouterView } from 'vue-router'
 </script>
 
 <template>
-  <div id="app">
-    <RouterView />
-  </div>
+  <RouterView />
 </template>
 

--- a/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
+++ b/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
@@ -228,22 +228,19 @@ test.describe('Vue Streaming SSR with Unhead', () => {
       await expect(page).toHaveTitle('StreamShop - Ready!')
     })
 
-    // Regression guard for the HeadStream hydration model: every script
-    // that carries a streamed head update must have `data-allow-mismatch` so
-    // Vue tolerates the inner-text difference between server and client.
-    test('HeadStream scripts carry data-allow-mismatch for hydration safety', async ({ page }) => {
+    // Each per-suspense head patch is emitted as a self-deleting inline
+    // script: it executes at HTML-parse time and calls
+    // `document.currentScript.remove()` so the DOM is clean before Vue
+    // hydrates. By the time the last chunk is rendered, no update scripts
+    // should remain attached.
+    test('streamed head patches self-delete before hydration', async ({ page }) => {
       await page.goto('/')
       await expect(page.locator('.newsletter')).toBeVisible({ timeout: 10000 })
-      const { total, unsafe } = await page.evaluate(() => {
-        const updateScripts = Array.from(document.querySelectorAll('script'))
-          .filter(n => (n.textContent || '').includes('window.__unhead__.push'))
-        return {
-          total: updateScripts.length,
-          unsafe: updateScripts.filter(n => !n.hasAttribute('data-allow-mismatch')).length,
-        }
-      })
-      expect(total).toBeGreaterThan(0)
-      expect(unsafe).toBe(0)
+      const leftover = await page.evaluate(() =>
+        Array.from(document.querySelectorAll('script'))
+          .filter(n => (n.textContent || '').includes('window.__unhead__.push')).length,
+      )
+      expect(leftover).toBe(0)
     })
 
     test('no unexpected console errors during streaming and hydration', async ({ page }) => {

--- a/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
+++ b/examples/vite-ssr-vue-streaming/tests/streaming.spec.ts
@@ -243,12 +243,12 @@ test.describe('Vue Streaming SSR with Unhead', () => {
       expect(leftover).toBe(0)
     })
 
-    test('no unexpected console errors during streaming and hydration', async ({ page }) => {
-      const errors: string[] = []
-      page.on('console', msg => {
-        if (msg.type() === 'error') {
-          errors.push(msg.text())
-        }
+    test('no console errors or hydration warnings during streaming and hydration', async ({ page }) => {
+      const messages: string[] = []
+      page.on('console', (msg) => {
+        const type = msg.type()
+        if (type === 'error' || type === 'warning')
+          messages.push(`[${type}] ${msg.text()}`)
       })
 
       await page.goto('/')
@@ -257,15 +257,15 @@ test.describe('Vue Streaming SSR with Unhead', () => {
       // Wait for hydration
       await page.waitForTimeout(500)
 
-      // Filter out expected non-critical errors
-      const criticalErrors = errors.filter(e =>
-        !e.includes('favicon') &&
-        !e.includes('Hydration') &&
-        !e.includes('mismatch') &&
-        !e.includes('WebSocket') &&
-        !e.includes('vite')
+      // Hydration mismatches surface as errors AND warnings — both must be
+      // clean for the streaming setup to be considered correct.
+      const critical = messages.filter(m =>
+        !m.includes('favicon')
+        && !m.includes('WebSocket')
+        && !m.includes('[vite]')
+        && !m.includes('Suspense> is an experimental feature'),
       )
-      expect(criticalErrors).toHaveLength(0)
+      expect(critical, critical.join('\n')).toEqual([])
     })
   })
 })

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -295,8 +295,10 @@ export interface StreamingTemplateParts {
 /**
  * @experimental
  *
- * Prepares a template for streaming SSR by splitting it at body tag boundaries
- * and injecting head content into both parts.
+ * Prepares a template for streaming SSR by splitting it at the SSR outlet
+ * marker (`<!--app-html-->` / `<!--ssr-outlet-->`) when present, so the
+ * streamed app content lands inside the mount container. Falls back to
+ * splitting at body tag boundaries when no marker is found.
  *
  * This is the recommended way to handle streaming templates as it:
  * - Uses consistent template parsing (same as transformHtmlTemplateRaw)
@@ -331,12 +333,25 @@ export function prepareStreamingTemplate(
   const bodyCloseStart = parsed.indexes.bodyCloseTagStart
 
   if (bodyEnd >= 0 && bodyCloseStart >= 0) {
-    const shellPart = template.substring(0, bodyEnd)
-    // Static content sitting between <body> and </body> in the template
-    // (e.g. scripts injected by Vite plugins via transformIndexHtml with
-    // injectTo: 'body'). Without preserving this, anything plugins inject
-    // into the body silently disappears in streaming mode.
     const bodyInterior = template.substring(bodyEnd, bodyCloseStart)
+    // Prefer splitting at a Vite-style SSR outlet marker so the streamed
+    // app content lands inside the container (e.g. `<div id="app">`) that
+    // the client mounts onto. Falls back to splitting at the <body> tag,
+    // which preserves any static body interior in `end`.
+    const markerMatch = bodyInterior.match(/<!--\s*(?:app-html|ssr-outlet)\s*-->/)
+
+    let beforeStream: string
+    let afterStream: string
+    if (markerMatch) {
+      beforeStream = bodyInterior.substring(0, markerMatch.index!)
+      afterStream = bodyInterior.substring(markerMatch.index! + markerMatch[0].length)
+    }
+    else {
+      beforeStream = ''
+      afterStream = bodyInterior
+    }
+
+    const shellPart = template.substring(0, bodyEnd) + beforeStream
     const endPart = template.substring(bodyCloseStart)
 
     const shellParsed = parseHtmlForIndexes(`${shellPart}</body></html>`)
@@ -349,7 +364,7 @@ export function prepareStreamingTemplate(
 
     return {
       shell,
-      end: bodyInterior + ssr.bodyTags + endPart,
+      end: afterStream + ssr.bodyTags + endPart,
     }
   }
 

--- a/packages/unhead/test/streaming/streaming.test.ts
+++ b/packages/unhead/test/streaming/streaming.test.ts
@@ -698,6 +698,42 @@ describe('streaming SSR', () => {
       expect(end).toBe('</body></html>')
     })
 
+    it('splits at <!--app-html--> marker so streamed content lands inside the container', () => {
+      const { head } = createStreamableHead()
+
+      const template = '<html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+      const { shell, end } = prepareStreamingTemplate(head, template)
+
+      // Shell ends inside the container; streamed content lands as its
+      // first child. Container closing tag plus </body></html> live in end.
+      expect(shell.endsWith('<div id="app">')).toBe(true)
+      expect(end).toBe('</div></body></html>')
+    })
+
+    it('also recognises Vite\'s <!--ssr-outlet--> marker', () => {
+      const { head } = createStreamableHead()
+
+      const template = '<html><head></head><body><div id="root"><!--ssr-outlet--></div></body></html>'
+      const { shell, end } = prepareStreamingTemplate(head, template)
+
+      expect(shell.endsWith('<div id="root">')).toBe(true)
+      expect(end).toBe('</div></body></html>')
+    })
+
+    it('preserves siblings around the marker', () => {
+      const { head } = createStreamableHead()
+      head.push({ script: [{ src: 'user.js', tagPosition: 'bodyClose' }] })
+
+      const template = '<html><head></head><body><header>before</header><div id="app"><!--app-html--></div><footer>after</footer></body></html>'
+      const { shell, end } = prepareStreamingTemplate(head, template)
+
+      expect(shell).toContain('<header>before</header><div id="app">')
+      // After-marker content + bodyTags + closing tags, in order.
+      expect(end.indexOf('</div>')).toBeLessThan(end.indexOf('<footer>after</footer>'))
+      expect(end.indexOf('<footer>after</footer>')).toBeLessThan(end.indexOf('user.js'))
+      expect(end.indexOf('user.js')).toBeLessThan(end.indexOf('</body>'))
+    })
+
     it('places head bodyTags after preserved body content', () => {
       const { head } = createStreamableHead()
       head.push({

--- a/packages/vue/build.config.ts
+++ b/packages/vue/build.config.ts
@@ -1,7 +1,7 @@
 import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
-  externals: ['vue', 'vite', 'magic-string', 'oxc-parser', 'oxc-walker', '@unhead/bundler', '@unhead/bundler/vite'],
+  externals: ['vue', 'vite', '@unhead/bundler', '@unhead/bundler/vite'],
   declaration: true,
   entries: [
     { input: 'src/index', name: 'index' },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -151,9 +151,6 @@
   "dependencies": {
     "@unhead/bundler": "workspace:*",
     "hookable": "catalog:",
-    "magic-string": "catalog:",
-    "oxc-parser": "catalog:",
-    "oxc-walker": "catalog:",
     "unhead": "workspace:*"
   },
   "devDependencies": {

--- a/packages/vue/src/stream/client.ts
+++ b/packages/vue/src/stream/client.ts
@@ -1,27 +1,9 @@
 import type { CreateStreamableClientHeadOptions, UnheadStreamQueue } from 'unhead/stream/client'
 import type { UseHeadInput, VueHeadClient } from '../types'
 import { createStreamableHead as _createStreamableHead } from 'unhead/stream/client'
-import { defineComponent, h } from 'vue'
 import { vueInstall } from '../install'
 import { VueResolver } from '../resolver'
 import { VueHeadMixin } from '../VueHeadMixin'
-
-/**
- * Client-side counterpart to the server `HeadStream`. Always emits a
- * `<script data-allow-mismatch="children">` with empty `innerHTML`. The
- * matching vnode type on both sides lets Vue hydrate the node; the
- * `data-allow-mismatch` attribute silences the inner-content difference
- * between the server-emitted streaming patch and this empty client vnode.
- *
- * The already-executed server script stays in the DOM after hydration — it's
- * inert (scripts only execute on parse) and the placeholder is cheap.
- */
-export const HeadStream = defineComponent({
-  name: 'HeadStream',
-  setup() {
-    return () => h('script', { 'data-allow-mismatch': 'children' })
-  },
-})
 
 /**
  * Creates a client head by wrapping the core instance from the iife script.

--- a/packages/vue/src/stream/server.ts
+++ b/packages/vue/src/stream/server.ts
@@ -3,40 +3,11 @@ import type { CreateStreamableServerHeadOptions, ResolvableHead, SSRHeadPayload 
 import type { VueHeadClient } from '../types'
 import {
   createStreamableHead as _createStreamableHead,
-  wrapStream as coreWrapStream,
+  prepareStreamingTemplate,
   renderSSRHeadSuspenseChunk,
 } from 'unhead/stream/server'
-import { defineComponent, h } from 'vue'
-import { injectHead } from '../composables'
 import { vueInstall } from '../install'
 import { VueResolver } from '../resolver'
-
-/**
- * Emits a `<script data-allow-mismatch="children">` whose `innerHTML` is the
- * pending head-update JS (if any). The client counterpart renders an identical
- * `<script data-allow-mismatch="children">` with empty innerHTML: symmetric
- * vnode types let Vue's hydrator match the node, and `data-allow-mismatch`
- * silences the inner-content difference.
- *
- * The Vite plugin injects one `<HeadStream />` at the top of every SFC
- * `<template>` that uses `useHead` / `useSeoMeta`.
- */
-export const HeadStream = defineComponent({
-  name: 'HeadStream',
-  setup() {
-    const head = injectHead()
-    return () => {
-      // Before `wrapStream` has captured the shell, entries belong to the
-      // initial render and are serialized by the shell, not re-emitted into
-      // the tree. Emit an empty placeholder so the client vnode tree stays in
-      // sync.
-      if (!(head as any)._shellRendered?.())
-        return h('script', { 'data-allow-mismatch': 'children' })
-      const update = renderSSRHeadSuspenseChunk(head)
-      return h('script', { 'data-allow-mismatch': 'children', 'innerHTML': update || '' })
-    }
-  },
-})
 
 /**
  * Vue-specific context returned by createStreamableHead.
@@ -51,6 +22,17 @@ export interface VueStreamableHeadContext extends Omit<WebStreamableHeadContext<
 
 /**
  * Creates a head instance configured for Vue streaming SSR.
+ *
+ * `wrapStream` is Vue-specific: Vue's `renderToWebStream` flushes chunks in
+ * document order per resolved Suspense boundary, so any head entries added
+ * during a chunk's render can be emitted as a self-deleting inline
+ * `<script>` right after the chunk. The script executes at HTML parse
+ * (updating the client head state progressively) and calls
+ * `document.currentScript.remove()` so the DOM is clean before Vue
+ * hydrates. This pattern is not safe for frameworks with out-of-order
+ * Suspense reveals (React, Solid) or framework-specific chunk formats
+ * (Svelte) — those continue to use an in-tree `<HeadStream />` component
+ * whose output is serialized inside the framework's own stream.
  *
  * @example
  * ```ts
@@ -79,19 +61,46 @@ export function createStreamableHead(
   const vueHead = head as VueHeadClient<any, SSRHeadPayload>
   vueHead.install = vueInstall(vueHead)
 
-  // HeadStream flips from "empty placeholder" to "pending suspense-chunk JS"
-  // once `wrapStream` has captured the shell state.
-  let shellRendered = false
-  ;(vueHead as any)._shellRendered = () => shellRendered
+  const encoder = new TextEncoder()
+
+  const flushPatch = (controller: ReadableStreamDefaultController<Uint8Array>) => {
+    const patch = renderSSRHeadSuspenseChunk(vueHead)
+    if (patch)
+      controller.enqueue(encoder.encode(`<script>${patch};document.currentScript.remove()</script>`))
+  }
 
   return {
     head: vueHead,
-    wrapStream: (stream: ReadableStream<Uint8Array>, template: string) => {
-      const preRenderedState = vueHead.render()
-      vueHead.entries.clear()
-      shellRendered = true
-      return coreWrapStream(vueHead, stream, template, preRenderedState)
-    },
+    wrapStream: (stream, template) =>
+      new ReadableStream<Uint8Array>({
+        async start(controller) {
+          try {
+            const { shell, end } = prepareStreamingTemplate(vueHead, template)
+            controller.enqueue(encoder.encode(shell))
+
+            const reader = stream.getReader()
+            try {
+              while (true) {
+                const { done, value } = await reader.read()
+                if (done)
+                  break
+                controller.enqueue(value)
+                flushPatch(controller)
+              }
+            }
+            finally {
+              reader.releaseLock()
+            }
+
+            flushPatch(controller)
+            controller.enqueue(encoder.encode(end))
+            controller.close()
+          }
+          catch (error) {
+            controller.error(error)
+          }
+        },
+      }),
   }
 }
 

--- a/packages/vue/src/stream/vite.ts
+++ b/packages/vue/src/stream/vite.ts
@@ -1,81 +1,13 @@
 import type { StreamingPluginOptions } from 'unhead/stream/vite'
-import MagicString from 'magic-string'
-import { parseAndWalk } from 'oxc-walker'
 import { createStreamingPlugin } from 'unhead/stream/vite'
 
-const TEMPLATE_RE = /<template[^>]*>/
-const SCRIPT_RE = /<script[^>]*>/i
-const FILTER_RE = /\.vue$/
-
 /**
- * Transforms Vue SFC code to inject `<HeadStream />` components for streaming
- * SSR support. One is added as the first child of each SFC `<template>` that
- * uses `useHead` / `useSeoMeta` / `useHeadSafe`; an import is inserted into
- * `<script>`.
+ * Vite plugin for Vue streaming SSR support.
  *
- * On the server `HeadStream` emits a `<script data-allow-mismatch="children">`
- * containing the pending head-update JS; on the client it emits an identical
- * empty `<script>`. Symmetric vnode types + `data-allow-mismatch` make Vue's
- * hydrator silently tolerate the inner-content difference.
- */
-function transform(code: string, id: string, isSSR: boolean, s: MagicString): boolean {
-  if (!code.includes('useHead') && !code.includes('useSeoMeta') && !code.includes('useHeadSafe'))
-    return false
-
-  const templateMatch = code.match(TEMPLATE_RE)
-  if (!templateMatch)
-    return false
-
-  const templateStart = templateMatch.index! + templateMatch[0].length
-
-  s.appendRight(templateStart, '<HeadStream />')
-
-  const importPath = `@unhead/vue/stream/${isSSR ? 'server' : 'client'}`
-  const scriptMatch = code.match(SCRIPT_RE)
-  if (!scriptMatch)
-    return true
-
-  const scriptEnd = scriptMatch.index! + scriptMatch[0].length
-  const scriptCloseIndex = code.indexOf('</script>', scriptEnd)
-  if (scriptCloseIndex === -1)
-    return true
-
-  const scriptContent = code.slice(scriptEnd, scriptCloseIndex)
-
-  let existingImport: { start: number, end: number, specifiers: string[] } | null = null
-  parseAndWalk(scriptContent, id, {
-    parseOptions: { lang: 'ts' },
-    enter(node: any) {
-      if (node.type === 'ImportDeclaration' && node.source.value === importPath) {
-        existingImport = {
-          start: scriptEnd + node.start,
-          end: scriptEnd + node.end,
-          specifiers: node.specifiers?.map((spec: any) => spec.local?.name).filter(Boolean) || [],
-        }
-        this.skip()
-      }
-    },
-  })
-
-  const foundImport = existingImport as { start: number, end: number, specifiers: string[] } | null
-  if (foundImport) {
-    if (!foundImport.specifiers.includes('HeadStream')) {
-      const inner = foundImport.specifiers.join(', ')
-      const newImports = inner ? `${inner}, HeadStream` : 'HeadStream'
-      s.overwrite(foundImport.start, foundImport.end, `import { ${newImports} } from '${importPath}'\n`)
-    }
-  }
-  else {
-    s.appendRight(scriptEnd, `\nimport { HeadStream } from '${importPath}'`)
-  }
-
-  return true
-}
-
-/**
- * Vite plugin for Vue streaming SSR support. Automatically injects
- * `<HeadStream />` into Vue SFC templates for components that use head
- * composables.
+ * Registers the streaming iife/client virtual modules and injects the
+ * bootstrap via `transformIndexHtml`. No SFC source transform is required:
+ * per-chunk head updates are emitted by `wrapStream` on the server as
+ * self-deleting inline scripts.
  *
  * @example
  * ```ts
@@ -83,27 +15,19 @@ function transform(code: string, id: string, isSSR: boolean, s: MagicString): bo
  * import { unheadVuePlugin } from '@unhead/vue/stream/vite'
  *
  * export default {
- *   plugins: [
- *     unheadVuePlugin(),
- *   ],
+ *   plugins: [unheadVuePlugin()],
  * }
  * ```
  */
 export function unheadVuePlugin(options?: Pick<StreamingPluginOptions, 'mode'>) {
   return createStreamingPlugin({
     framework: '@unhead/vue',
-    filter: FILTER_RE,
+    // No-op transform: per-chunk head patches are emitted by wrapStream on
+    // the server. The filter/transform options are required by the factory;
+    // we pass a never-matching regex so the transform hook is never invoked.
+    filter: /$^/,
+    transform: () => null,
     mode: options?.mode,
-    transform(code, id, opts) {
-      const s = new MagicString(code)
-      if (!transform(code, id, opts?.ssr ?? false, s))
-        return null
-
-      return {
-        code: s.toString(),
-        map: s.generateMap({ includeContent: true, source: id }),
-      }
-    },
   })
 }
 

--- a/packages/vue/test/streaming.test.ts
+++ b/packages/vue/test/streaming.test.ts
@@ -1,12 +1,9 @@
 // @vitest-environment node
 import type { SSRHeadPayload } from 'unhead/types'
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { createSSRApp, defineComponent, h } from 'vue'
-import { renderToString } from 'vue/server-renderer'
 import {
   createBootstrapScript,
   createStreamableHead,
-  HeadStream,
   renderShell,
   renderSSRHeadShell,
   renderSSRHeadSuspenseChunk,
@@ -131,80 +128,62 @@ describe('vue streaming SSR', () => {
     })
   })
 
-  describe('headStream component', () => {
-    it('emits <script data-allow-mismatch="children"> with update content after shell', async () => {
-      const { head } = createStreamableHead()
-      await renderSSRHeadShell(head, '<html><head></head><body>')
-      ;(head as any)._shellRendered = () => true
-      head.push({ title: 'Streamed Title' })
+  describe('wrapStream head patches', () => {
+    const TEMPLATE = '<html><head></head><body><div id="app"><!--app-html--></div></body></html>'
 
-      const App = defineComponent({
-        setup() {
-          return () => h(HeadStream)
+    // `pull` defers the chunk + head.push until wrapStream is reading, so
+    // the entry lands after shell preparation and should surface as an
+    // interleaved patch script rather than in the shell.
+    it('interleaves self-deleting head-update scripts between app chunks', async () => {
+      const { head, wrapStream } = createStreamableHead()
+      head.push({ title: 'Initial' })
+
+      const encoder = new TextEncoder()
+      let step = 0
+      const appStream = new ReadableStream<Uint8Array>({
+        pull(c) {
+          if (step === 0) {
+            c.enqueue(encoder.encode('<div>first</div>'))
+            head.push({ title: 'Updated mid-stream' })
+          }
+          else if (step === 1) {
+            c.enqueue(encoder.encode('<div>second</div>'))
+          }
+          else {
+            c.close()
+          }
+          step++
         },
       })
-      const app = createSSRApp(App)
-      app.provide('usehead', head)
-      const html = await renderToString(app)
 
-      expect(html).toContain('data-allow-mismatch="children"')
-      expect(html).toContain('window.__unhead__.push')
-      expect(html).toContain('Streamed Title')
+      const text = await new Response(wrapStream(appStream, TEMPLATE)).text()
+
+      expect(text).toContain('<title>Initial</title>')
+      expect(text).toMatch(/<div>first<\/div><script>window\.__unhead__\.push\(.*Updated mid-stream.*\);document\.currentScript\.remove\(\)<\/script><div>second<\/div>/)
     })
 
-    it('emits empty placeholder script when no updates are pending', async () => {
-      const { head } = createStreamableHead()
-      await renderSSRHeadShell(head, '<html><head></head><body>')
-      ;(head as any)._shellRendered = () => true
+    it('escapes script-breakout sequences in streamed head updates', async () => {
+      const { head, wrapStream } = createStreamableHead()
 
-      const App = defineComponent({
-        setup() {
-          return () => h(HeadStream)
+      const encoder = new TextEncoder()
+      let step = 0
+      const appStream = new ReadableStream<Uint8Array>({
+        pull(c) {
+          if (step === 0) {
+            c.enqueue(encoder.encode('<div>app</div>'))
+            head.push({ title: '</script><script>alert("xss")</script>' })
+          }
+          else {
+            c.close()
+          }
+          step++
         },
       })
-      const app = createSSRApp(App)
-      app.provide('usehead', head)
-      const html = await renderToString(app)
 
-      // Symmetric with the client vnode so Vue's hydrator matches.
-      expect(html).toBe('<script data-allow-mismatch="children"></script>')
-    })
+      const text = await new Response(wrapStream(appStream, TEMPLATE)).text()
 
-    it('emits empty placeholder before shell is rendered', async () => {
-      const { head } = createStreamableHead()
-      head.push({ title: 'Shell Title' })
-      // _shellRendered defaults to false: HeadStream must not leak shell-time
-      // entries back into the tree.
-
-      const App = defineComponent({
-        setup() {
-          return () => h(HeadStream)
-        },
-      })
-      const app = createSSRApp(App)
-      app.provide('usehead', head)
-      const html = await renderToString(app)
-
-      expect(html).toBe('<script data-allow-mismatch="children"></script>')
-    })
-
-    it('properly escapes script content to prevent XSS', async () => {
-      const { head } = createStreamableHead()
-      await renderSSRHeadShell(head, '<html><head></head><body>')
-      ;(head as any)._shellRendered = () => true
-      head.push({ title: '</script><script>alert("xss")</script>' })
-
-      const App = defineComponent({
-        setup() {
-          return () => h(HeadStream)
-        },
-      })
-      const app = createSSRApp(App)
-      app.provide('usehead', head)
-      const html = await renderToString(app)
-
-      expect(html).not.toContain('</script><script>alert')
-      expect(html).toContain('\\u003c')
+      expect(text).not.toContain('</script><script>alert')
+      expect(text).toContain('\\u003c')
     })
   })
 

--- a/packages/vue/test/vite-plugin.test.ts
+++ b/packages/vue/test/vite-plugin.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { unheadVuePlugin } from '../src/stream/vite'
 
-const FILTER_RE = /\.vue$/
-
 describe('unheadVuePlugin', () => {
   const plugin = unheadVuePlugin() as any
-  const transform = plugin.transform.handler
 
   describe('basic configuration', () => {
     it('has correct name', () => {
@@ -15,113 +12,35 @@ describe('unheadVuePlugin', () => {
     it('enforces pre order', () => {
       expect(plugin.enforce).toBe('pre')
     })
+
+    // No SFC source transform runs: per-chunk head patches are emitted by
+    // wrapStream on the server. The transform hook is still registered by
+    // the core factory, but with a never-matching filter.
+    it('registers a never-matching transform filter', () => {
+      expect(plugin.transform.filter.id.test('any.vue')).toBe(false)
+    })
   })
 
-  describe('transform', () => {
-    it('filters to .vue files only', () => {
-      expect(plugin.transform.filter.id).toEqual(FILTER_RE)
+  describe('virtual modules', () => {
+    it('resolves the iife virtual id', () => {
+      const resolved = plugin.resolveId.handler('virtual:@unhead/streaming-iife.js')
+      expect(resolved).toBe('\0virtual:@unhead/streaming-iife.js')
     })
 
-    it('skips files without useHead', () => {
-      const code = `
-        <script setup>
-        </script>
-        <template>
-          <div>Hello</div>
-        </template>
-      `
-      const result = transform(code, 'component.vue')
-      expect(result).toBeNull()
+    it('resolves the client virtual id', () => {
+      const resolved = plugin.resolveId.handler('virtual:@unhead/streaming-client')
+      expect(resolved).toBe('\0virtual:@unhead/streaming-client')
     })
+  })
 
-    it('injects HeadStream in template for components with useHead', () => {
-      const code = `
-        <script setup>
-          import { useHead } from '@unhead/vue'
-          useHead({ title: 'Test' })
-        </script>
-        <template>
-          <div>Hello</div>
-        </template>
-      `
-      const result = transform(code, 'component.vue')
-      expect(result).not.toBeNull()
-      expect(result!.code).toContain('<HeadStream />')
-    })
-
-    it('adds HeadStream import from client for non-SSR builds', () => {
-      const code = `
-        <script setup>
-          import { useHead } from '@unhead/vue'
-          useHead({ title: 'Test' })
-        </script>
-        <template>
-          <div>Hello</div>
-        </template>
-      `
-      const result = transform(code, 'component.vue', { ssr: false })
-      expect(result).not.toBeNull()
-      expect(result!.code).toContain('import { HeadStream } from \'@unhead/vue/stream/client\'')
-    })
-
-    it('adds HeadStream import from server for SSR builds', () => {
-      const code = `
-        <script setup>
-          import { useHead } from '@unhead/vue'
-          useHead({ title: 'Test' })
-        </script>
-        <template>
-          <div>Hello</div>
-        </template>
-      `
-      const result = transform(code, 'component.vue', { ssr: true })
-      expect(result).not.toBeNull()
-      expect(result!.code).toContain('import { HeadStream } from \'@unhead/vue/stream/server\'')
-    })
-
-    it('adds HeadStream to existing server import for SSR builds', () => {
-      const code = `
-        <script setup>
-          import { useHead } from '@unhead/vue/stream/server'
-          useHead({ title: 'Test' })
-        </script>
-        <template>
-          <div>Hello</div>
-        </template>
-      `
-      const result = transform(code, 'component.vue', { ssr: true })
-      expect(result).not.toBeNull()
-      expect(result!.code).toContain('useHead, HeadStream')
-    })
-
-    it('transforms files with useSeoMeta', () => {
-      const code = `
-        <script setup>
-          import { useSeoMeta } from '@unhead/vue'
-          useSeoMeta({ title: 'Test' })
-        </script>
-        <template>
-          <div>Hello</div>
-        </template>
-      `
-      const result = transform(code, 'component.vue')
-      expect(result).not.toBeNull()
-      expect(result!.code).toContain('<HeadStream />')
-    })
-
-    it('generates source map', () => {
-      const code = `
-        <script setup>
-          import { useHead } from '@unhead/vue'
-          useHead({ title: 'Test' })
-        </script>
-        <template>
-          <div>Hello</div>
-        </template>
-      `
-      const result = transform(code, 'component.vue')
-      expect(result).not.toBeNull()
-      expect(result!.map).toBeDefined()
+  describe('transformIndexHtml', () => {
+    it('injects the iife script tag for async mode', () => {
+      const tags = plugin.transformIndexHtml()
+      expect(Array.isArray(tags)).toBe(true)
+      expect(tags[0].tag).toBe('script')
+      expect(tags[0].injectTo).toBe('head-prepend')
+      expect(tags[0].attrs).toMatchObject({ async: true })
+      expect(tags[0].attrs.src).toContain('virtual:@unhead/streaming-iife.js')
     })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1034,15 +1034,6 @@ importers:
       hookable:
         specifier: 'catalog:'
         version: 6.1.1
-      magic-string:
-        specifier: 'catalog:'
-        version: 0.30.21
-      oxc-parser:
-        specifier: 'catalog:'
-        version: 0.127.0
-      oxc-walker:
-        specifier: 'catalog:'
-        version: 0.7.0(oxc-parser@0.127.0)
       unhead:
         specifier: workspace:*
         version: link:../unhead

--- a/test/exports/vue.yaml
+++ b/test/exports/vue.yaml
@@ -49,7 +49,6 @@
   VueHeadMixin: object
 ./stream/client:
   createStreamableHead: function
-  HeadStream: object
   VueHeadMixin: object
 ./stream/iife:
   streamingIifeCode: string
@@ -57,7 +56,6 @@
 ./stream/server:
   createBootstrapScript: function
   createStreamableHead: function
-  HeadStream: object
   prepareStreamingTemplate: function
   renderShell: function
   renderSSRHeadShell: function


### PR DESCRIPTION
### 🔗 Linked issue

N/A — surfaced while debugging Vue streaming hydration in `examples/vite-ssr-vue-streaming`.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Vue streaming relied on an SFC AST transform that injected a `<HeadStream />` component into every template using `useHead` / `useSeoMeta`, plus a symmetric client vnode with `data-allow-mismatch` — heavy plumbing that also needed a vue-loader patch on webpack/rspack. Replaced it with per-chunk flushing in `wrapStream`: after each framework stream chunk, any newly added head entries are emitted as `<script>window.__unhead__.push(...);document.currentScript.remove()</script>`, which executes during HTML parse and removes itself before Vue hydrates. Also splits `prepareStreamingTemplate` at the canonical `<!--app-html-->` / `<!--ssr-outlet-->` marker so templates can wrap the stream in `<div id="app">...</div>` without container mismatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Vue SSR streaming now emits per-chunk, self-deleting inline head update scripts between app chunks instead of using a placeholder component.
  * Vite plugin simplified to rely on index.html transforms and server streaming rather than source-level SFC injection.
  * Tests and examples updated to use the new streaming flow and template marker.

* **Chores**
  * Build configuration adjusted to include previously externalized dependencies in the bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->