### PR TITLE
feat(stream): split template at <!--app-html--> / <!--ssr-outlet--> marker

### DIFF
--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -7,6 +7,8 @@ import { DEFAULT_STREAM_KEY } from './client'
 const LT_RE = /</g
 const GT_RE = />/g
 const AMP_RE = /&/g
+// Canonical Vite SSR outlet markers. Either form is accepted.
+const OUTLET_RE = /<!--\s*(?:app-html|ssr-outlet)\s*-->/
 
 // Conservative ASCII identifier: must be a safe `window.<name>` accessor.
 // Disallows anything that could break out of the dot-notation sink used by
@@ -336,16 +338,30 @@ export function prepareStreamingTemplate(
     // (e.g. scripts injected by Vite plugins via transformIndexHtml with
     // injectTo: 'body'). Without preserving this, anything plugins inject
     // into the body silently disappears in streaming mode.
-    const bodyInterior = template.substring(bodyEnd, bodyCloseStart)
+    let bodyInterior = template.substring(bodyEnd, bodyCloseStart)
     const endPart = template.substring(bodyCloseStart)
 
     const shellParsed = parseHtmlForIndexes(`${shellPart}</body></html>`)
-    const shell = applyHeadToHtml(shellParsed, {
+    let shell = applyHeadToHtml(shellParsed, {
       htmlAttrs: ssr.htmlAttrs,
       headTags: bootstrapScript + ssr.headTags,
       bodyAttrs: ssr.bodyAttrs,
       bodyTags: '',
     }).replace('</body></html>', '')
+
+    // If the template marks an explicit SSR outlet (canonical Vite pattern),
+    // split the body interior at that marker so the app stream lands inside
+    // it instead of before it. This lets a template wrap the stream in
+    // `<div id="app"><!--app-html--></div>` without creating a hydration
+    // container mismatch.
+    const outletMatch = bodyInterior.match(OUTLET_RE)
+    if (outletMatch) {
+      const outletIndex = outletMatch.index!
+      const beforeOutlet = bodyInterior.substring(0, outletIndex)
+      const afterOutlet = bodyInterior.substring(outletIndex + outletMatch[0].length)
+      shell = shell + beforeOutlet
+      bodyInterior = afterOutlet
+    }
 
     return {
       shell,

--- a/packages/unhead/test/streaming/streaming.test.ts
+++ b/packages/unhead/test/streaming/streaming.test.ts
@@ -421,6 +421,38 @@ describe('streaming SSR', () => {
       expect(result).toContain('data-theme="dark"')
       expect(result).toContain('data-page="home"')
     })
+
+    it('splits at <!--app-html--> outlet marker', () => {
+      const { head } = createStreamableHead()
+      head.push({ title: 'Outlet Test' })
+
+      const template = '<html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+      const { shell, end } = prepareStreamingTemplate(head, template)
+
+      expect(shell).toContain('<title>Outlet Test</title>')
+      expect(shell).toContain('<div id="app">')
+      expect(shell).not.toContain('<!--app-html-->')
+      expect(end).toContain('</div></body></html>')
+    })
+
+    it('splits at <!--ssr-outlet--> outlet marker', () => {
+      const { head } = createStreamableHead()
+      const template = '<html><head></head><body><div id="root"><!--ssr-outlet--></div></body></html>'
+      const { shell, end } = prepareStreamingTemplate(head, template)
+
+      expect(shell).toContain('<div id="root">')
+      expect(shell).not.toContain('<!--ssr-outlet-->')
+      expect(end).toContain('</div></body></html>')
+    })
+
+    it('falls back to body boundary when no outlet marker present', () => {
+      const { head } = createStreamableHead()
+      const template = '<html><head></head><body><div id="app"></div></body></html>'
+      const { shell, end } = prepareStreamingTemplate(head, template)
+
+      expect(shell).not.toContain('<div id="app">')
+      expect(end).toContain('<div id="app">')
+    })
   })
 
   describe('concurrent streams', () => {


### PR DESCRIPTION
### 🔗 Linked issue

N/A — surfaced while making the Vue streaming example use the canonical Vite outlet template.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

\`prepareStreamingTemplate\` only split at the body tag boundary, so a canonical Vite SSR template like \`<body><div id=\"app\"><!--app-html--></div></body>\` emitted the app stream as a sibling of \`<div id=\"app\">\` and the client couldn't hydrate \`#app\` without a container mismatch. When the body interior contains \`<!--app-html-->\` or \`<!--ssr-outlet-->\`, we now split at that marker so the app stream lands inside the container. Templates without a marker keep current behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming SSR template handling to properly detect and position outlet markers, ensuring correct content placement between shell and streamed sections in Vite SSR configurations.

* **Tests**
  * Added comprehensive test coverage for streaming SSR template scenarios with various outlet marker patterns and fallback behavior to ensure streaming reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->