### PR TITLE
fix: scope alternate link dedupeKey by href when type is used

### DIFF
--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -14,9 +14,10 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
   if (t === 'link' && props.rel === 'canonical')
     return 'canonical'
   if (t === 'link' && props.rel === 'alternate') {
-    const altKey = props.hreflang || props.type
-    if (altKey)
-      return `alternate:${altKey}`
+    if (props.hreflang)
+      return `alternate:${props.hreflang}`
+    if (props.type)
+      return `alternate:${props.type}:${props.href || ''}`
   }
 
   if (props.charset)

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -581,7 +581,44 @@ describe('dedupe', () => {
     expect(headTags).toContain('hreflang="fr"')
   })
 
-  it('dedupes RSS feeds with same type', async () => {
+  it('dedupes RSS feeds with same type and same href on rehydration', async () => {
+    const head = createServerHeadWithContext()
+    head.push({
+      link: [
+        { rel: 'alternate', type: 'application/rss+xml', href: 'https://example.com/feed.xml', title: 'RSS Feed' },
+      ],
+    })
+    // Push the same link again (simulating SSR + hydration of the same feed).
+    head.push({
+      link: [
+        { rel: 'alternate', type: 'application/rss+xml', href: 'https://example.com/feed.xml', title: 'RSS Feed' },
+      ],
+    })
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags.split('rel="alternate"').length).toBe(2)
+    expect(headTags).toContain('feed.xml')
+  })
+
+  it('keeps multiple RSS feeds with same type and different hrefs (#758)', async () => {
+    // Regression for https://github.com/unjs/unhead/issues/758 — `dedupeKey`
+    // for `rel="alternate"` used to collapse on `type` alone, which dropped
+    // every feed but the last when two RSS feeds shared `application/rss+xml`.
+    const head = createServerHeadWithContext()
+    head.push({
+      link: [
+        { rel: 'alternate', type: 'application/rss+xml', href: 'https://example.com/feed.xml', title: 'RSS Feed' },
+        { rel: 'alternate', type: 'application/rss+xml', href: 'https://example.com/feed2.xml', title: 'RSS Feed 2' },
+      ],
+    })
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags.split('rel="alternate"').length).toBe(3)
+    expect(headTags).toContain('feed.xml')
+    expect(headTags).toContain('feed2.xml')
+  })
+
+  it('keeps multiple RSS feeds across separate head pushes (#758)', async () => {
+    // Same as above but split across two `head.push` calls (the way Vue/Nuxt
+    // composables typically register tags from different components).
     const head = createServerHeadWithContext()
     head.push({
       link: [
@@ -594,9 +631,9 @@ describe('dedupe', () => {
       ],
     })
     const { headTags } = await renderSSRHead(head)
-    expect(headTags.split('rel="alternate"').length).toBe(2)
+    expect(headTags.split('rel="alternate"').length).toBe(3)
+    expect(headTags).toContain('feed.xml')
     expect(headTags).toContain('feed2.xml')
-    expect(headTags).not.toContain('feed.xml"')
   })
 
   it('allows RSS and Atom feeds to coexist', async () => {


### PR DESCRIPTION
## Problem

Multiple RSS/Atom alternate <link> tags with the same 	ype but different hrefs are incorrectly deduplicated into a single tag.

### Root cause

In dedupe.ts, the deduplication key for el="alternate" links is built as:

`	s
const altKey = props.hreflang || props.type
if (altKey)
  return `alternate:${altKey}`
`

When hreflang is absent (e.g. RSS/Atom feeds), all feeds with the same 	ype (e.g. pplication/rss+xml) share the same key — lternate:application/rss+xml — regardless of their href. This collapses all but one of them.

### Fix

Use hreflang alone as the key (language variants are uniquely identified by it). For type-based alternates (RSS/Atom), include href in the key so distinct feeds are not conflated:

`	s
if (t === 'link' && props.rel === 'alternate') {
  if (props.hreflang)
    return `alternate:${props.hreflang}`
  if (props.type)
    return `alternate:${props.type}:${props.href || ''}`
}
`

Fixes #758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deduplication for alternate link tags: hreflang values are treated separately, and type-based deduplication now also considers href to avoid collapsing distinct alternates.
  * Updated tests to cover RSS/feed deduplication: identical type+href dedupes, different hrefs are preserved, and behavior is consistent across consecutive updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->