### PR TITLE
fix: scope alternate link dedupeKey by href when type is used

### DIFF
--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -31,10 +31,10 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
 
   // dedupe alternate links with hreflang/type by that attribute
   if (name === 'link' && props.rel === 'alternate') {
-    const altKey = props.hreflang || props.type
-    if (altKey) {
-      return `alternate:${altKey}`
-    }
+    if (props.hreflang)
+      return `alternate:${props.hreflang}`
+    if (props.type)
+      return `alternate:${props.type}:${props.href || ''}`
   }
 
   if (props.charset)

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -644,7 +644,38 @@ describe('dedupe', () => {
     expect(headTags).toContain('hreflang="fr"')
   })
 
-  it('dedupes RSS feeds with same type', async () => {
+  it('dedupes RSS feeds with same type and same href on rehydration', async () => {
+    const head = createServerHeadWithContext()
+    head.push({
+      link: [
+        { rel: 'alternate', type: 'application/rss+xml', href: 'https://example.com/feed.xml', title: 'RSS Feed' },
+      ],
+    })
+    head.push({
+      link: [
+        { rel: 'alternate', type: 'application/rss+xml', href: 'https://example.com/feed.xml', title: 'RSS Feed' },
+      ],
+    })
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags.split('rel="alternate"').length).toBe(2)
+    expect(headTags).toContain('feed.xml')
+  })
+
+  it('keeps multiple RSS feeds with same type and different hrefs (#758)', async () => {
+    const head = createServerHeadWithContext()
+    head.push({
+      link: [
+        { rel: 'alternate', type: 'application/rss+xml', href: 'https://example.com/feed.xml', title: 'RSS Feed' },
+        { rel: 'alternate', type: 'application/rss+xml', href: 'https://example.com/feed2.xml', title: 'RSS Feed 2' },
+      ],
+    })
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags.split('rel="alternate"').length).toBe(3)
+    expect(headTags).toContain('feed.xml')
+    expect(headTags).toContain('feed2.xml')
+  })
+
+  it('keeps multiple RSS feeds across separate head pushes (#758)', async () => {
     const head = createServerHeadWithContext()
     head.push({
       link: [
@@ -657,9 +688,9 @@ describe('dedupe', () => {
       ],
     })
     const { headTags } = await renderSSRHead(head)
-    expect(headTags.split('rel="alternate"').length).toBe(2)
+    expect(headTags.split('rel="alternate"').length).toBe(3)
+    expect(headTags).toContain('feed.xml')
     expect(headTags).toContain('feed2.xml')
-    expect(headTags).not.toContain('feed.xml"')
   })
 
   it('allows RSS and Atom feeds to coexist', async () => {


### PR DESCRIPTION
Backport of #759 to the v2 branch.

## Problem

Multiple RSS/Atom `<link rel="alternate">` tags sharing the same `type` but with different `href` values were being collapsed into one tag, because `dedupeKey` for alternates was built from `type` alone.

## Fix

Use `hreflang` alone as the key when present (language variants are uniquely identified by it). For type-based alternates, include `href` in the key so distinct feeds are not conflated.

```ts
if (name === 'link' && props.rel === 'alternate') {
  if (props.hreflang)
    return `alternate:${props.hreflang}`
  if (props.type)
    return `alternate:${props.type}:${props.href || ''}`
}
```

Fixes #758