### PR TITLE
chore: publish v2 packages under @v2 dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
-      - run: pnpm publish -r --access public --no-git-checks
+      - run: pnpm publish -r --access public --no-git-checks --tag v2

--- a/packages-aliased/dom/package.json
+++ b/packages-aliased/dom/package.json
@@ -13,7 +13,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "v2"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages-aliased/schema/package.json
+++ b/packages-aliased/schema/package.json
@@ -16,7 +16,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "v2"
   },
   "keywords": [
     "head",

--- a/packages-aliased/shared/package.json
+++ b/packages-aliased/shared/package.json
@@ -13,7 +13,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "v2"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages-aliased/ssr/package.json
+++ b/packages-aliased/ssr/package.json
@@ -13,7 +13,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "v2"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -14,7 +14,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "v2"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -14,7 +14,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "v2"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages/schema-org/package.json
+++ b/packages/schema-org/package.json
@@ -17,7 +17,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "v2"
   },
   "keywords": [
     "schema.org",

--- a/packages/unhead/package.json
+++ b/packages/unhead/package.json
@@ -10,7 +10,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "v2"
   },
   "license": "MIT",
   "funding": "https://github.com/sponsors/harlan-zw",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -14,7 +14,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "v2"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"


### PR DESCRIPTION
## Why

The v2 branch's `publishConfig.tag` is still `\"next\"` from when v3 was upcoming. Now that v3 is `latest`:

- `latest` → `3.1.0`
- `next` → `3.0.0-beta.9` (stale)

If we cut a v2 release as-is, `pnpm publish -r` would push 2.1.x to `next`, downgrading anyone running `npm i unhead@next`.

## What

Switch all v2 publishable packages (`unhead`, `@unhead/vue`, `@unhead/schema-org`, `@unhead/addons`, `@unhead/angular`) to `publishConfig.tag: \"v2\"`. Users on v2 install via `npm i unhead@v2`.

`latest` is unaffected either way — `publishConfig.tag` overrides the default.