### PR TITLE
chore(release): use `2x` dist-tag instead of `v2`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
-      - run: pnpm publish -r --access public --no-git-checks --tag v2
+      - run: pnpm publish -r --access public --no-git-checks --tag 2x

--- a/packages-aliased/dom/package.json
+++ b/packages-aliased/dom/package.json
@@ -13,7 +13,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v2"
+    "tag": "2x"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages-aliased/schema/package.json
+++ b/packages-aliased/schema/package.json
@@ -16,7 +16,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v2"
+    "tag": "2x"
   },
   "keywords": [
     "head",

--- a/packages-aliased/shared/package.json
+++ b/packages-aliased/shared/package.json
@@ -13,7 +13,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v2"
+    "tag": "2x"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages-aliased/ssr/package.json
+++ b/packages-aliased/ssr/package.json
@@ -13,7 +13,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v2"
+    "tag": "2x"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -14,7 +14,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v2"
+    "tag": "2x"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -14,7 +14,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v2"
+    "tag": "2x"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"

--- a/packages/schema-org/package.json
+++ b/packages/schema-org/package.json
@@ -17,7 +17,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v2"
+    "tag": "2x"
   },
   "keywords": [
     "schema.org",

--- a/packages/unhead/package.json
+++ b/packages/unhead/package.json
@@ -10,7 +10,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v2"
+    "tag": "2x"
   },
   "license": "MIT",
   "funding": "https://github.com/sponsors/harlan-zw",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -14,7 +14,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v2"
+    "tag": "2x"
   },
   "bugs": {
     "url": "https://github.com/unjs/unhead/issues"


### PR DESCRIPTION
The v2 release workflow failed with:

\`\`\`
npm error Tag name must not be a valid SemVer range: v2
\`\`\`

npm rejects \`v2\` because it parses as a SemVer range (shorthand for \`2.x.x\`). Switching to \`2x\` (not a valid SemVer range) across:

- \`publishConfig.tag\` in all 9 publishable packages (\`packages/*\` + \`packages-aliased/*\`)
- \`--tag 2x\` in \`.github/workflows/release.yml\`

Users install with \`npm i unhead@2x\`.