### PR TITLE
fix(types): support union rel/type in defineLink and defineScript

### DIFF
--- a/packages/unhead/src/types/schema/link.ts
+++ b/packages/unhead/src/types/schema/link.ts
@@ -879,28 +879,53 @@ export type Link
 // ============================================================================
 
 /**
- * Pick {@link Link} union members whose `rel` accepts `R`.
+ * Pick {@link Link} union members whose `rel` accepts `R`. Distributes over `R`,
+ * so a union rel like `'preconnect' | 'dns-prefetch'` returns the union of all
+ * matching variants.
  *
  * Unlike `Extract<Link, { rel: R }>`, this handles members whose `rel` is itself
  * a union (e.g. {@link FaviconLink}'s `'icon' | 'shortcut icon'`).
  */
 type MatchLinkByRel<R>
-  = Link extends infer M
-    ? M extends { rel: infer MR }
-      ? R extends MR
-        ? M
+  = R extends any
+    ? Link extends infer M
+      ? M extends { rel: infer MR }
+        ? R extends MR
+          ? M
+          : never
         : never
       : never
     : never
 
+type UnionToIntersection<U>
+  = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+
+type IsUnion<T, U extends T = T> = T extends T ? ([U] extends [T] ? false : true) : never
+
+/**
+ * For a union rel input, the structural intersection of matching variants
+ * (minus their `rel` discriminator) plus the original rel union. Lets
+ * {@link defineLink} accept a runtime-determined rel like
+ * `cond ? 'preconnect' : 'dns-prefetch'` without losing field validation.
+ */
+type InferLinkUnion<R>
+  = UnionToIntersection<MatchLinkByRel<R> extends infer M ? (M extends any ? Omit<M, 'rel'> : never) : never>
+    & { rel: R }
+
 /**
  * Resolve a single link input to either its strict {@link Link} variant (when
  * `rel` is a {@link KnownLinkRel}) or {@link GenericLink} (for custom rels).
+ *
+ * Union `rel` inputs (e.g. `'preconnect' | 'dns-prefetch'`) resolve to the
+ * structural intersection of matching variants, so runtime-determined rels are
+ * accepted without casts.
  */
 export type InferLink<T>
   = T extends { rel: infer R }
     ? R extends KnownLinkRel
-      ? DeepReadonly<MatchLinkByRel<R>>
+      ? IsUnion<R> extends true
+        ? DeepReadonly<InferLinkUnion<R>>
+        : DeepReadonly<MatchLinkByRel<R>>
       : R extends string
         ? DeepReadonly<GenericLink> & { rel: R }
         : never

--- a/packages/unhead/src/types/schema/script.ts
+++ b/packages/unhead/src/types/schema/script.ts
@@ -464,23 +464,46 @@ export type KnownScriptType
     | 'application/json'
 
 /**
- * Pick {@link Script} union members whose `type` accepts `U`.
+ * Pick {@link Script} union members whose `type` accepts `U`. Distributes over
+ * `U`, so a union type like `'text/javascript' | 'module'` returns the union of
+ * all matching variants.
  *
  * Handles members whose `type` is itself a union (e.g. {@link ExternalScript}'s
  * `'' | 'text/javascript'`), and members where `type` is optional.
  */
 type MatchScriptByType<U>
-  = Script extends infer M
-    ? M extends { type?: infer MT }
-      ? U extends MT
-        ? M
+  = U extends any
+    ? Script extends infer M
+      ? M extends { type?: infer MT }
+        ? U extends MT
+          ? M
+          : never
         : never
       : never
     : never
 
+type UnionToIntersection<U>
+  = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+
+type IsUnion<T, U extends T = T> = T extends T ? ([U] extends [T] ? false : true) : never
+
+/**
+ * For a union `type` input, the structural intersection of matching variants
+ * (minus their `type` discriminator) plus the original type union. Lets
+ * {@link defineScript} accept a runtime-determined type like
+ * `cond ? 'text/javascript' : 'module'` without losing field validation.
+ */
+type InferScriptUnion<U>
+  = UnionToIntersection<MatchScriptByType<U> extends infer M ? (M extends any ? Omit<M, 'type'> : never) : never>
+    & { type: U }
+
 /**
  * Resolve a single script input to either its strict {@link Script} variant (when
  * `type` is a {@link KnownScriptType}) or {@link GenericScript} (for custom types).
+ *
+ * Union `type` inputs (e.g. `'text/javascript' | 'module'`) resolve to the
+ * structural intersection of matching variants, so runtime-determined types are
+ * accepted without casts.
  *
  * When no `type` field is present, or `type` is non-string, the full {@link Script}
  * union is returned so discriminators like `src` vs `textContent` still apply.
@@ -489,7 +512,9 @@ export type InferScript<T>
   = T extends { type: infer U }
     ? U extends string
       ? U extends KnownScriptType
-        ? DeepReadonly<MatchScriptByType<U>>
+        ? IsUnion<U> extends true
+          ? DeepReadonly<InferScriptUnion<U>>
+          : DeepReadonly<MatchScriptByType<U>>
         : DeepReadonly<GenericScript> & { type: U }
       : DeepReadonly<Script>
     : DeepReadonly<Script>

--- a/packages/unhead/test/unit/types.test.ts
+++ b/packages/unhead/test/unit/types.test.ts
@@ -1,5 +1,6 @@
 import type { PreloadLink, SerializableHead } from '../../src/types'
 import { useHead, useHeadSafe, useSeoMeta } from '../../src/composables'
+import { defineLink, defineScript } from '../../src/define'
 import { createHead } from '../../src/server'
 
 describe('types', () => {
@@ -92,6 +93,215 @@ describe('types', () => {
 
     void validPreloadLink
     void invalidPreloadLink
+  })
+  it('types defineLink with union rels (e.g. preconnect/dns-prefetch)', () => {
+    const head = createHead()
+    const eager = Math.random() > 0.5
+
+    // Valid: runtime-determined rel across structurally-compatible variants.
+    // Without defineLink, the Link discriminated union can't pick a branch for
+    // a union rel — this is the canonical workaround.
+    useHead(head, {
+      link: [
+        defineLink({
+          rel: eager ? 'preconnect' : 'dns-prefetch',
+          href: 'https://example.com',
+        }),
+      ],
+    })
+
+    // Valid: preconnect-only `crossorigin` still allowed (structural intersection
+    // keeps optional fields from any matching variant).
+    useHead(head, {
+      link: [
+        defineLink({
+          rel: eager ? 'preconnect' : 'dns-prefetch',
+          href: 'https://example.com',
+          crossorigin: 'anonymous',
+        }),
+      ],
+    })
+
+    // Valid: single-rel input still strictly narrowed
+    useHead(head, {
+      link: [
+        defineLink({ rel: 'preconnect', href: 'https://example.com', crossorigin: 'anonymous' }),
+      ],
+    })
+
+    // Invalid: missing href is still rejected for a known rel that requires it
+    // @ts-expect-error href is required
+    defineLink({ rel: eager ? 'preconnect' : 'dns-prefetch' })
+
+    // Invalid: a union mixing rels with incompatible required fields (preload
+    // requires `as`) still forces the stricter requirement.
+    // @ts-expect-error `as` is required when 'preload' is in the rel union
+    defineLink({ rel: eager ? 'preload' : 'modulepreload', href: '/m.js' })
+  })
+  it('types defineScript with union types (e.g. text/javascript / module)', () => {
+    const head = createHead()
+    const useModule = Math.random() > 0.5
+
+    // Valid: runtime-determined script type across structurally-compatible variants
+    useHead(head, {
+      script: [
+        defineScript({
+          type: useModule ? 'module' : 'text/javascript',
+          src: '/app.js',
+        }),
+      ],
+    })
+
+    // Valid: single-type input still strictly narrowed
+    useHead(head, {
+      script: [
+        defineScript({ type: 'application/ld+json', textContent: '{}' }),
+      ],
+    })
+
+    // Invalid: a union mixing types with incompatible required fields
+    // (application/ld+json requires textContent) forces the stricter requirement.
+    // @ts-expect-error textContent is required when 'application/ld+json' is in the type union
+    defineScript({ type: useModule ? 'text/javascript' : 'application/ld+json', src: '/a.js' })
+  })
+  it('types defineLink union rels: adversarial coverage', () => {
+    const cond = Math.random() > 0.5
+
+    // ── Single-literal rel: strict narrowing preserved ────────────────────
+
+    // @ts-expect-error 'preload' requires `as`
+    defineLink({ rel: 'preload', href: '/x' })
+
+    // @ts-expect-error 'modulepreload' requires `href`
+    defineLink({ rel: 'modulepreload' })
+
+    // valid: preload with full required shape
+    defineLink({ rel: 'preload', href: '/font.woff2', as: 'font', crossorigin: 'anonymous' })
+
+    // ── Two-rel union, structurally compatible ────────────────────────────
+
+    defineLink({ rel: cond ? 'preconnect' : 'dns-prefetch', href: '/' })
+    defineLink({ rel: cond ? 'dns-prefetch' : 'prerender', href: '/' })
+
+    // @ts-expect-error href still required across the union
+    defineLink({ rel: cond ? 'preconnect' : 'dns-prefetch' })
+
+    // ── Three-rel union ───────────────────────────────────────────────────
+
+    const r3: 'preconnect' | 'dns-prefetch' | 'prerender' = cond ? 'preconnect' : 'dns-prefetch'
+    defineLink({ rel: r3, href: '/' })
+
+    // ── Optional carry-over: crossorigin only meaningful on preconnect ───
+    // Intersection keeps it as optional, so it's accepted across the union.
+    defineLink({ rel: cond ? 'preconnect' : 'dns-prefetch', href: '/', crossorigin: 'anonymous' })
+
+    // Wrong literal value for an optional carried-over field is still rejected
+    // @ts-expect-error 'bogus' not in crossorigin literal union
+    defineLink({ rel: cond ? 'preconnect' : 'dns-prefetch', href: '/', crossorigin: 'bogus' })
+
+    // ── Union with differing required fields: stricter wins ──────────────
+
+    // @ts-expect-error 'preload' contributes required `as`
+    defineLink({ rel: cond ? 'preload' : 'modulepreload', href: '/m.js' })
+
+    // Supplying `as` satisfies the preload branch
+    defineLink({ rel: cond ? 'preload' : 'modulepreload', href: '/m.js', as: 'script' })
+
+    // ── Variant with rel that's itself a union (FaviconLink: icon | shortcut icon) ─
+
+    defineLink({ rel: 'icon', href: '/favicon.ico' })
+    defineLink({ rel: 'shortcut icon', href: '/favicon.ico' })
+    defineLink({ rel: cond ? 'icon' : 'shortcut icon', href: '/favicon.ico' })
+    // Plus extra rels around it
+    defineLink({ rel: cond ? 'icon' : 'apple-touch-icon', href: '/favicon.ico' })
+
+    // ── Known + unknown rel mix falls through to generic ─────────────────
+
+    defineLink({ rel: 'openid2.provider', href: 'https://op.example.com/' })
+    // Custom rel doesn't enforce stylesheet shape
+    defineLink({ rel: 'EditURI', href: '/rsd.xml', type: 'application/rsd+xml' })
+
+    // ── rel widened to string falls through to generic ───────────────────
+
+    const wideRel = (cond ? 'preconnect' : 'custom-rel') as string
+    defineLink({ rel: wideRel, href: '/' })
+
+    // ── Wrong field type still rejected on union input ───────────────────
+
+    // @ts-expect-error href must be string
+    defineLink({ rel: cond ? 'preconnect' : 'dns-prefetch', href: 123 })
+
+    // ── as const inputs accepted (DeepReadonly) ───────────────────────────
+
+    defineLink({ rel: 'icon', href: '/favicon.ico', sizes: '32x32' } as const)
+
+    // ── Excess properties on union input are accepted (data-*, custom attrs) ─
+
+    defineLink({
+      'rel': cond ? 'preconnect' : 'dns-prefetch',
+      'href': '/',
+      'data-test': 'ok',
+    })
+
+    // ── Empty union (impossible at runtime, but exercise the type) ───────
+
+    type EmptyRel = never
+    // @ts-expect-error rel cannot be never
+    defineLink({ rel: null as unknown as EmptyRel, href: '/' })
+
+    // ── Full structural union covering most KnownLinkRel resource hints ──
+
+    const allHints: 'preconnect' | 'dns-prefetch' | 'prerender' | 'prefetch'
+      = cond ? 'preconnect' : 'prefetch'
+    // 'prefetch' adds optional `as` — should be accepted with or without it
+    defineLink({ rel: allHints, href: '/' })
+    defineLink({ rel: allHints, href: '/', as: 'script' })
+
+    // ── Variant whose rel is itself a union, combined with another rel ───
+    // FaviconLink rel = 'icon' | 'shortcut icon'; combine with 'manifest'
+    defineLink({ rel: cond ? 'icon' : 'manifest', href: '/manifest.json' })
+  })
+  it('types defineScript union types: adversarial coverage', () => {
+    const cond = Math.random() > 0.5
+
+    // ── Single-literal type: strict narrowing preserved ──────────────────
+
+    defineScript({ type: 'application/ld+json', textContent: '{"@context":"…"}' })
+
+    // @ts-expect-error 'application/ld+json' requires textContent
+    defineScript({ type: 'application/ld+json' })
+
+    defineScript({ type: 'module', src: '/x.mjs' })
+
+    // ── Compatible two-type union ────────────────────────────────────────
+
+    defineScript({ type: cond ? 'text/javascript' : 'module', src: '/app.js' })
+    defineScript({ type: cond ? '' : 'text/javascript', src: '/app.js' })
+
+    // ── Incompatible required fields force stricter shape ────────────────
+
+    // @ts-expect-error 'application/ld+json' requires textContent
+    defineScript({ type: cond ? 'text/javascript' : 'application/ld+json', src: '/a.js' })
+
+    // Supplying textContent satisfies the ld+json branch
+    defineScript({
+      type: cond ? 'text/javascript' : 'application/ld+json',
+      textContent: '{}',
+    })
+
+    // ── Custom type falls through to GenericScript ───────────────────────
+
+    defineScript({ type: 'text/partytown', src: '/p.js' })
+
+    // ── type widened to string falls through ─────────────────────────────
+
+    const wideType = (cond ? 'text/javascript' : 'text/plain') as string
+    defineScript({ type: wideType, src: '/a.js' })
+
+    // ── Wrong field type still rejected on union input ───────────────────
+
+    // @ts-expect-error src must be string
+    defineScript({ type: cond ? 'text/javascript' : 'module', src: 123 })
   })
   it('types SerializableHead', () => {
     const head = createHead()


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`defineLink` / `defineScript` previously rejected runtime-determined rels and types (e.g. `cond ? 'preconnect' : 'dns-prefetch'`) because `InferLink` / `InferScript` only matched single-literal inputs against the discriminated union.

Distributes the match over the input union, then intersects matching variants (minus their discriminator) so optional fields like `crossorigin` carry over while incompatible required fields (e.g. `preload`'s `as`, `application/ld+json`'s `textContent`) still force the stricter shape. Single-literal inputs remain strictly narrowed.

Adversarial type-test coverage added for resource-hint unions, FaviconLink's internal rel union, generic-rel fallthrough, and script-type unions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved type inference for link and script definitions using union-based `rel` and `type` values, with enhanced IDE support and field validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unhead/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->