### PR TITLE
fix(server): re-expose `omitLineBreaks` render option

### DIFF
--- a/docs/head/1.guides/plugins/minify.md
+++ b/docs/head/1.guides/plugins/minify.md
@@ -52,7 +52,26 @@ export interface MinifyPluginOptions {
    * @default true
    */
   json?: boolean
+  /**
+   * Omit the line breaks between rendered tags, producing a single line of output.
+   * Only removes the separators between tags; newlines inside inline content are
+   * left to the minifiers above.
+   * @default false
+   */
+  omitLineBreaks?: boolean
 }
+```
+::
+
+### Omit Line Breaks
+
+By default tags render one per line. Set `omitLineBreaks` to render them on a single line. This only drops the separators between tags, so newlines inside inline `<script>`/`<style>`/JSON-LD content are preserved (the minifiers handle those):
+
+::code-block
+```ts [Input]
+MinifyPlugin({
+  omitLineBreaks: true,
+})
 ```
 ::
 

--- a/docs/head/7.api/hooks/13.ssr-render.md
+++ b/docs/head/7.api/hooks/13.ssr-render.md
@@ -21,25 +21,7 @@ export interface Hook {
 |------|------|-------------|
 | `ctx` | Object | Context object with rendering information |
 | `ctx.tags` | `HeadTag[]` | Array of finalized head tags being rendered |
-| `ctx.options` | `RenderSSRHeadOptions` | Per-render options passed to the renderer. Mutating these changes how the tags are serialized, for example setting `omitLineBreaks` to drop the separators between tags. |
-
-### Controlling render output
-
-`ctx.options` is a fresh copy for each render, so plugins can override render behaviour without leaking into later renders. For example, omit the line breaks between tags:
-
-```ts
-import { defineHeadPlugin } from '@unhead/dynamic-import'
-
-export const omitLineBreaksPlugin = defineHeadPlugin({
-  hooks: {
-    'ssr:render': (ctx) => {
-      ctx.options.omitLineBreaks = true
-    }
-  }
-})
-```
-
-This is how `MinifyPlugin({ omitLineBreaks: true })` works: it only changes the separators between tags, leaving newlines inside inline `<script>`/`<style>`/JSON-LD content untouched.
+| `ctx.options` | `RenderSSRHeadOptions` | Per-render options passed to the renderer. A fresh copy each render, so mutating it changes how tags are serialized for that render only. To omit line breaks between tags, use [`MinifyPlugin`](/docs/head/guides/plugins/minify) rather than setting this directly. |
 
 ### Returns
 

--- a/docs/head/7.api/hooks/13.ssr-render.md
+++ b/docs/head/7.api/hooks/13.ssr-render.md
@@ -5,13 +5,13 @@ navigation:
   title: "ssr:render"
 ---
 
-The `ssr:render` hook is called during the server-side rendering process after tags have been resolved but before they're converted to HTML strings. This hook provides access to the finalized tags and allows for last-minute modifications specific to server-side rendering.
+The `ssr:render` hook is called during the server-side rendering process after tags have been resolved but before they're converted to HTML strings. This hook provides access to the finalized tags and the render options, allowing for last-minute modifications specific to server-side rendering.
 
 ## Hook Signature
 
 ```ts
 export interface Hook {
-  'ssr:render': (ctx: { tags: HeadTag[] }) => SyncHookResult
+  'ssr:render': (ctx: { tags: HeadTag[], options: RenderSSRHeadOptions }) => SyncHookResult
 }
 ```
 
@@ -21,6 +21,25 @@ export interface Hook {
 |------|------|-------------|
 | `ctx` | Object | Context object with rendering information |
 | `ctx.tags` | `HeadTag[]` | Array of finalized head tags being rendered |
+| `ctx.options` | `RenderSSRHeadOptions` | Per-render options passed to the renderer. Mutating these changes how the tags are serialized, for example setting `omitLineBreaks` to drop the separators between tags. |
+
+### Controlling render output
+
+`ctx.options` is a fresh copy for each render, so plugins can override render behaviour without leaking into later renders. For example, omit the line breaks between tags:
+
+```ts
+import { defineHeadPlugin } from '@unhead/dynamic-import'
+
+export const omitLineBreaksPlugin = defineHeadPlugin({
+  hooks: {
+    'ssr:render': (ctx) => {
+      ctx.options.omitLineBreaks = true
+    }
+  }
+})
+```
+
+This is how `MinifyPlugin({ omitLineBreaks: true })` works: it only changes the separators between tags, leaving newlines inside inline `<script>`/`<style>`/JSON-LD content untouched.
 
 ### Returns
 

--- a/packages/unhead/src/plugins/minify.ts
+++ b/packages/unhead/src/plugins/minify.ts
@@ -19,6 +19,15 @@ export interface MinifyPluginOptions {
    * @default true
    */
   json?: boolean
+  /**
+   * Omit line breaks between rendered tags, producing a single line of output.
+   *
+   * Applied surgically by the renderer (separators only); newlines inside
+   * inline content are still handled by the minifiers above, so this is safe.
+   *
+   * @default false
+   */
+  omitLineBreaks?: boolean
 }
 
 const JSON_TYPES = new Set(['application/json', 'application/ld+json'])
@@ -45,11 +54,14 @@ export function MinifyPlugin(options?: MinifyPluginOptions): HeadPluginInput {
   const jsMinify = options?.js === false ? false : (options?.js || minifyJS)
   const cssMinify = options?.css === false ? false : (options?.css || minifyCSS)
   const jsonMinify = options?.json !== false
+  const omitLineBreaks = options?.omitLineBreaks === true
   return {
     key: 'minify',
     hooks: {
-      'ssr:render': ({ tags }) => {
-        for (const tag of tags) {
+      'ssr:render': (ctx) => {
+        if (omitLineBreaks)
+          ctx.options.omitLineBreaks = true
+        for (const tag of ctx.tags) {
           const content = tag.innerHTML
           if (!content || content.length < 20)
             continue

--- a/packages/unhead/src/server/createHead.ts
+++ b/packages/unhead/src/server/createHead.ts
@@ -12,7 +12,7 @@ export interface ServerUnhead<T = ResolvableHead> extends Unhead<T, SSRHeadPaylo
 /* @__NO_SIDE_EFFECTS__ */
 export function createHead<T = ResolvableHead>(options: CreateServerHeadOptions = {}): ServerUnhead<T> {
   const tagWeight = options.tagWeight || capoTagWeight
-  const render = createServerRenderer({ tagWeight })
+  const render = createServerRenderer({ tagWeight, omitLineBreaks: options.omitLineBreaks })
   const core = createUnhead<T, SSRHeadPayload>(render, {
     _tagWeight: tagWeight,
     // @ts-expect-error untyped

--- a/packages/unhead/src/server/renderSSRHead.ts
+++ b/packages/unhead/src/server/renderSSRHead.ts
@@ -11,9 +11,14 @@ export function createServerRenderer(options: RenderSSRHeadOptions = {}): HeadRe
     callHook(head, 'ssr:beforeRender', beforeRenderCtx)
     if (!beforeRenderCtx.shouldRender)
       return ssrRenderTags([])
-    const ctx = { tags: options.resolvedTags || resolveTags(head, { tagWeight: options.tagWeight ?? capoTagWeight }) }
+    // Fresh per-render options so plugins (e.g. MinifyPlugin) can override
+    // render behaviour like `omitLineBreaks` without leaking into the closure.
+    const ctx = {
+      tags: options.resolvedTags || resolveTags(head, { tagWeight: options.tagWeight ?? capoTagWeight }),
+      options: { ...options },
+    }
     callHook(head, 'ssr:render', ctx)
-    const html: SSRHeadPayload = ssrRenderTags(ctx.tags, options)
+    const html: SSRHeadPayload = ssrRenderTags(ctx.tags, ctx.options)
     const renderCtx: SSRRenderContext = { tags: ctx.tags, html }
     callHook(head, 'ssr:rendered', renderCtx)
     return renderCtx.html

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -155,6 +155,17 @@ export interface CreateServerHeadOptions extends CreateHeadOptions {
    * - <meta name="viewport" content="width=device-width, initial-scale=1">
    */
   disableDefaults?: boolean
+  /**
+   * Omit line breaks between rendered tags, producing a single line of output.
+   *
+   * Only removes the separators *between* tags; newlines inside inline
+   * `<script>`/`<style>`/JSON-LD content are preserved.
+   *
+   * @deprecated Prefer `MinifyPlugin` from `unhead/plugins`, which minifies the
+   * inline content itself (where the real bytes are) rather than only dropping
+   * separators.
+   */
+  omitLineBreaks?: boolean
 }
 
 export interface CreateStreamableServerHeadOptions extends Omit<CreateServerHeadOptions, 'experimentalStreamKey'> {

--- a/packages/unhead/src/types/hooks.ts
+++ b/packages/unhead/src/types/hooks.ts
@@ -55,7 +55,7 @@ export interface DOMHeadHooks {
 
 export interface SSRHeadHooks {
   'ssr:beforeRender': (ctx: ShouldRenderContext) => HookResult
-  'ssr:render': (ctx: { tags: HeadTag[] }) => HookResult
+  'ssr:render': (ctx: { tags: HeadTag[], options: RenderSSRHeadOptions }) => HookResult
   'ssr:rendered': (ctx: SSRRenderContext) => HookResult
 }
 

--- a/packages/unhead/test/unit/plugins/minify.test.ts
+++ b/packages/unhead/test/unit/plugins/minify.test.ts
@@ -178,4 +178,29 @@ describe('minifyPlugin', () => {
     const { headTags } = head.render()
     expect(headTags).toContain('function a(){return 1}a();void 0')
   })
+
+  it('omitLineBreaks drops inter-tag separators surgically', () => {
+    const head = createServerHeadWithContext({
+      plugins: [MinifyPlugin({ omitLineBreaks: true })],
+    })
+    head.push({
+      script: [
+        { innerHTML: 'const a = 1;\nconst b = 2;' },
+        // content minify never touches: its internal newlines must survive,
+        // proving this is a renderer-level join change and not a blanket strip
+        { type: 'speculationrules', innerHTML: '{\n  "prerender": []\n}' },
+        { type: 'importmap', innerHTML: '{\n  "imports": {}\n}' },
+        { innerHTML: 'a =\n1' }, // under the 20-char minify threshold
+      ],
+      meta: [{ name: 'a', content: '1' }],
+    })
+
+    const { headTags } = head.render()
+    // no separators between tags
+    expect(headTags).not.toContain('>\n<')
+    // un-minified content keeps its internal newlines
+    expect(headTags).toContain('{\n  "prerender": []\n}')
+    expect(headTags).toContain('{\n  "imports": {}\n}')
+    expect(headTags).toContain('a =\n1')
+  })
 })

--- a/packages/unhead/test/unit/server/ssr.test.ts
+++ b/packages/unhead/test/unit/server/ssr.test.ts
@@ -131,6 +131,27 @@ describe('ssr', () => {
   `)
   })
 
+  it('omitLineBreaks via createHead option applies to head.render()', () => {
+    const head = createServerHeadWithContext({ omitLineBreaks: true })
+
+    head.push({
+      script: [
+        { src: 'https://cdn.example.com/script-1.js' },
+        { src: 'https://cdn.example.com/script-2.js' },
+      ],
+    })
+
+    expect(head.render()).toMatchInlineSnapshot(`
+    {
+      "bodyAttrs": "",
+      "bodyTags": "",
+      "bodyTagsOpen": "",
+      "headTags": "<script src="https://cdn.example.com/script-1.js"></script><script src="https://cdn.example.com/script-2.js"></script>",
+      "htmlAttrs": "",
+    }
+  `)
+  })
+
   it('multiword attributes in html template', async () => {
     const head = createServerHeadWithContext()
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #766

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`renderSSRHead(head, { omitLineBreaks })` is deprecated in favour of `head.render()`, but `head.render()` took no arguments and `createHead` only forwarded `tagWeight` to the renderer, so `omitLineBreaks` could not be applied. The only non-deprecated path was post-processing with `replaceAll('\n', '')`, which also strips newlines inside inline `<script>`/`<style>`/JSON-LD content.

This forwards the render options into the renderer so `head.render()` honours them:

- `createHead({ omitLineBreaks })` (deprecated, JSDoc points to `MinifyPlugin`) wires the option through `createServerRenderer` into `ssrRenderTags`.
- The `ssr:render` hook ctx now exposes a per-render `options` object, so plugins can flip render behaviour before the join happens.
- `MinifyPlugin({ omitLineBreaks })` uses that hook to drop separators surgically. Because it sets the renderer flag rather than stripping the string, skip-types (`importmap`, `speculationrules`), sub-20-char scripts, and `js: false` content keep their internal newlines.

Tests cover the `createHead` path and the `MinifyPlugin` path including the previously fragile skip cases. `MinifyPlugin` minifies the inline content where the real bytes are; `omitLineBreaks` only removes separators, so they compose rather than replace each other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an omitLineBreaks option to produce more compact head output by removing separators between tags while preserving newlines inside inline scripts, styles, and JSON-LD.

* **Breaking Changes**
  * The SSR render hook now receives per-render options alongside tags; hook payload shape changed and can affect rendered output.

* **Documentation**
  * Updated SSR-render hook and minify plugin docs with new option and guidance.

* **Tests**
  * Added tests covering omitLineBreaks behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->