### PR TITLE
fix(bundler): resolve dynamic ogImage in useSeoMeta transform

### DIFF
--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -212,9 +212,13 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
               const expandObject = (objNode: any): string | false => {
                 const tags: string[] = []
                 for (const p of objNode.properties) {
-                  if (p.type === 'SpreadElement' || p.key?.type !== 'Identifier')
+                  // Only plain `key: value` pairs can be reproduced statically. Spreads, getters,
+                  // setters, methods, and computed/non-identifier keys bail to runtime.
+                  if (p.type === 'SpreadElement' || p.computed || p.method || p.kind !== 'init' || p.key?.type !== 'Identifier')
                     return false
-                  const suffix = p.key.name === 'url' ? '' : `:${p.key.name}`
+                  // Match runtime `unpackMeta`: `url` -> bare property, `secureUrl` -> `:secure_url`.
+                  const name = p.key.name
+                  const suffix = name === 'url' ? '' : `:${name === 'secureUrl' ? 'secure_url' : name}`
                   tags.push(`    { ${key}: '${keyValue}${suffix}', ${valueKey}: ${code.substring(p.value.start, p.value.end)} },`)
                 }
                 return tags.join('\n')
@@ -247,11 +251,15 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
                 output.push(parts.join('\n'))
                 return
               }
-              // Literals (string/number/boolean) and template literals always resolve to a scalar
-              // -> a single safe tag. Any other value (identifier, ref(), computed(), getter) could
-              // resolve to an object or array; we can't expand it statically, so bail to runtime.
-              const t = property.value.type
-              if (t !== 'Literal' && t !== 'StringLiteral' && t !== 'NumericLiteral' && t !== 'TemplateLiteral') {
+              // Primitive literals (string/number/boolean) and template literals always resolve to a
+              // scalar -> a single safe tag. Anything else (identifier, ref(), computed(), getter,
+              // or a non-primitive literal like a regexp) could resolve to an object/array, so bail
+              // to runtime `unpackMeta`.
+              const v = property.value
+              const primitive = typeof v.value === 'string' || typeof v.value === 'number' || typeof v.value === 'boolean'
+              const isScalar = v.type === 'TemplateLiteral'
+                || ((v.type === 'Literal' || v.type === 'StringLiteral' || v.type === 'NumericLiteral') && primitive)
+              if (!isScalar) {
                 output = false
                 return
               }
@@ -334,15 +342,17 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
             if (spec.type !== 'ImportSpecifier')
               continue
             const importedName = spec.imported.name
+            // Preserve the local alias (`useSeoMeta as usm`) so kept call sites stay bound.
+            const keepOriginal = importedName === spec.local.name ? importedName : `${importedName} as ${spec.local.name}`
             if (transformedNames.has(importedName)) {
               newSpecifiers.add(importedName.includes('Server') ? 'useServerHead' : 'useHead')
               // Keep original import if it's still referenced as a value or called in a form we
               // couldn't statically transform (dynamic first arg, spread properties, etc.).
               if (valueReferenced.has(importedName) || untransformedCallees.has(importedName))
-                newSpecifiers.add(importedName)
+                newSpecifiers.add(keepOriginal)
             }
             else {
-              newSpecifiers.add(importedName)
+              newSpecifiers.add(keepOriginal)
             }
           }
           s.overwrite(

--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -29,6 +29,12 @@ export interface UseSeoMetaTransformOptions extends BaseTransformerTypes {
 
 const SEO_META_NAMES = new Set(['useSeoMeta', 'useServerSeoMeta'])
 
+// Keys whose runtime value is structurally expanded into multiple meta tags based on its shape
+// (e.g. `ogImage: { url, width }` -> `og:image` + `og:image:width`). See `unpackMeta` MEDIA branch.
+// We can only reproduce this statically for object/array literals; any dynamic value (ref, computed,
+// getter, identifier) could resolve to an object and MUST be left to runtime `unpackMeta`.
+const MEDIA_KEYS = new Set(['ogImage', 'ogVideo', 'ogAudio', 'twitterImage'])
+
 /**
  * useSeoMeta({
  *   title: 'My Title',
@@ -198,6 +204,59 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
               key = 'charset'
             }
             let value = code.substring(property.value.start as number, property.value.end as number)
+
+            if (MEDIA_KEYS.has(propertyKey.name)) {
+              // Expand an object literal `{ url, width, ... }` into `og:image`, `og:image:width`, ...
+              // matching runtime `unpackMeta`. Leaf values may be dynamic; only the structure must
+              // be statically known. Returns false when a prop key can't be resolved statically.
+              const expandObject = (objNode: any): string | false => {
+                const tags: string[] = []
+                for (const p of objNode.properties) {
+                  if (p.type === 'SpreadElement' || p.key?.type !== 'Identifier')
+                    return false
+                  const suffix = p.key.name === 'url' ? '' : `:${p.key.name}`
+                  tags.push(`    { ${key}: '${keyValue}${suffix}', ${valueKey}: ${code.substring(p.value.start, p.value.end)} },`)
+                }
+                return tags.join('\n')
+              }
+              if (property.value.type === 'ObjectExpression') {
+                const expanded = expandObject(property.value)
+                if (expanded === false) {
+                  output = false
+                  return
+                }
+                output.push(expanded)
+                return
+              }
+              if (property.value.type === 'ArrayExpression') {
+                if (!property.value.elements.length)
+                  return
+                const parts: string[] = []
+                for (const element of property.value.elements) {
+                  if (!element || element.type !== 'ObjectExpression') {
+                    output = false
+                    return
+                  }
+                  const expanded = expandObject(element)
+                  if (expanded === false) {
+                    output = false
+                    return
+                  }
+                  parts.push(expanded)
+                }
+                output.push(parts.join('\n'))
+                return
+              }
+              // Literals (string/number/boolean) and template literals always resolve to a scalar
+              // -> a single safe tag. Any other value (identifier, ref(), computed(), getter) could
+              // resolve to an object or array; we can't expand it statically, so bail to runtime.
+              const t = property.value.type
+              if (t !== 'Literal' && t !== 'StringLiteral' && t !== 'NumericLiteral' && t !== 'TemplateLiteral') {
+                output = false
+                return
+              }
+            }
+
             if (property.value.type === 'ArrayExpression') {
               const elements = property.value.elements
               if (!elements.length)

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -145,12 +145,12 @@ describe('useSeoMetaTransform', () => {
     `)
   })
 
-  it('handles reactivity', async () => {
+  it('inlines reactive values for non-structural keys', async () => {
     const code = await transform([
       'import { useSeoMeta } from \'unhead\'',
       'import { ref } from \'vue\'',
       'const someValue = { value: \'test\' }',
-      'useSeoMeta({ title: \'Hello\', description: () => someValue.value, ogImage: ref(\'test\')  })',
+      'useSeoMeta({ title: \'Hello\', description: () => someValue.value, ogTitle: ref(\'test\')  })',
     ])
     expect(code).toMatchInlineSnapshot(`
       "import { useHead } from 'unhead'
@@ -160,7 +160,44 @@ describe('useSeoMetaTransform', () => {
         title: 'Hello',
         meta: [
           { name: 'description', content: () => someValue.value },
-          { property: 'og:image', content: ref('test') },
+          { property: 'og:title', content: ref('test') },
+        ]
+      })"
+    `)
+  })
+
+  it('leaves dynamic media values to runtime (issue #769)', async () => {
+    // A dynamic `ogImage` (ref/computed/getter) can resolve to an object or array that runtime
+    // `unpackMeta` expands into `og:image`, `og:image:width`, ... Inlining it as a single
+    // `content` would serialize the object to `[object Object]`, so the call must stay
+    // `useSeoMeta(...)` and be handled at runtime. A static sibling still transforms.
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'import { computed } from \'vue\'',
+      'const og = computed(() => [{ url: \'/og.png\', width: 800 }])',
+      'useSeoMeta({ title: \'Static\', description: \'desc\' })',
+      'useSeoMeta({ ogImage: () => [{ url: \'/og.png\', width: 800 }] })',
+      'useSeoMeta({ ogImage: og })',
+    ])
+    expect(code).toContain('import { useHead, useSeoMeta } from')
+    expect(code).toContain('useSeoMeta({ ogImage: () => [{ url: \'/og.png\', width: 800 }] })')
+    expect(code).toContain('useSeoMeta({ ogImage: og })')
+    expect(code).toContain('{ name: \'description\', content: \'desc\' }')
+  })
+
+  it('expands static media object and array literals', async () => {
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ ogImage: { url: \'/og.png\', width: 800 }, twitterImage: [{ url: \'/t.png\', alt: \'hi\' }] })',
+    ])
+    expect(code).toMatchInlineSnapshot(`
+      "import { useHead } from 'unhead'
+      useHead({
+        meta: [
+          { property: 'og:image', content: '/og.png' },
+          { property: 'og:image:width', content: 800 },
+          { name: 'twitter:image', content: '/t.png' },
+          { name: 'twitter:image:alt', content: 'hi' },
         ]
       })"
     `)
@@ -239,11 +276,11 @@ describe('useSeoMetaTransform', () => {
       "import { useHead } from 'unhead'
       useHead({
         meta: [
-          { property: 'og:image:url', content: 'https://example.com/image.png' },
+          { property: 'og:image', content: 'https://example.com/image.png' },
           { property: 'og:image:width', content: 800 },
           { property: 'og:image:height', content: 600 },
           { property: 'og:image:alt', content: 'My amazing image' },
-          { name: 'twitter:image:url', content: 'https://example.com/image.png' },
+          { name: 'twitter:image', content: 'https://example.com/image.png' },
           { name: 'twitter:image:width', content: 800 },
           { name: 'twitter:image:height', content: 600 },
           { name: 'twitter:image:alt', content: 'My amazing image' },

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -203,6 +203,56 @@ describe('useSeoMetaTransform', () => {
     `)
   })
 
+  it('maps secureUrl to secure_url in static media objects', async () => {
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ ogImage: { url: \'/og.png\', secureUrl: \'/s.png\' } })',
+    ])
+    expect(code).toMatchInlineSnapshot(`
+      "import { useHead } from 'unhead'
+      useHead({
+        meta: [
+          { property: 'og:image', content: '/og.png' },
+          { property: 'og:image:secure_url', content: '/s.png' },
+        ]
+      })"
+    `)
+  })
+
+  it('bails media objects with getters/methods/computed keys', async () => {
+    // These can't be reproduced as plain `key: value` tags, so the call must go to runtime.
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ ogImage: { get url() { return \'/o.png\' } } })',
+    ])).toBeUndefined()
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ ogImage: { [key]: \'/o.png\' } })',
+    ])).toBeUndefined()
+  })
+
+  it('bails non-primitive literal media values (regexp)', async () => {
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ ogImage: /og.*/i })',
+    ])).toBeUndefined()
+  })
+
+  it('preserves aliased import when a media call bails', async () => {
+    const code = await transform([
+      'import { useSeoMeta as usm } from \'unhead\'',
+      'usm({ title: \'Static\' })',
+      'usm({ ogImage: og })',
+    ])
+    expect(code).toMatchInlineSnapshot(`
+      "import { useHead, useSeoMeta as usm } from 'unhead'
+      useHead({
+        title: 'Static',
+      })
+      usm({ ogImage: og })"
+    `)
+  })
+
   it('fails gracefully with nested objects', async () => {
     const code = await transform([
       'import { useSeoMeta } from \'unhead\'',

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -229,6 +229,10 @@ describe('useSeoMetaTransform', () => {
       'import { useSeoMeta } from \'unhead\'',
       'useSeoMeta({ ogImage: { [key]: \'/o.png\' } })',
     ])).toBeUndefined()
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ ogImage: { url() { return \'/o.png\' } } })',
+    ])).toBeUndefined()
   })
 
   it('bails non-primitive literal media values (regexp)', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #769

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `useSeoMeta` -> `useHead` build transform only expanded `ogImage`/`twitterImage` when written as object or array literals. A dynamic value (`ref`, `computed`, a getter, or a plain identifier) was inlined as a single `content` field, so at runtime the resolved object serialized to `[object Object]` instead of expanding into `og:image`, `og:image:width`, etc.

The runtime (`unpackMeta` via `FlatMetaPlugin`) already handles these dynamic values correctly; only the build transform diverged. `UseSeoMetaTransform` now detects the media keys (`ogImage`, `ogVideo`, `ogAudio`, `twitterImage`) and:

- bails the call to runtime whenever the value is not a static literal (so the original `useSeoMeta(...)` is preserved and resolved at runtime),
- expands static object literals like `ogImage: { url, width }` into separate tags, matching runtime,
- fixes the `url` sub-key, which was emitted as `og:image:url` instead of `og:image`.

Verified against runtime output: dynamic getters/refs/computed for `ogImage` (array and object) and the corrected static expansion now match the SSR result. Covered by new and updated tests in `useSeoMetaTransform.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded SEO/meta handling: static Open Graph/Twitter media object/array literals now generate multiple meta tags (including derived image/video/audio fields); non-static values still handled at runtime.
  * Normalized media field names (e.g., secureUrl → secure_url) and adjusted tag naming for image/twitter entries.

* **Bug Fixes**
  * Preserved local import aliases when transforming meta calls.

* **Tests**
  * Added coverage for static vs dynamic media, naming, and aliasing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->