### PR TITLE
fix(scripts): resolve useScript load promise via microtask

### DIFF
--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -84,7 +84,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     // promise never resolves
     if (head.ssr)
       return
-    const emit = (api: T) => requestAnimationFrame(() => resolve(api))
+    // resolve on a microtask rather than requestAnimationFrame: rAF is suspended while the
+    // tab is hidden, which would defer onLoaded() callbacks indefinitely (unjs/unhead#771)
+    const emit = (api: T) => queueMicrotask(() => resolve(api))
     const unhook = head.hooks?.hook('script:updated', ({ script }: { script: ScriptInstance<T> }) => {
       // vue augmentation... not ideal
       const status = script.status

--- a/packages/unhead/test/unit/scripts/events.test.ts
+++ b/packages/unhead/test/unit/scripts/events.test.ts
@@ -17,6 +17,48 @@ describe('useScript events', () => {
       head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
     })).toBeTruthy()
   })
+  it('fires onLoaded when requestAnimationFrame is suspended (hidden tab) - #771', async () => {
+    // browsers suspend rAF callbacks entirely while a tab is hidden; stub it to a no-op
+    const originalRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = (() => 0) as any
+    try {
+      const head = createHead()
+      const instance = useScript(head, '/script.js', {
+        trigger: 'server',
+      })
+      await expect(new Promise<true>((resolve) => {
+        instance.onLoaded(() => {
+          resolve(true)
+        })
+        head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+      })).resolves.toBeTruthy()
+    }
+    finally {
+      globalThis.requestAnimationFrame = originalRaf
+    }
+  })
+  it('fires onLoaded registered after status=loaded when rAF is suspended (hidden tab) - #771', async () => {
+    // late registrations are also gated behind the load promise resolving, so they must
+    // not depend on requestAnimationFrame either
+    const originalRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = (() => 0) as any
+    try {
+      const head = createHead()
+      const instance = useScript(head, '/script.js', {
+        trigger: 'server',
+      })
+      head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+      // register after the load hook already fired
+      await expect(new Promise<true>((resolve) => {
+        instance.onLoaded(() => {
+          resolve(true)
+        })
+      })).resolves.toBeTruthy()
+    }
+    finally {
+      globalThis.requestAnimationFrame = originalRaf
+    }
+  })
   it('dedupe', async () => {
     const head = createHead()
     const instance = useScript(head, '/script.js', {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #771

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`useScript` resolved its internal load promise inside a `requestAnimationFrame` callback. Browsers suspend rAF entirely while a tab is hidden, so when a script finished loading in a background tab the script status flipped to `loaded` synchronously but the load promise never resolved. Queued `onLoaded()` callbacks never flushed, and callbacks registered after that point queued forever too, since `_cbs.loaded` is only nulled when the promise resolves. This surfaced in production via `@nuxtjs/turnstile` / `@nuxt/scripts`: the Turnstile widget silently failed to render in background tabs, headless contexts, and prerendered pages.

`useScript.ts` now resolves the promise with `queueMicrotask` instead of `requestAnimationFrame`. Microtasks are not visibility-throttled, and `use()` only reads globals the loaded script sets synchronously, so no paint wait is needed.

Added two regression tests in `events.test.ts` that stub `requestAnimationFrame` to a no-op (what the browser does in a hidden tab) and assert `onLoaded()` still fires, both for callbacks registered before and after `status` becomes `loaded`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Script loading callbacks now resolve consistently, even when the browser tab is hidden or backgrounded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->