### PR TITLE
fix(unhead): avoid crash on script template params with no type

### DIFF
--- a/packages/unhead/src/plugins/templateParams.ts
+++ b/packages/unhead/src/plugins/templateParams.ts
@@ -39,7 +39,7 @@ export const TemplateParamsPlugin = /* @__PURE__ */ defineHeadPlugin((head) => {
           else if (tag.processTemplateParams || tag.tag === 'titleTemplate' || tag.tag === 'title') {
             for (const p of contentAttrs) {
               if (typeof tag[p] === 'string')
-                tag[p] = processTemplateParams(tag[p], params, sep, tag.tag === 'script' && tag.props.type.endsWith('json'))
+                tag[p] = processTemplateParams(tag[p], params, sep, tag.tag === 'script' && typeof tag.props.type === 'string' && tag.props.type.endsWith('json'))
             }
           }
         }

--- a/packages/unhead/test/unit/server/templateParams.test.ts
+++ b/packages/unhead/test/unit/server/templateParams.test.ts
@@ -69,7 +69,8 @@ describe('ssr templateParams', () => {
     })
     const { headTags } = renderSSRHead(head)
 
-    expect(headTags).toContain('My Site')
+    expect(headTags).toContain('<script>console.log("My Site")</script>')
+    expect(headTags).not.toContain('%s')
   })
 
   it('does not affect other content', async () => {

--- a/packages/unhead/test/unit/server/templateParams.test.ts
+++ b/packages/unhead/test/unit/server/templateParams.test.ts
@@ -51,6 +51,27 @@ describe('ssr templateParams', () => {
     `)
   })
 
+  it('script with processTemplateParams and no type does not throw', async () => {
+    const head = createServerHeadWithContext({
+      plugins: [TemplateParamsPlugin],
+    })
+    head.push({
+      title: 'My Site',
+      script: [
+        {
+          innerHTML: 'console.log("%s")',
+          processTemplateParams: true,
+        },
+      ],
+      templateParams: {
+        s: 'My Site',
+      },
+    })
+    const { headTags } = renderSSRHead(head)
+
+    expect(headTags).toContain('My Site')
+  })
+
   it('does not affect other content', async () => {
     const head = createServerHeadWithContext({
       plugins: [TemplateParamsPlugin],


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue. Found during a security sweep of `packages/unhead/src`.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

In `TemplateParamsPlugin`, a `<script>` tag with `processTemplateParams: true` but no `type` prop threw `TypeError: Cannot read properties of undefined (reading 'endsWith')` from `tag.props.type.endsWith('json')`, which aborted the whole `tags:resolve` pass instead of just that tag.

Guarded the `type` access with `typeof tag.props.type === 'string'` before calling `.endsWith`. A script without a JSON type now falls back to non-JSON substitution. Added a server test that reproduces the crash, and (per CodeRabbit) it asserts the substituted `<script>console.log("My Site")</script>` payload directly and that no `%s` placeholder remains, so it can't pass off the `<title>` tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template parameter processing for JSON-type script elements during server-side rendering so placeholders are correctly replaced in JSON-script content.
* **Tests**
  * Added a unit test ensuring template parameter replacement does not throw for script entries that request processing but lack a type, improving SSR reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->