### PR TITLE
fix(unhead): parse HTML attribute values without backslash escaping

### DIFF
--- a/packages/unhead/src/parser/index.ts
+++ b/packages/unhead/src/parser/index.ts
@@ -195,10 +195,10 @@ export function parseAttributes(attrStr: string): Record<string, string> {
         break
 
       case QUOTED_VALUE:
-        if (charCode === BACKSLASH_CHAR && i + 1 < len) {
-          i++
-        }
-        else if (charCode === quoteChar) {
+        // HTML attribute values have no backslash escaping; the quote char
+        // always terminates the value (matches browser parsing and the
+        // tag-boundary scanner above).
+        if (charCode === quoteChar) {
           result[name] = attrStr.substring(valueStart, i)
           state = WHITESPACE
         }

--- a/packages/unhead/test/unit/parser/parseAttributes.test.ts
+++ b/packages/unhead/test/unit/parser/parseAttributes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { parseAttributes } from '../../../src/parser'
+
+describe('parseAttributes', () => {
+  it('treats backslash as a literal char in quoted values', () => {
+    // HTML has no backslash escaping in attribute values, so a trailing
+    // backslash must not consume the closing quote.
+    expect(parseAttributes('href="C:\\"')).toEqual({ href: 'C:\\' })
+  })
+
+  it('does not let a backslash swallow the closing quote of an attribute', () => {
+    expect(parseAttributes('content="a\\" name="description"')).toEqual({
+      content: 'a\\',
+      name: 'description',
+    })
+  })
+
+  it('parses basic quoted and unquoted attributes', () => {
+    expect(parseAttributes('name="description" content=hello disabled')).toEqual({
+      name: 'description',
+      content: 'hello',
+      disabled: '',
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue. Found during a security sweep of `packages/unhead/src`.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`parseAttributes` (used by `transformHtmlTemplate`) treated `\` as an escape character inside quoted attribute values. HTML has no backslash escaping there, so a trailing backslash swallowed the closing quote and diverged from both the browser and the tag-boundary scanner in the same file:

- `href="C:\"` parsed `href` as `C:\"` (browser: `C:\`)
- `content="a\" name="description"` parsed `content` as `a\" name=` plus a junk attribute (browser: `content` = `a\`, `name` = `description`)

Output is re-escaped on render, so this is a parsing-correctness issue, not an injection. Dropped the backslash branch in the `QUOTED_VALUE` state so the quote char always terminates the value. `BACKSLASH_CHAR` is still used by `findClosingTag` for quote-aware script/style scanning. Added `test/unit/parser/parseAttributes.test.ts` covering the trailing-backslash cases plus basic quoted, unquoted, and boolean attributes.