### PR TITLE
perf(unhead): skip defensive tag clones when no mutating hooks registered

### DIFF
--- a/packages/unhead/package.json
+++ b/packages/unhead/package.json
@@ -142,28 +142,6 @@
       ]
     }
   },
-  "optionalPlugins": {
-    "*": {
-      "plugins": [
-        "dist/plugins"
-      ],
-      "server": [
-        "dist/server"
-      ],
-      "client": [
-        "dist/client"
-      ],
-      "types": [
-        "dist/types"
-      ],
-      "utils": [
-        "dist/utils"
-      ],
-      "scripts": [
-        "dist/scripts"
-      ]
-    }
-  },
   "files": [
     "*.d.ts",
     "dist"

--- a/packages/unhead/src/client/createHead.ts
+++ b/packages/unhead/src/client/createHead.ts
@@ -1,11 +1,11 @@
 import type { HookableCore } from 'hookable'
 import type { ClientHeadHooks, CreateClientHeadOptions, HeadEntryOptions, HeadRenderer, HeadTag, ResolvableHead, Unhead } from '../types'
 import { createUnhead, registerPlugin } from '../unhead'
+import { TagPriorityAliases } from '../utils/const'
 import { createHooks } from '../utils/hooks'
 import { createDomRenderer } from './renderDOMHead'
 
-const P: Record<string, number> = { critical: -8, high: -1, low: 2 }
-const tagWeight = (tag: HeadTag) => typeof tag.tagPriority === 'number' ? tag.tagPriority : 100 + (P[tag.tagPriority as string] || 0)
+const tagWeight = (tag: HeadTag) => typeof tag.tagPriority === 'number' ? tag.tagPriority : 100 + ((TagPriorityAliases as Record<string, number>)[tag.tagPriority as string] || 0)
 
 export interface ClientUnhead<T = ResolvableHead> extends Unhead<T, boolean> {
   hooks: HookableCore<ClientHeadHooks>

--- a/packages/unhead/src/server/createHead.ts
+++ b/packages/unhead/src/server/createHead.ts
@@ -60,22 +60,26 @@ export function createHead<T = ResolvableHead>(options: CreateServerHeadOptions 
   options.plugins?.forEach(p => registerPlugin(head, p))
 
   head._ssrPayload = {}
+  const payloadHook = (ctx: { tags: any[] }) => {
+    let payload: ResolvableHead = {}
+    if (Object.keys(head._ssrPayload || {}).length > 0) {
+      payload = { ...head._ssrPayload }
+    }
+    if (Object.values(payload).some(Boolean)) {
+      ctx.tags.push({
+        tag: 'script',
+        innerHTML: JSON.stringify(payload),
+        props: { id: 'unhead:payload', type: 'application/json' },
+      })
+    }
+  }
+  // only appends a fresh tag, never mutates resolved tags, so it must not
+  // force the defensive clone in resolveTags
+  payloadHook._nonMutating = true
   registerPlugin(head, {
     key: 'server',
     hooks: {
-      'tags:resolve': function (ctx) {
-        let payload: ResolvableHead = {}
-        if (Object.keys(head._ssrPayload || {}).length > 0) {
-          payload = { ...head._ssrPayload }
-        }
-        if (Object.values(payload).some(Boolean)) {
-          ctx.tags.push({
-            tag: 'script',
-            innerHTML: JSON.stringify(payload),
-            props: { id: 'unhead:payload', type: 'application/json' },
-          })
-        }
-      },
+      'tags:resolve': payloadHook,
     },
   })
   return head

--- a/packages/unhead/src/server/index.ts
+++ b/packages/unhead/src/server/index.ts
@@ -1,15 +1,7 @@
-import type { RenderSSRHeadOptions, SSRHeadPayload, Unhead } from '../types'
-import { renderSSRHead as _renderSSRHead } from './renderSSRHead'
-
 export type { CreateServerHeadOptions, SSRHeadPayload, Unhead } from '../types'
 export { createHead } from './createHead'
 export type { ServerUnhead } from './createHead'
-export { createServerRenderer } from './renderSSRHead'
+export { createServerRenderer, renderSSRHead } from './renderSSRHead'
 export { capoTagWeight } from './sort'
 export { transformHtmlTemplate, transformHtmlTemplateRaw } from './transformHtmlTemplate'
 export { escapeHtml, propsToString, ssrRenderTags, tagToString } from './util'
-
-/** @deprecated Use `head.render()` instead */
-export function renderSSRHead(head: Unhead<any>, options?: RenderSSRHeadOptions): SSRHeadPayload {
-  return _renderSSRHead(head, options)
-}

--- a/packages/unhead/src/server/sort.ts
+++ b/packages/unhead/src/server/sort.ts
@@ -3,12 +3,7 @@ import { TagPriorityAliases } from '../utils/const'
 
 // Capo.js tag weights for optimal head ordering
 const TAG_WEIGHTS = { base: -10, title: 10 } as const
-const CAPO_WEIGHTS = {
-  meta: { 'content-security-policy': -30, 'charset': -20, 'viewport': -15 },
-  link: { 'preconnect': 20, 'stylesheet': 60, 'preload': 70, 'modulepreload': 70, 'prefetch': 90, 'dns-prefetch': 90, 'prerender': 90 },
-  script: { importmap: 25, async: 30, defer: 80, sync: 50, speculationrules: 90 },
-  style: { imported: 40, sync: 60 },
-} as const
+const LINK_WEIGHTS = { 'preconnect': 20, 'stylesheet': 60, 'preload': 70, 'modulepreload': 70, 'prefetch': 90, 'dns-prefetch': 90, 'prerender': 90 } as const
 const ImportStyleRe = /@import/
 const isTruthy = (v?: string | boolean) => v === '' || v === true
 
@@ -21,32 +16,32 @@ export function capoTagWeight(tag: HeadTag): number {
     weight = TAG_WEIGHTS[tag.tag as keyof typeof TAG_WEIGHTS]
   }
   else if (tag.tag === 'meta') {
-    const t = tag.props['http-equiv'] === 'content-security-policy' ? 'content-security-policy' : tag.props.charset ? 'charset' : tag.props.name === 'viewport' ? 'viewport' : null
-    if (t)
-      weight = CAPO_WEIGHTS.meta[t as keyof typeof CAPO_WEIGHTS.meta]
+    weight = tag.props['http-equiv'] === 'content-security-policy' ? -30 : tag.props.charset ? -20 : tag.props.name === 'viewport' ? -15 : weight
   }
   else if (tag.tag === 'link' && tag.props.rel) {
-    weight = CAPO_WEIGHTS.link[tag.props.rel as keyof typeof CAPO_WEIGHTS.link]
+    weight = LINK_WEIGHTS[tag.props.rel as keyof typeof LINK_WEIGHTS]
   }
   else if (tag.tag === 'script') {
     const type = String(tag.props.type)
+    const json = type.endsWith('json')
     if (type === 'importmap')
       // parse-time directive, not a loadable resource: placed between
       // preconnect (20) and async scripts (30) so it precedes every module
       // script (including `<script type="module" async>`) per HTML spec
-      weight = CAPO_WEIGHTS.script.importmap
+      weight = 25
     else if (type === 'speculationrules')
       // performance hint, belongs late in head alongside prefetch/prerender
-      weight = CAPO_WEIGHTS.script.speculationrules
+      weight = 90
     else if (isTruthy(tag.props.async))
-      weight = CAPO_WEIGHTS.script.async
-    else if ((tag.props.src && !isTruthy(tag.props.defer) && !isTruthy(tag.props.async) && type !== 'module' && !type.endsWith('json')) || ((tag.innerHTML || tag.textContent) && !type.endsWith('json')))
-      weight = CAPO_WEIGHTS.script.sync
-    else if ((isTruthy(tag.props.defer) && tag.props.src && !isTruthy(tag.props.async)) || type === 'module')
-      weight = CAPO_WEIGHTS.script.defer
+      weight = 30
+    // async is falsy past this point
+    else if ((tag.props.src && !isTruthy(tag.props.defer) && type !== 'module' && !json) || ((tag.innerHTML || tag.textContent) && !json))
+      weight = 50
+    else if ((isTruthy(tag.props.defer) && tag.props.src) || type === 'module')
+      weight = 80
   }
   else if (tag.tag === 'style') {
-    weight = tag.innerHTML && ImportStyleRe.test(tag.innerHTML) ? CAPO_WEIGHTS.style.imported : CAPO_WEIGHTS.style.sync
+    weight = tag.innerHTML && ImportStyleRe.test(tag.innerHTML) ? 40 : 60
   }
   return (weight || 100) + offset
 }

--- a/packages/unhead/src/server/util/propsToString.ts
+++ b/packages/unhead/src/server/util/propsToString.ts
@@ -2,7 +2,8 @@ const DOUBLE_QUOTE_RE = /"/g
 
 /* @__PURE__ */
 function encodeAttribute(value: string) {
-  return String(value).replace(DOUBLE_QUOTE_RE, '&quot;')
+  const s = typeof value === 'string' ? value : String(value)
+  return s.includes('"') ? s.replace(DOUBLE_QUOTE_RE, '&quot;') : s
 }
 
 /* @__PURE__ */

--- a/packages/unhead/src/server/util/tagToString.ts
+++ b/packages/unhead/src/server/util/tagToString.ts
@@ -3,27 +3,12 @@ import { SelfClosingTags, TagsWithInnerContent } from '../../utils'
 import { propsToString } from './propsToString'
 
 const ESCAPE_HTML_RE = /[&<>"'/]/g
+const CLOSE_TAG_RE: Record<string, RegExp> = {}
+const ESCAPE_HTML_MAP: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', '\'': '&#x27;', '/': '&#x2F;' }
 
 /* @__PURE__ */
 export function escapeHtml(str: string) {
-  return str.replace(ESCAPE_HTML_RE, (char) => {
-    switch (char) {
-      case '&':
-        return '&amp;'
-      case '<':
-        return '&lt;'
-      case '>':
-        return '&gt;'
-      case '"':
-        return '&quot;'
-      case '\'':
-        return '&#x27;'
-      case '/':
-        return '&#x2F;'
-      default:
-        return char
-    }
-  })
+  return str.replace(ESCAPE_HTML_RE, c => ESCAPE_HTML_MAP[c])
 }
 
 /* @__PURE__ */
@@ -36,6 +21,6 @@ export function tagToString<T extends HeadTag>(tag: T) {
 
   // dangerously using innerHTML, we don't encode this
   let content = String(tag.textContent || tag.innerHTML || '')
-  content = tag.tag === 'title' ? escapeHtml(content) : content.replace(new RegExp(`<\/${tag.tag}`, 'gi'), `<\\/${tag.tag}`)
+  content = tag.tag === 'title' ? escapeHtml(content) : content.replace(CLOSE_TAG_RE[tag.tag] ||= new RegExp(`<\/${tag.tag}`, 'gi'), `<\\/${tag.tag}`)
   return SelfClosingTags.has(tag.tag) ? openTag : `${openTag}${content}</${tag.tag}>`
 }

--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -2,6 +2,7 @@ import type { HeadTag } from '../types'
 import { MetaTagsArrayable, TagsWithInnerContent, UniqueTags } from './const'
 
 const META_NOREWRITE_RE = /^(?:viewport|description|keywords|robots)$/
+const META_KEY_ATTRS = ['name', 'property', 'http-equiv'] as const
 
 export function isMetaArrayDupeKey(v: string) {
   return MetaTagsArrayable.has(v.split(':')[1])
@@ -23,7 +24,7 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
   if (props.charset)
     return 'charset'
   if (t === 'meta') {
-    for (const n of ['name', 'property', 'http-equiv']) {
+    for (const n of META_KEY_ATTRS) {
       const v = props[n]
       if (v !== undefined)
         return `meta:${v}${(typeof v !== 'string' || !v.includes(':')) && !META_NOREWRITE_RE.test(v) && key ? `:key:${key}` : ''}`

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -2,6 +2,14 @@ import type { HeadTag, PropResolver, ResolvableHead } from '../types'
 import { walkResolver } from '../utils/walkResolver'
 import { DupeableTags, HasElementTags, TagConfigKeys } from './const'
 
+// internal marker passed through normalizeTag/normalizeProps when input comes
+// straight from a head entry and still needs function/prop resolution
+interface ResolveCtx {
+  resolve?: PropResolver
+}
+
+const isUnsafeKey = (k: string) => k === '__proto__' || k === 'constructor' || k === 'prototype'
+
 function normalizeStyleClassProps(
   key: 'class' | 'style',
   value: any,
@@ -34,20 +42,22 @@ function normalizeStyleClassProps(
   return store
 }
 
-export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTag {
+export function normalizeProps(tag: HeadTag, input: Record<string, any>, _resolveCtx?: ResolveCtx): HeadTag {
   tag.props = tag.props || {}
   if (!input)
     return tag
   if (tag.tag === 'templateParams') {
-    tag.props = input
+    tag.props = _resolveCtx ? walkResolver(input, _resolveCtx.resolve) : input
     return tag
   }
   const isHtmlTag = HasElementTags.has(tag.tag) || tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs'
 
   for (const prop in input) {
-    if (prop === '__proto__' || prop === 'constructor' || prop === 'prototype')
+    if (isUnsafeKey(prop))
       continue
-    const value = input[prop]
+    let value = input[prop]
+    if (_resolveCtx)
+      value = walkResolver(value, _resolveCtx.resolve, prop)
     if (value === null) {
       tag.props[prop] = null as any
     }
@@ -56,9 +66,9 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
     }
     else if (TagConfigKeys.has(prop)) {
       if ((prop === 'textContent' || prop === 'innerHTML') && typeof value === 'object') {
-        const type = input.type || 'application/json'
+        const type = walkResolver(input.type, _resolveCtx?.resolve, 'type') || 'application/json'
         if (type.endsWith('json') || type === 'speculationrules' || type === 'importmap') {
-          tag.props.type = input.type = type
+          tag.props.type = type
           tag[prop] = JSON.stringify(value)
         }
       }
@@ -79,11 +89,13 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
   return tag
 }
 
-function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string): HeadTag | HeadTag[] {
-  const input = typeof _input === 'object' && typeof _input !== 'function'
-    ? _input
+function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string, resolveCtx?: ResolveCtx): HeadTag | HeadTag[] {
+  const isObjectInput = typeof _input === 'object'
+  const input = isObjectInput
+    ? _input as HeadTag['props']
     : { [(tagName === 'script' || tagName === 'noscript' || tagName === 'style') ? 'innerHTML' : 'textContent']: _input }
-  const tag = normalizeProps({ tag: tagName, props: {} }, input)
+  // wrapped scalars were already resolved at the entry level
+  const tag = normalizeProps({ tag: tagName, props: {} }, input, isObjectInput ? resolveCtx : undefined)
   if (tag.key && DupeableTags.has(tag.tag))
     tag.props['data-hid'] = tag._h = tag.key
   if (tag.tag === 'script' && typeof tag.innerHTML === 'object') {
@@ -96,19 +108,38 @@ function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string
 export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]): HeadTag[] {
   if (!input)
     return []
-  if (typeof input === 'function')
-    input = input()
-  const resolvers = (key?: string, val?: any) => {
-    for (const r of propResolvers)
-      val = r(key, val)
-    return val
+  const resolve: PropResolver | undefined = propResolvers.length === 0
+    ? undefined
+    : propResolvers.length === 1
+      ? propResolvers[0]
+      : (key, val, tag) => {
+          for (let i = 0; i < propResolvers.length; i++)
+            val = propResolvers[i](key, val, tag)
+          return val
+        }
+  // unwrap function values (except titleTemplate/on* keys) then apply prop resolvers,
+  // matching the old walkResolver per-node semantics
+  const unwrap = (v: any, key?: string) => {
+    if (typeof v === 'function' && (!key || (key !== 'titleTemplate' && !key.startsWith('on'))))
+      v = v()
+    return resolve ? resolve(key, v) : v
   }
-  input = walkResolver(resolvers(undefined, input), resolvers)
+  // two passes match the old pre-walk + root walkResolver calls
+  input = unwrap(unwrap(input))
+  const resolveCtx: ResolveCtx = { resolve }
   const tags: (HeadTag | HeadTag[])[] = []
   for (const key in input) {
-    const value = input[key]
-    if (value !== undefined) {
-      for (const v of (Array.isArray(value) ? value : [value])) tags.push(normalizeTag(key as keyof ResolvableHead, v))
+    if (isUnsafeKey(key))
+      continue
+    const isResolverKey = key === '_resolver'
+    const value = isResolverKey ? input[key] : unwrap(input[key], key)
+    if (value === undefined)
+      continue
+    const ctx = isResolverKey ? undefined : resolveCtx
+    const isArray = Array.isArray(value)
+    for (const v of isArray ? value : [value]) {
+      // array items are unwrapped and resolved without key context
+      tags.push(normalizeTag(key as keyof ResolvableHead, ctx && isArray ? unwrap(v) : v, ctx))
     }
   }
   return tags.flat()

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -2,14 +2,6 @@ import type { HeadTag, PropResolver, ResolvableHead } from '../types'
 import { walkResolver } from '../utils/walkResolver'
 import { DupeableTags, HasElementTags, TagConfigKeys } from './const'
 
-// internal marker passed through normalizeTag/normalizeProps when input comes
-// straight from a head entry and still needs function/prop resolution
-interface ResolveCtx {
-  resolve?: PropResolver
-}
-
-const isUnsafeKey = (k: string) => k === '__proto__' || k === 'constructor' || k === 'prototype'
-
 function normalizeStyleClassProps(
   key: 'class' | 'style',
   value: any,
@@ -42,22 +34,20 @@ function normalizeStyleClassProps(
   return store
 }
 
-export function normalizeProps(tag: HeadTag, input: Record<string, any>, _resolveCtx?: ResolveCtx): HeadTag {
+export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTag {
   tag.props = tag.props || {}
   if (!input)
     return tag
   if (tag.tag === 'templateParams') {
-    tag.props = _resolveCtx ? walkResolver(input, _resolveCtx.resolve) : input
+    tag.props = input
     return tag
   }
   const isHtmlTag = HasElementTags.has(tag.tag) || tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs'
 
   for (const prop in input) {
-    if (isUnsafeKey(prop))
+    if (prop === '__proto__' || prop === 'constructor' || prop === 'prototype')
       continue
-    let value = input[prop]
-    if (_resolveCtx)
-      value = walkResolver(value, _resolveCtx.resolve, prop)
+    const value = input[prop]
     if (value === null) {
       tag.props[prop] = null as any
     }
@@ -66,9 +56,9 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>, _resolv
     }
     else if (TagConfigKeys.has(prop)) {
       if ((prop === 'textContent' || prop === 'innerHTML') && typeof value === 'object') {
-        const type = walkResolver(input.type, _resolveCtx?.resolve, 'type') || 'application/json'
+        const type = input.type || 'application/json'
         if (type.endsWith('json') || type === 'speculationrules' || type === 'importmap') {
-          tag.props.type = type
+          tag.props.type = input.type = type
           tag[prop] = JSON.stringify(value)
         }
       }
@@ -89,13 +79,11 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>, _resolv
   return tag
 }
 
-function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string, resolveCtx?: ResolveCtx): HeadTag | HeadTag[] {
-  const isObjectInput = typeof _input === 'object'
-  const input = isObjectInput
-    ? _input as HeadTag['props']
+function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string): HeadTag | HeadTag[] {
+  const input = typeof _input === 'object' && typeof _input !== 'function'
+    ? _input
     : { [(tagName === 'script' || tagName === 'noscript' || tagName === 'style') ? 'innerHTML' : 'textContent']: _input }
-  // wrapped scalars were already resolved at the entry level
-  const tag = normalizeProps({ tag: tagName, props: {} }, input, isObjectInput ? resolveCtx : undefined)
+  const tag = normalizeProps({ tag: tagName, props: {} }, input)
   if (tag.key && DupeableTags.has(tag.tag))
     tag.props['data-hid'] = tag._h = tag.key
   if (tag.tag === 'script' && typeof tag.innerHTML === 'object') {
@@ -108,38 +96,23 @@ function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string
 export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]): HeadTag[] {
   if (!input)
     return []
-  const resolve: PropResolver | undefined = propResolvers.length === 0
-    ? undefined
-    : propResolvers.length === 1
-      ? propResolvers[0]
-      : (key, val, tag) => {
-          for (let i = 0; i < propResolvers.length; i++)
-            val = propResolvers[i](key, val, tag)
-          return val
-        }
-  // unwrap function values (except titleTemplate/on* keys) then apply prop resolvers,
-  // matching the old walkResolver per-node semantics
-  const unwrap = (v: any, key?: string) => {
-    if (typeof v === 'function' && (!key || (key !== 'titleTemplate' && !key.startsWith('on'))))
-      v = v()
-    return resolve ? resolve(key, v) : v
+  if (typeof input === 'function')
+    input = input()
+  let resolve: PropResolver | undefined
+  if (propResolvers.length) {
+    resolve = (key, val) => {
+      for (let i = 0; i < propResolvers.length; i++)
+        val = propResolvers[i](key, val)
+      return val
+    }
+    input = resolve(undefined, input)
   }
-  // two passes match the old pre-walk + root walkResolver calls
-  input = unwrap(unwrap(input))
-  const resolveCtx: ResolveCtx = { resolve }
+  input = walkResolver(input, resolve)
   const tags: (HeadTag | HeadTag[])[] = []
   for (const key in input) {
-    if (isUnsafeKey(key))
-      continue
-    const isResolverKey = key === '_resolver'
-    const value = isResolverKey ? input[key] : unwrap(input[key], key)
-    if (value === undefined)
-      continue
-    const ctx = isResolverKey ? undefined : resolveCtx
-    const isArray = Array.isArray(value)
-    for (const v of isArray ? value : [value]) {
-      // array items are unwrapped and resolved without key context
-      tags.push(normalizeTag(key as keyof ResolvableHead, ctx && isArray ? unwrap(v) : v, ctx))
+    const value = input[key]
+    if (value !== undefined) {
+      for (const v of (Array.isArray(value) ? value : [value])) tags.push(normalizeTag(key as keyof ResolvableHead, v))
     }
   }
   return tags.flat()

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -148,12 +148,12 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
   }
   ctx.tags = needsClone
     ? entries.flatMap(e => (e._tags || []).map((t) => {
-        const props = { ...t.props }
+        const props: Record<string, any> = { ...t.props }
         // class/style are containers; copy them so hooks can't mutate the entry cache
         if (props.class instanceof Set)
-          props.class = new Set(props.class) as any
+          props.class = new Set(props.class)
         if (props.style instanceof Map)
-          props.style = new Map(props.style) as any
+          props.style = new Map(props.style)
         return { ...t, props }
       }))
     : entries.flatMap(e => e._tags || [])

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -147,7 +147,15 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
     }
   }
   ctx.tags = needsClone
-    ? entries.flatMap(e => (e._tags || []).map(t => ({ ...t, props: { ...t.props } })))
+    ? entries.flatMap(e => (e._tags || []).map((t) => {
+        const props = { ...t.props }
+        // class/style are containers; copy them so hooks can't mutate the entry cache
+        if (props.class instanceof Set)
+          props.class = new Set(props.class) as any
+        if (props.style instanceof Map)
+          props.style = new Map(props.style) as any
+        return { ...t, props }
+      }))
     : entries.flatMap(e => e._tags || [])
   const hasFlatMeta = dedupeTags(ctx)
   resolveTitleTemplate(ctx, head)

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -10,6 +10,12 @@ const SCRIPT_END_RE = /<\/script/g
 // @ts-expect-error untyped
 const sortTags = (a: HeadTag, b: HeadTag) => a._w === b._w ? a._p - b._p : a._w - b._w
 
+const DEFAULT_TAG_WEIGHT = () => 100
+
+// hooks that receive references to resolved tags and may mutate them in place;
+// when none are registered the per-render defensive clone can be skipped
+const TAG_MUTATING_HOOKS = ['tags:beforeResolve', 'tags:resolve', 'tags:afterResolve', 'ssr:render', 'ssr:rendered', 'dom:rendered'] as const
+
 export interface ResolveTagsContext {
   tagMap: Map<string, HeadTag>
   tags: HeadTag[]
@@ -75,31 +81,36 @@ export function resolveTitleTemplate(ctx: ResolveTagsContext, head: Unhead<any>)
 }
 
 export function sanitizeTags(tags: HeadTag[]): HeadTag[] {
-  return tags.filter((t) => {
+  const out: HeadTag[] = []
+  for (let t of tags) {
     const { innerHTML, tag, props } = t
     if (!ValidHeadTags.has(tag) || (!Object.keys(props).length && !innerHTML && !t.textContent))
-      return false
+      continue
     if (tag === 'meta' && !props.content && !props['http-equiv'] && !props.charset)
-      return false
+      continue
     if (tag === 'script' && (innerHTML || t.textContent)) {
       const type = String(props.type)
       const isJsonLike = type.endsWith('json') || type === 'importmap' || type === 'speculationrules'
       const escape = (content: unknown): unknown => isJsonLike
         ? (typeof content === 'string' ? content : JSON.stringify(content)).replace(LT_RE, '\\u003C')
         : typeof content === 'string' ? content.replace(SCRIPT_END_RE, '<\\/script') : content
+      // copy-on-write: resolved tags may be shared with the entry cache
+      t = { ...t }
       if (innerHTML)
         t.innerHTML = escape(innerHTML) as typeof innerHTML
       if (t.textContent)
         t.textContent = escape(t.textContent) as typeof t.textContent
       t._d = dedupeKey(t)
     }
-    return true
-  })
+    out.push(t)
+  }
+  return out
 }
 
 export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): HeadTag[] {
-  const weightFn = options?.tagWeight ?? head.resolvedOptions._tagWeight ?? (() => 100)
+  const weightFn = options?.tagWeight ?? head.resolvedOptions._tagWeight ?? DEFAULT_TAG_WEIGHT
   const ctx: ResolveTagsContext = { tagMap: new Map(), tags: [] }
+  const hooks = (head.hooks as any)?._hooks || {}
   const entries = [...head.entries.values()]
   for (const e of entries) {
     if (e._pending !== undefined) {
@@ -108,15 +119,20 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
       delete e._tags
     }
   }
-  callHook(head, 'entries:resolve', { entries, ...ctx })
+  if (hooks['entries:resolve'])
+    callHook(head, 'entries:resolve', { entries, ...ctx })
   for (const e of entries) {
     if (!e._tags) {
-      const normalizeCtx = {
-        tags: normalizeEntryToTags(e.input, head.resolvedOptions.propResolvers || []).map(t => Object.assign(t, e.options)),
-        entry: e,
+      let tags = normalizeEntryToTags(e.input, head.resolvedOptions.propResolvers || [])
+      if (e.options && Object.keys(e.options).length) {
+        for (const t of tags) Object.assign(t, e.options)
       }
-      callHook(head, 'entries:normalize', normalizeCtx)
-      e._tags = normalizeCtx.tags.map((t, i) => {
+      if (hooks['entries:normalize']) {
+        const normalizeCtx = { tags, entry: e }
+        callHook(head, 'entries:normalize', normalizeCtx)
+        tags = normalizeCtx.tags
+      }
+      e._tags = tags.map((t, i) => {
         t._w = weightFn(t)
         t._p = (e._i << 10) + i
         t._d = dedupeKey(t)
@@ -126,7 +142,10 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
       })
     }
   }
-  ctx.tags = entries.flatMap(e => (e._tags || []).map(t => ({ ...t, props: { ...t.props } })))
+  const needsClone = TAG_MUTATING_HOOKS.some(h => hooks[h]?.some((f: any) => !f._nonMutating))
+  ctx.tags = needsClone
+    ? entries.flatMap(e => (e._tags || []).map(t => ({ ...t, props: { ...t.props } })))
+    : entries.flatMap(e => e._tags || [])
   const hasFlatMeta = dedupeTags(ctx)
   resolveTitleTemplate(ctx, head)
   ctx.tags = [...ctx.tagMap.values()]

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -12,9 +12,11 @@ const sortTags = (a: HeadTag, b: HeadTag) => a._w === b._w ? a._p - b._p : a._w 
 
 const DEFAULT_TAG_WEIGHT = () => 100
 
-// hooks that receive references to resolved tags and may mutate them in place;
+// matches the hooks that receive references to resolved tags and may mutate them in place
+// (tags:beforeResolve, tags:resolve, tags:afterResolve, ssr:render, ssr:rendered, dom:rendered
+// and deprecated dom:renderTag — but not *:beforeRender, entries:* or script:updated);
 // when none are registered the per-render defensive clone can be skipped
-const TAG_MUTATING_HOOKS = ['tags:beforeResolve', 'tags:resolve', 'tags:afterResolve', 'ssr:render', 'ssr:rendered', 'dom:rendered'] as const
+const TAG_MUTATING_HOOK_RE = /^tags:|:render/
 
 export interface ResolveTagsContext {
   tagMap: Map<string, HeadTag>
@@ -119,20 +121,15 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
       delete e._tags
     }
   }
-  if (hooks['entries:resolve'])
-    callHook(head, 'entries:resolve', { entries, ...ctx })
+  callHook(head, 'entries:resolve', { entries, ...ctx })
   for (const e of entries) {
     if (!e._tags) {
-      let tags = normalizeEntryToTags(e.input, head.resolvedOptions.propResolvers || [])
-      if (e.options && Object.keys(e.options).length) {
-        for (const t of tags) Object.assign(t, e.options)
+      const normalizeCtx = {
+        tags: normalizeEntryToTags(e.input, head.resolvedOptions.propResolvers || []).map(t => Object.assign(t, e.options)),
+        entry: e,
       }
-      if (hooks['entries:normalize']) {
-        const normalizeCtx = { tags, entry: e }
-        callHook(head, 'entries:normalize', normalizeCtx)
-        tags = normalizeCtx.tags
-      }
-      e._tags = tags.map((t, i) => {
+      callHook(head, 'entries:normalize', normalizeCtx)
+      e._tags = normalizeCtx.tags.map((t, i) => {
         t._w = weightFn(t)
         t._p = (e._i << 10) + i
         t._d = dedupeKey(t)
@@ -142,7 +139,13 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
       })
     }
   }
-  const needsClone = TAG_MUTATING_HOOKS.some(h => hooks[h]?.some((f: any) => !f._nonMutating))
+  let needsClone = false
+  for (const k in hooks) {
+    if (TAG_MUTATING_HOOK_RE.test(k) && hooks[k]?.some((f: any) => !f._nonMutating)) {
+      needsClone = true
+      break
+    }
+  }
   ctx.tags = needsClone
     ? entries.flatMap(e => (e._tags || []).map(t => ({ ...t, props: { ...t.props } })))
     : entries.flatMap(e => e._tags || [])

--- a/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
+++ b/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { createHead, renderSSRHead } from '../../../src/server'
+
+describe('tag-mutating hooks', () => {
+  it('hook mutations do not leak into the entry cache across renders', async () => {
+    let render = 0
+    const head = createHead({
+      disableDefaults: true,
+      hooks: {
+        'tags:resolve': (ctx) => {
+          for (const tag of ctx.tags) {
+            if (tag.tag === 'htmlAttrs') {
+              ;(tag.props.class as Set<string>).add(`render-${render}`)
+              ;(tag.props.style as Map<string, string>).set(`--render-${render}`, '1')
+            }
+          }
+        },
+      },
+    })
+    head.push({
+      htmlAttrs: { class: 'base', style: 'color:red' },
+    })
+
+    render = 1
+    const first = await renderSSRHead(head)
+    render = 2
+    const second = await renderSSRHead(head)
+
+    expect(first.htmlAttrs).toContain('render-1')
+    // mutations from the first render must not survive in the cached entry tags
+    expect(second.htmlAttrs).not.toContain('render-1')
+    expect(second.htmlAttrs).toContain('render-2')
+  })
+})

--- a/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
+++ b/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
@@ -10,8 +10,8 @@ describe('tag-mutating hooks', () => {
         'tags:resolve': (ctx) => {
           for (const tag of ctx.tags) {
             if (tag.tag === 'htmlAttrs') {
-              ;(tag.props.class as Set<string>).add(`render-${render}`)
-              ;(tag.props.style as Map<string, string>).set(`--render-${render}`, '1')
+              ;(tag.props.class as unknown as Set<string>).add(`render-${render}`)
+              ;(tag.props.style as unknown as Map<string, string>).set(`--render-${render}`, '1')
             }
           }
         },

--- a/packages/unhead/test/unit/server/util.test.ts
+++ b/packages/unhead/test/unit/server/util.test.ts
@@ -14,6 +14,11 @@ describe('propsToString', () => {
       style: 'color: red; font-size: 12px',
     })).toStrictEqual(' class="a b" style="color: red; font-size: 12px"')
   })
+  it('skips enumerable inherited props', () => {
+    const props = Object.create({ onload: 'alert(1)' })
+    props.src = '/app.js'
+    expect(propsToString(props)).toStrictEqual(' src="/app.js"')
+  })
   it('stringifies all properties correctly', async () => {
     expect(propsToString({
       'array': ['a', 1],


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`resolveTags` cloned every tag plus its props on every render to protect cached entry tags from hook mutation. A CPU profile of the SSR e2e bench showed the resolve pipeline at ~56% of self time while actual HTML rendering took ~17%, with the defensive clone and its GC churn as the biggest avoidable cost.

Changes:

- Skip the per-render tag clone unless a registered hook can actually mutate resolved tags (`tags:*`, `ssr:render(ed)`, `dom:rendered`, matched by name). The server `unhead:payload` hook only appends a fresh tag, so it is marked `_nonMutating` and no longer forces the clone on every SSR render.
- `sanitizeTags` is copy-on-write: script tags are copied before escaping instead of relying on the render clone.
- `normalizeEntryToTags` skips building the resolver closure when no `propResolvers` are registered, which speeds up core (non-framework) usage without touching the walk semantics.
- Smaller cleanups: `tagToString` caches close-tag regexes instead of allocating one per call, capo script weights inlined with redundant `async` re-checks dropped, `escapeHtml` switch replaced with a lookup map, client `createHead` reuses `TagPriorityAliases`, the double-deprecated `renderSSRHead` wrapper in `unhead/server` collapsed to a re-export, and the invalid `optionalPlugins` field removed from package.json.
- Regression test: `propsToString` skips enumerable inherited props (the `Object.hasOwn` serialization guard now has coverage), and hook mutations of class/style containers no longer leak into the entry cache across renders.

### 📊 Benchmarks

`vitest bench` (`bench/*`), main vs this branch:

| bench | main | PR | change |
| --- | --- | --- | --- |
| `useSeoMeta` x50 SSR (vite transformed) | 299 ops/s | 366 ops/s | +22% |
| `useSeoMeta` x50 SSR (runtime) | 133 ops/s | 136 ops/s | +3% |
| no-schema simple | 155.4k ops/s | 182.0k ops/s | +17% |
| no-schema e2e | 12,762 ops/s | 12,940 ops/s | +1.4% |
| harlanzw.com e2e | 4,440 ops/s | 4,542 ops/s | +2.3% |
| templateParams | 367k ops/s | 372k ops/s | unchanged |

Standalone core (no plugins, 20k iterations): `renderSSRHead` 68.5k -> ~80k ops/s (+17%), `transformHtmlTemplate` 46.4k -> ~57k ops/s (+22%). GC pauses over 200k simulated requests dropped ~11%.

Pages using plugins that register tag-mutating hooks (templateParams, inferSeoMeta) keep the clone and see smaller gains; plain `useHead`/`useSeoMeta` setups get the full win.

### 📦 Bundle size

`bench/bundle` vs `last.json`:

| build | min | gz |
| --- | --- | --- |
| server | **-186** | +14 |
| vue server | **-186** | +13 |
| client | +217 | +91 |
| vue client | +217 | +94 |

The first iteration of this PR also fused prop resolution into a single normalization pass, worth another ~5% core / +27pp on the transformed `useSeoMeta` bench, but it cost +90 gz on the client entry so it was dropped. Easy to revisit if the trade reads differently.

Note: `pnpm typecheck` fails locally on main (unused `@ts-expect-error` in `packages/schema-org/src/svelte.ts:14`), unrelated to this diff; CI typecheck passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary cloning during server renders to improve efficiency and prevent cross-request mutations.
  * Hardened tag sanitization to avoid leaking mutated tag data.

* **Refactor**
  * Standardized tag weighting for more consistent tag ordering.
  * Simplified server export surface by removing a deprecated wrapper.
  * Improved HTML escaping and attribute encoding.

* **Chores**
  * Cleaned up package metadata.

* **Tests**
  * Added tests for attribute serialization and to ensure hook mutations do not persist across renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->