### PR TITLE
test(unhead): resolve reactive root entry input

### DIFF
--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -105,8 +105,9 @@ export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]):
         val = propResolvers[i](key, val)
       return val
     }
-    input = resolve(undefined, input)
   }
+  // walkResolver applies the resolver chain to the root, so the input
+  // passes through each propResolver exactly once
   input = walkResolver(input, resolve)
   const tags: (HeadTag | HeadTag[])[] = []
   for (const key in input) {

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -105,9 +105,12 @@ export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]):
         val = propResolvers[i](key, val)
       return val
     }
+    // load-bearing: walkResolver unwraps functions BEFORE resolving, so a
+    // resolvable yielding a function (e.g. `useHead(ref(() => ({...})))`,
+    // see vite-pwa/vite-plugin-pwa#832) only renders if a resolve pass runs
+    // first. The root intentionally passes through the resolver chain twice.
+    input = resolve(undefined, input)
   }
-  // walkResolver applies the resolver chain to the root, so the input
-  // passes through each propResolver exactly once
   input = walkResolver(input, resolve)
   const tags: (HeadTag | HeadTag[])[] = []
   for (const key in input) {

--- a/packages/vue/test/unit/ssr/root-shapes.test.ts
+++ b/packages/vue/test/unit/ssr/root-shapes.test.ts
@@ -1,0 +1,21 @@
+import { renderSSRHead } from '@unhead/ssr'
+import { useHead } from '@unhead/vue'
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { ssrVueAppWithUnhead } from '../../util'
+
+describe('root resolvable shapes', () => {
+  it('ref root (vite-pwa #832)', async () => {
+    const head = await ssrVueAppWithUnhead(() => {
+      useHead(ref({ title: 'ref-root' }))
+    })
+    expect((await renderSSRHead(head)).headTags).toContain('ref-root')
+  })
+  it('ref-of-function root', async () => {
+    const head = await ssrVueAppWithUnhead(() => {
+      // @ts-expect-error runtime looseness
+      useHead(ref(() => ({ title: 'ref-fn-root' })))
+    })
+    expect((await renderSSRHead(head)).headTags).toContain('ref-fn-root')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #776 / the CodeRabbit "avoid resolving the root input twice" thread.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

This PR originally removed the explicit root resolve in `normalizeEntryToTags` since `walkResolver` also resolves the root, making it look like a redundant double pass. Digging into history showed it is intentional: `walkResolver` unwraps function values *before* applying resolvers, so a resolvable that yields a function, e.g. `useHead(ref(() => ({...})))`, only renders if a resolve pass runs first. The pre-call dates to a255df04 (`fix(vue): broken reactivity`, the vite-pwa/vite-plugin-pwa#832 input class), and the full test suite passed without it because only the plain-ref root shape had coverage.

The optimization is reverted here. What lands instead:

- a comment on the pre-call explaining why the root intentionally passes through the resolver chain twice
- `root-shapes.test.ts` covering both root shapes (`ref({...})` and `ref(() => ({...}))`); the second fails against the "optimized" version

Net behavior change vs main: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added SSR unit tests to validate that root-resolved head entries (including function-wrapped patterns) render expected head tags, improving runtime reliability.

* **Chore**
  * Added clarifying internal comments to the normalization logic to improve maintainability; no runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->