### PR TITLE
fix(vue): return a no-op entry from clientUseHead when the scope is dead

### DIFF
--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -94,7 +94,7 @@ export const Head: DefineComponent = /* @__PURE__ */ defineComponent({
     const entry = useHead(obj)
 
     onBeforeUnmount(() => {
-      entry.dispose()
+      entry?.dispose()
     })
 
     return () => {

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -94,7 +94,7 @@ export const Head: DefineComponent = /* @__PURE__ */ defineComponent({
     const entry = useHead(obj)
 
     onBeforeUnmount(() => {
-      entry?.dispose()
+      entry.dispose()
     })
 
     return () => {

--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -40,15 +40,21 @@ export function useHead<I = UseHeadInput>(input?: UseHeadInput, options: UseHead
 }
 
 function clientUseHead<I = UseHeadInput>(head: Unhead<I>, input?: I, options: HeadEntryOptions = {}): ActiveHeadEntry<I> {
+  const scope = getCurrentScope()
+
+  // Dead scope (e.g. setup resuming after an await once a Suspense/KeepAlive
+  // teardown stopped it): a watchEffect is inert here, so no entry gets pushed.
+  // The component is gone, so return a no-op rather than hand back `undefined`.
+  if (scope && !scope.active) {
+    return { patch() {}, dispose() {}, _i: -1 }
+  }
+
   const deactivated = ref(false)
 
   // Wrap onRendered to preserve the Vue component's effect scope
-  if (options.onRendered) {
-    const scope = getCurrentScope()
-    if (scope) {
-      const _onRendered = options.onRendered
-      options = { ...options, onRendered: ctx => scope.run(() => _onRendered(ctx)) }
-    }
+  if (options.onRendered && scope) {
+    const _onRendered = options.onRendered
+    options = { ...options, onRendered: ctx => scope.run(() => _onRendered(ctx)) }
   }
 
   let entry: ActiveHeadEntry<I>
@@ -65,7 +71,7 @@ function clientUseHead<I = UseHeadInput>(head: Unhead<I>, input?: I, options: He
   const vm = getCurrentInstance()
   if (vm) {
     onBeforeUnmount(() => {
-      entry?.dispose()
+      entry.dispose()
     })
     onDeactivated(() => {
       deactivated.value = true

--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -65,7 +65,7 @@ function clientUseHead<I = UseHeadInput>(head: Unhead<I>, input?: I, options: He
   const vm = getCurrentInstance()
   if (vm) {
     onBeforeUnmount(() => {
-      entry.dispose()
+      entry?.dispose()
     })
     onDeactivated(() => {
       deactivated.value = true

--- a/packages/vue/test/unit/dom/disposeUndefinedEntry.test.ts
+++ b/packages/vue/test/unit/dom/disposeUndefinedEntry.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { createHead } from '@unhead/vue/client'
+import { describe, expect, it } from 'vitest'
+import { createApp, defineComponent, getCurrentScope, h, onBeforeUnmount } from 'vue'
+import { useHead } from '../../../src'
+
+describe('dispose undefined entry', () => {
+  // Regression for the crash where `useHead` runs while the owning effect scope
+  // has already been stopped — e.g. a component whose `setup` resumes after an
+  // `await` once a KeepAlive/Suspense teardown has stopped its scope. In that
+  // state `clientUseHead`'s `watchEffect` never performs its initial run, so the
+  // head `entry` is never created. The `onBeforeUnmount` hook still fires on
+  // teardown and previously called `entry.dispose()` on `undefined`, throwing
+  // "undefined is not an object (evaluating 'entry.dispose')".
+  it('does not throw on unmount when the scope was stopped before the entry was created', () => {
+    const head = createHead({ document })
+
+    let beforeUnmountFired = false
+
+    const Comp = defineComponent({
+      setup() {
+        // Stop the component's scope before registering head, reproducing the
+        // teardown-during-async-setup race. A watchEffect created now is inert,
+        // so `entry` inside clientUseHead stays undefined.
+        getCurrentScope()!.stop()
+
+        // pass `head` explicitly so resolution doesn't depend on inject context
+        useHead({ title: 'page' }, { head })
+
+        onBeforeUnmount(() => {
+          beforeUnmountFired = true
+        })
+
+        return () => h('div', 'hello')
+      },
+    })
+
+    const el = document.createElement('div')
+    const app = createApp(Comp)
+    app.use(head)
+    app.mount(el)
+
+    expect(() => app.unmount()).not.toThrow()
+    // guard: ensure the teardown hook actually ran, otherwise the test proves nothing
+    expect(beforeUnmountFired).toBe(true)
+  })
+})

--- a/packages/vue/test/unit/dom/disposeUndefinedEntry.test.ts
+++ b/packages/vue/test/unit/dom/disposeUndefinedEntry.test.ts
@@ -2,17 +2,34 @@
 
 import { createHead } from '@unhead/vue/client'
 import { describe, expect, it } from 'vitest'
-import { createApp, defineComponent, getCurrentScope, h, onBeforeUnmount } from 'vue'
+import * as vue from 'vue'
+import {
+  createApp,
+  defineComponent,
+  getCurrentInstance,
+  getCurrentScope,
+  h,
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  Suspense,
+} from 'vue'
 import { useHead } from '../../../src'
+import { Head } from '../../../src/components'
 
+const tick = () => new Promise(resolve => setTimeout(resolve))
+
+// `withAsyncContext` is the compiler-internal helper emitted for `<script setup>`
+// top-level awaits; it isn't part of vue's public types, so reach it via a cast.
+const withAsyncContext = (vue as unknown as {
+  withAsyncContext: <T>(getAwaitable: () => T) => [T, () => void]
+}).withAsyncContext
+
+// In a dead scope the watchEffect is inert, so no entry gets pushed and
+// clientUseHead used to return `entry!` (undefined), crashing on dispose/patch.
+// The fix returns a no-op entry, keeping the ActiveHeadEntry contract for every
+// consumer: the unmount hook, the <Head> component's patch, and external callers.
 describe('dispose undefined entry', () => {
-  // Regression for the crash where `useHead` runs while the owning effect scope
-  // has already been stopped — e.g. a component whose `setup` resumes after an
-  // `await` once a KeepAlive/Suspense teardown has stopped its scope. In that
-  // state `clientUseHead`'s `watchEffect` never performs its initial run, so the
-  // head `entry` is never created. The `onBeforeUnmount` hook still fires on
-  // teardown and previously called `entry.dispose()` on `undefined`, throwing
-  // "undefined is not an object (evaluating 'entry.dispose')".
   it('does not throw on unmount when the scope was stopped before the entry was created', () => {
     const head = createHead({ document })
 
@@ -44,5 +61,126 @@ describe('dispose undefined entry', () => {
     expect(() => app.unmount()).not.toThrow()
     // guard: ensure the teardown hook actually ran, otherwise the test proves nothing
     expect(beforeUnmountFired).toBe(true)
+  })
+
+  it('returns a usable entry so external callers never receive undefined', () => {
+    const head = createHead({ document })
+
+    let returned: ReturnType<typeof useHead> | undefined
+
+    const Comp = defineComponent({
+      setup() {
+        getCurrentScope()!.stop()
+        returned = useHead({ title: 'page' }, { head })
+        return () => h('div')
+      },
+    })
+
+    const app = createApp(Comp)
+    app.use(head)
+    app.mount(document.createElement('div'))
+
+    expect(returned).toBeDefined()
+    // a caller using the return value must not crash on the dead-scope path
+    expect(() => returned!.patch({ title: 'x' })).not.toThrow()
+    expect(() => returned!.dispose()).not.toThrow()
+
+    app.unmount()
+  })
+
+  it('does not throw when the <Head> component renders in a dead scope', () => {
+    const head = createHead({ document })
+
+    const Comp = defineComponent({
+      setup() {
+        getCurrentScope()!.stop()
+        return () => h(Head, null, { default: () => h('title', 'x') })
+      },
+    })
+
+    const app = createApp(Comp)
+    app.use(head)
+    app.mount(document.createElement('div'))
+
+    expect(() => app.unmount()).not.toThrow()
+  })
+
+  it('still applies head normally when the scope is active', async () => {
+    const head = createHead({ document })
+
+    const Comp = defineComponent({
+      setup() {
+        useHead({ title: 'real' }, { head })
+        return () => h('div')
+      },
+    })
+
+    const app = createApp(Comp)
+    app.use(head)
+    app.mount(document.createElement('div'))
+
+    await tick()
+    expect(document.title).toBe('real')
+
+    app.unmount()
+  })
+
+  // Production-shaped scenario: a `<script setup>` with a top-level await
+  // (compiled to `withAsyncContext`) torn down mid-suspension. The scope resumes
+  // stopped, so head is skipped instead of crashing.
+  it('does not throw on a withAsyncContext teardown race', async () => {
+    const head = createHead({ document })
+
+    let resolveGate: () => void
+    const gate = new Promise<void>((resolve) => {
+      resolveGate = resolve
+    })
+    let scopeActiveAtUseHead: boolean | undefined
+    let threw: unknown
+
+    const AsyncSfc = defineComponent({
+      async setup() {
+        // matches the SFC compiler output for `await gate`
+        const [__temp, __restore] = withAsyncContext(() => gate)
+        await __temp
+        __restore()
+
+        scopeActiveAtUseHead = getCurrentScope()?.active
+        // sanity: the instance context is restored too
+        expect(getCurrentInstance()).toBeTruthy()
+        try {
+          useHead({ title: 'late' }, { head })
+        }
+        catch (error) {
+          threw = error
+        }
+        return () => h('div')
+      },
+    })
+
+    const show = ref(true)
+    const Parent = defineComponent({
+      setup() {
+        return () =>
+          show.value
+            ? h(Suspense, null, { default: () => h(AsyncSfc), fallback: () => h('span', '...') })
+            : h('div', 'gone')
+      },
+    })
+
+    const app = createApp(Parent)
+    app.use(head)
+    app.mount(document.createElement('div'))
+    await nextTick()
+
+    // navigate away before the await resolves, then resume into the dead scope
+    show.value = false
+    await nextTick()
+    resolveGate!()
+    await tick()
+    await nextTick()
+
+    expect(scopeActiveAtUseHead).toBe(false)
+    expect(threw).toBeUndefined()
   })
 })


### PR DESCRIPTION
 <!---
  ☝️ PR title should follow conventional commits (https://conventionalcommits.org)
  -->

  ### 🔗 Linked issue

  <!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

  N/A — no existing issue (couldn't find a duplicate when searching issues/PRs for `dispose` / `Suspense` / `undefined`).

  ### ❓ Type of change

  <!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

  - [ ] 📖 Documentation (updates to the documentation or readme)
  - [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
  - [ ] 👌 Enhancement (improving an existing functionality)
  - [ ] ✨ New feature (a non-breaking change that adds functionality)
  - [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
  - [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

  ### 📚 Description

  When a component's `setup` resumes after an `await` (e.g. `await callOnce(...)` in Nuxt) once a KeepAlive/Suspense teardown has already stopped its effect scope, the `watchEffect` inside `clientUseHead` never performs its initial run, so the head `entry` is never created. The `onBeforeUnmount` hook still fires on teardown and called `entry.dispose()` on `undefined`, throwing:

  TypeError: undefined is not an object (evaluating 'entry.dispose')

  This surfaces in production Nuxt apps on fast navigations/redirects (notably iOS native webviews) where a page registers
  `useHead`/`useSeoMeta` *after* an `await` and is torn down mid-suspension.

  **Fix:** disposing a never-created entry is semantically a no-op, so guard both teardown call sites — `clientUseHead` and the `<Head>` component — with optional chaining (`entry?.dispose()`). Note `clientUseHead` already returns `entry!`, acknowledging `entry` can be `undefined`.

  **Test:** adds a regression test (`packages/vue/test/unit/dom/disposeUndefinedEntry.test.ts`) that stops the effect scope before `useHead` registers — reproducing the teardown-during-async-setup race — and asserts unmount doesn't throw (while verifying the `onBeforeUnmount` hook actually fires, so the test is meaningful). It fails on `main` with the exact `TypeError` and passes with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved head management when a Vue effect scope has already been stopped, such as during async teardown with KeepAlive or Suspense.
  * Prevented crashes during unmount by returning a safe no-op result when head updates can’t be registered.
  * Ensured head rendering and cleanup still behave correctly in normal active-scope cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->