### PR TITLE
fix(vue): return a no-op entry from clientUseHead when the scope is dead

### DIFF
--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -40,15 +40,25 @@ export function useHead<I = UseHeadInput>(input?: UseHeadInput, options: UseHead
 }
 
 function clientUseHead<I = UseHeadInput>(head: Unhead<I>, input?: I, options: HeadEntryOptions = {}): ActiveHeadEntry<I> {
+  const scope = getCurrentScope()
+
+  // If the owning effect scope has already been stopped — e.g. a component whose
+  // `setup` resumes after an `await` once a KeepAlive/Suspense teardown stopped
+  // its scope — a `watchEffect` created now is inert: its initial run never fires
+  // (the effect is constructed with its active flag cleared, so the scheduled
+  // first job bails), so no entry is ever pushed. Nothing will render and there's
+  // no live unmount hook to clean up, so return a no-op entry instead of letting
+  // `useHead` hand back `undefined` while typed as `ActiveHeadEntry`.
+  if (scope && !scope.active) {
+    return { patch() {}, dispose() {}, _i: -1 }
+  }
+
   const deactivated = ref(false)
 
   // Wrap onRendered to preserve the Vue component's effect scope
-  if (options.onRendered) {
-    const scope = getCurrentScope()
-    if (scope) {
-      const _onRendered = options.onRendered
-      options = { ...options, onRendered: ctx => scope.run(() => _onRendered(ctx)) }
-    }
+  if (options.onRendered && scope) {
+    const _onRendered = options.onRendered
+    options = { ...options, onRendered: ctx => scope.run(() => _onRendered(ctx)) }
   }
 
   let entry: ActiveHeadEntry<I>

--- a/packages/vue/test/unit/dom/disposeUndefinedEntry.test.ts
+++ b/packages/vue/test/unit/dom/disposeUndefinedEntry.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+import { createHead } from '@unhead/vue/client'
+import { describe, expect, it } from 'vitest'
+import * as vue from 'vue'
+import {
+  createApp,
+  defineComponent,
+  getCurrentInstance,
+  getCurrentScope,
+  h,
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  Suspense,
+} from 'vue'
+import { useHead } from '../../../src'
+import { Head } from '../../../src/components'
+
+const tick = () => new Promise(resolve => setTimeout(resolve))
+
+// `withAsyncContext` is the compiler-internal helper emitted for `<script setup>`
+// top-level awaits; it isn't part of vue's public types, so reach it via a cast.
+const withAsyncContext = (vue as unknown as {
+  withAsyncContext: <T>(getAwaitable: () => T) => [T, () => void]
+}).withAsyncContext
+
+// When `clientUseHead` runs while its owning effect scope has already been
+// stopped, the `watchEffect` is inert: its scheduled initial job sees the
+// effect's active flag cleared and bails, so `head.push` never runs and the
+// `entry` stays `undefined`. `clientUseHead` then returns `entry!` — a lie —
+// and `onBeforeUnmount` would call `entry.dispose()` on `undefined`, throwing
+// "Cannot read properties of undefined (reading 'dispose')".
+//
+// The fix guards the source: a dead scope returns a no-op entry, so the
+// `ActiveHeadEntry` contract holds for every consumer (the unmount hook, the
+// `<Head>` component's `entry.patch`, and any external caller of the return).
+describe('dispose undefined entry', () => {
+  it('does not throw on unmount when the scope was stopped before the entry was created', () => {
+    const head = createHead({ document })
+
+    let beforeUnmountFired = false
+
+    const Comp = defineComponent({
+      setup() {
+        // Stop the component's scope before registering head, reproducing the
+        // teardown-during-async-setup race. A watchEffect created now is inert,
+        // so `entry` inside clientUseHead stays undefined.
+        getCurrentScope()!.stop()
+
+        // pass `head` explicitly so resolution doesn't depend on inject context
+        useHead({ title: 'page' }, { head })
+
+        onBeforeUnmount(() => {
+          beforeUnmountFired = true
+        })
+
+        return () => h('div', 'hello')
+      },
+    })
+
+    const el = document.createElement('div')
+    const app = createApp(Comp)
+    app.use(head)
+    app.mount(el)
+
+    expect(() => app.unmount()).not.toThrow()
+    // guard: ensure the teardown hook actually ran, otherwise the test proves nothing
+    expect(beforeUnmountFired).toBe(true)
+  })
+
+  it('returns a usable entry so external callers never receive undefined', () => {
+    const head = createHead({ document })
+
+    let returned: ReturnType<typeof useHead> | undefined
+
+    const Comp = defineComponent({
+      setup() {
+        getCurrentScope()!.stop()
+        returned = useHead({ title: 'page' }, { head })
+        return () => h('div')
+      },
+    })
+
+    const app = createApp(Comp)
+    app.use(head)
+    app.mount(document.createElement('div'))
+
+    expect(returned).toBeDefined()
+    // a caller using the return value must not crash on the dead-scope path
+    expect(() => returned!.patch({ title: 'x' })).not.toThrow()
+    expect(() => returned!.dispose()).not.toThrow()
+
+    app.unmount()
+  })
+
+  it('does not throw when the <Head> component renders in a dead scope', () => {
+    const head = createHead({ document })
+
+    const Comp = defineComponent({
+      setup() {
+        getCurrentScope()!.stop()
+        return () => h(Head, null, { default: () => h('title', 'x') })
+      },
+    })
+
+    const app = createApp(Comp)
+    app.use(head)
+    app.mount(document.createElement('div'))
+
+    expect(() => app.unmount()).not.toThrow()
+  })
+
+  it('still applies head normally when the scope is active', async () => {
+    const head = createHead({ document })
+
+    const Comp = defineComponent({
+      setup() {
+        useHead({ title: 'real' }, { head })
+        return () => h('div')
+      },
+    })
+
+    const app = createApp(Comp)
+    app.use(head)
+    app.mount(document.createElement('div'))
+
+    await tick()
+    expect(document.title).toBe('real')
+
+    app.unmount()
+  })
+
+  // Documents the production-shaped scenario the fix targets: a `<script setup>`
+  // component with a top-level await (compiled with `withAsyncContext`) torn down
+  // mid-suspension. The scope is restored stopped after the await, so head is
+  // silently skipped rather than crashing — the no-op entry keeps it safe.
+  it('does not throw on a withAsyncContext teardown race', async () => {
+    const head = createHead({ document })
+
+    let resolveGate: () => void
+    const gate = new Promise<void>((resolve) => {
+      resolveGate = resolve
+    })
+    let scopeActiveAtUseHead: boolean | undefined
+    let threw: unknown
+
+    const AsyncSfc = defineComponent({
+      async setup() {
+        // matches the SFC compiler output for `await gate`
+        const [__temp, __restore] = withAsyncContext(() => gate)
+        await __temp
+        __restore()
+
+        scopeActiveAtUseHead = getCurrentScope()?.active
+        // sanity: the instance context is restored too
+        expect(getCurrentInstance()).toBeTruthy()
+        try {
+          useHead({ title: 'late' }, { head })
+        }
+        catch (error) {
+          threw = error
+        }
+        return () => h('div')
+      },
+    })
+
+    const show = ref(true)
+    const Parent = defineComponent({
+      setup() {
+        return () =>
+          show.value
+            ? h(Suspense, null, { default: () => h(AsyncSfc), fallback: () => h('span', '...') })
+            : h('div', 'gone')
+      },
+    })
+
+    const app = createApp(Parent)
+    app.use(head)
+    app.mount(document.createElement('div'))
+    await nextTick()
+
+    // navigate away before the await resolves, then resume into the dead scope
+    show.value = false
+    await nextTick()
+    resolveGate!()
+    await tick()
+    await nextTick()
+
+    expect(scopeActiveAtUseHead).toBe(false)
+    expect(threw).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### 📚 Description

Alternative root-cause fix for the crash #778 targets (`TypeError: ... reading 'dispose'` on unmount).

When `clientUseHead` runs while its owning effect scope has **already been stopped**, the `watchEffect`'s scheduled initial job bails out (the `ReactiveEffect` is constructed with its active flag cleared because `activeEffectScope.active === false`), so `head.push` never runs and `entry` stays `undefined`. `clientUseHead` then returns `entry!` — a non-null assertion that's actually a lie — and `onBeforeUnmount` calls `entry.dispose()` on `undefined`.

#### Why guard the source instead of the call sites

#778 adds `entry?.dispose()` at two consumers. That leaves the real problem in place: `useHead` is typed `ActiveHeadEntry<I>` but can hand back `undefined`. Anything else using the return value hits the same crash, e.g.:

- the `<Head>` component's `entry.patch(...)` in its render `watchEffect` (`components.ts`) — still unguarded by #778
- any user/Nuxt code that captures the entry: `const e = useHead(...); e.patch(...)`

This PR fixes the contract once, at the source: a dead scope returns a no-op `ActiveHeadEntry`, so **no consumer needs defensive `?.`** and `components.ts` needs no changes.

#### Why no-op (not eager/sync push)

For a live scope the initial push is **already synchronous** (the `flush: 'pre'` scheduler runs the first job inline), so making the `watchEffect` immediate/sync buys nothing there — and on the dead-scope path it would push a tag onto a tearing-down component that may never run its unmount hook, leaking it into the DOM. Doing nothing is the correct handling for a scope that's gone.

### 🔍 On reproducibility (worth a maintainer's eyes)

The crash needs a **stopped current scope** *and* an `onBeforeUnmount` that still fires. Vue's `unmountComponent` runs `bum` hooks **before** `scope.stop()`, so in a normal unmount these can't co-occur — the scope must be stopped *out of band*. I built the genuine `withAsyncContext` + Suspense teardown the original report describes: the scope does end up stopped (`active === false`), but the instance is already `isUnmounted`, so `onBeforeUnmount` never fires → **silent head drop, not a crash**. I could only trigger the actual `dispose` crash via an out-of-band `scope.stop()`. So the production iOS stack trace may reach this state by a path not yet reproduced; this fix is a strict improvement regardless, but confirming the real trigger (ideally a Nuxt repro) is still open.

### ✅ Tests

`packages/vue/test/unit/dom/disposeUndefinedEntry.test.ts`:
- minimal crash repro (fails on `main` with the exact `TypeError`, passes here)
- external caller receives a usable entry (never `undefined`)
- `<Head>` component renders/unmounts in a dead scope
- control: active scope still applies head (no regression)
- `withAsyncContext` teardown race documents the stopped-scope path (`active === false`, no throw)

Full vue suite (159 tests), `vue-tsc`, and eslint all pass.

Relates to #778.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where unmounting the application could throw an error in edge cases involving async component setup and scope deactivation.

* **Tests**
  * Added regression tests for edge case handling in component lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->