### PR TITLE
perf(bundler): optimize minify transform

### DIFF
--- a/packages/bundler/src/unplugin/MinifyTransform.ts
+++ b/packages/bundler/src/unplugin/MinifyTransform.ts
@@ -11,6 +11,19 @@ const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
 
 const SKIP_JS_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
+const HEAD_FN_NAMES = new Set(['useHead', 'useServerHead'])
+const CONTENT_PROP_NAMES = ['innerHTML', 'textContent']
+const CONTENT_PROPS = new Set(CONTENT_PROP_NAMES)
+const MINIFY_CACHE_MAX = 100
+
+type TagType = 'script' | 'style'
+
+interface PendingMinification {
+  end: number
+  minified: Promise<string | null>
+  raw: string
+  start: number
+}
 
 export type MinifyFn = (code: string) => Promise<string | null>
 
@@ -44,10 +57,10 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
   const doJS = !!jsMinifier
   const doCSS = !!cssMinifier
 
-  // head composable names that accept script/style tags
-  const HEAD_FN_NAMES = new Set(['useHead', 'useServerHead'])
-  // properties that hold inline content
-  const CONTENT_PROPS = new Set(['innerHTML', 'textContent'])
+  const minifyCache: Record<TagType, Map<string, Promise<string | null>>> = {
+    script: new Map(),
+    style: new Map(),
+  }
 
   return {
     name: 'unhead:minify-transform',
@@ -81,6 +94,11 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
       if (!code.includes('useHead') && !code.includes('useServerHead'))
         return
 
+      // Escaped identifiers still need parsing because their source does not
+      // contain the decoded property name.
+      if (!CONTENT_PROP_NAMES.some(name => code.includes(name)) && !code.includes('\\u'))
+        return
+
       let ast
       try {
         ast = parseSync(id, code)
@@ -90,32 +108,15 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
       }
 
       const scopeTracker = new ScopeTracker()
-      const s = new MagicString(code)
-      const pendingMinifications: Promise<void>[] = []
+      const pendingMinifications: PendingMinification[] = []
 
       walk(ast.program, {
         scopeTracker,
         enter(node: any, _parent: any) {
-          if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier')
+          if (node.type !== 'CallExpression')
             return
 
-          // check if this is a useHead/useServerHead call (imported or auto-imported)
-          const decl = scopeTracker.getDeclaration(node.callee.name)
-          let originalName: string
-
-          if (decl instanceof ScopeTrackerImport) {
-            if (decl.node.type !== 'ImportSpecifier' || decl.node.imported.type !== 'Identifier')
-              return
-            originalName = decl.node.imported.name
-          }
-          else if (!decl && HEAD_FN_NAMES.has(node.callee.name)) {
-            originalName = node.callee.name
-          }
-          else {
-            return
-          }
-
-          if (!HEAD_FN_NAMES.has(originalName))
+          if (!resolveHeadFunctionName(node.callee, scopeTracker))
             return
 
           const arg = node.arguments[0]
@@ -145,29 +146,69 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
               if (!element || element.type !== 'ObjectExpression')
                 continue
 
-              processScriptOrStyleObject(element, tagType, code, s, pendingMinifications)
+              processScriptOrStyleObject(element, tagType, pendingMinifications)
             }
           }
         },
       })
 
-      await Promise.all(pendingMinifications)
+      if (!pendingMinifications.length)
+        return
 
-      if (s.hasChanged()) {
-        return {
-          code: s.toString(),
-          map: s.generateMap({ includeContent: true, source: id }) as SourceMapInput,
-        }
+      const minified = await Promise.all(pendingMinifications.map(pending => pending.minified))
+      const s = new MagicString(code)
+
+      for (let i = 0; i < pendingMinifications.length; i++) {
+        const pending = pendingMinifications[i]
+        const result = minified[i]
+        if (result && result.length < pending.raw.length)
+          s.overwrite(pending.start, pending.end, JSON.stringify(result))
+      }
+
+      if (!s.hasChanged())
+        return
+
+      return {
+        code: s.toString(),
+        map: s.generateMap({ includeContent: true, source: id }) as SourceMapInput,
       }
     },
   }
 
+  function resolveHeadFunctionName(callee: any, scopeTracker: ScopeTracker): string | undefined {
+    if (callee.type === 'Identifier') {
+      const decl = scopeTracker.getDeclaration(callee.name)
+
+      if (decl instanceof ScopeTrackerImport) {
+        if (decl.node.type === 'ImportSpecifier'
+          && decl.node.imported.type === 'Identifier'
+          && HEAD_FN_NAMES.has(decl.node.imported.name)) {
+          return decl.node.imported.name
+        }
+      }
+      else if (!decl && HEAD_FN_NAMES.has(callee.name)) {
+        return callee.name
+      }
+      return
+    }
+
+    if (callee.type !== 'MemberExpression'
+      || callee.computed
+      || callee.object.type !== 'Identifier'
+      || callee.property.type !== 'Identifier'
+      || !HEAD_FN_NAMES.has(callee.property.name)) {
+      return
+    }
+
+    const decl = scopeTracker.getDeclaration(callee.object.name)
+    if (decl instanceof ScopeTrackerImport && decl.node.type === 'ImportNamespaceSpecifier')
+      return callee.property.name
+  }
+
   function processScriptOrStyleObject(
     objectNode: any,
-    tagType: 'script' | 'style',
-    code: string,
-    s: MagicString,
-    pendingMinifications: Promise<void>[],
+    tagType: TagType,
+    pendingMinifications: PendingMinification[],
   ) {
     // for scripts, check if it's a skippable type
     if (tagType === 'script') {
@@ -188,40 +229,60 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
 
       // only handle static string literals and template literals without expressions
       if (prop.value?.type === 'Literal') {
-        const raw = prop.value.value as string
-        if (raw.length < 20)
+        const raw = prop.value.value
+        if (typeof raw !== 'string' || raw.length < 20)
           continue
 
-        pendingMinifications.push(
-          minifyStringContent(raw, tagType).then((minified) => {
-            if (minified && minified.length < raw.length) {
-              // replace the string literal value (keep the quotes)
-              s.overwrite(prop.value.start, prop.value.end, JSON.stringify(minified))
-            }
-          }),
-        )
+        pendingMinifications.push({
+          end: prop.value.end,
+          minified: minifyStringContent(raw, tagType),
+          raw,
+          start: prop.value.start,
+        })
       }
       else if (prop.value?.type === 'TemplateLiteral' && prop.value.expressions.length === 0) {
         const raw = prop.value.quasis[0]?.value?.cooked as string
         if (!raw || raw.length < 20)
           continue
 
-        pendingMinifications.push(
-          minifyStringContent(raw, tagType).then((minified) => {
-            if (minified && minified.length < raw.length) {
-              s.overwrite(prop.value.start, prop.value.end, JSON.stringify(minified))
-            }
-          }),
-        )
+        pendingMinifications.push({
+          end: prop.value.end,
+          minified: minifyStringContent(raw, tagType),
+          raw,
+          start: prop.value.start,
+        })
       }
     }
   }
 
-  async function minifyStringContent(content: string, tagType: 'script' | 'style'): Promise<string | null> {
-    if (tagType === 'script' && jsMinifier)
-      return jsMinifier(content)
-    if (tagType === 'style' && cssMinifier)
-      return cssMinifier(content)
-    return null
+  function minifyStringContent(content: string, tagType: TagType): Promise<string | null> {
+    const minifier = tagType === 'script' ? jsMinifier : cssMinifier
+    if (!minifier)
+      return Promise.resolve(null)
+
+    const cache = minifyCache[tagType]
+    const cached = cache.get(content)
+    if (cached) {
+      cache.delete(content)
+      cache.set(content, cached)
+      return cached
+    }
+
+    const pending: Promise<string | null> = Promise.resolve()
+      .then(() => minifier(content))
+      .catch((error) => {
+        if (cache.get(content) === pending)
+          cache.delete(content)
+        throw error
+      })
+    cache.set(content, pending)
+
+    if (cache.size > MINIFY_CACHE_MAX) {
+      const oldest = cache.keys().next().value
+      if (oldest !== undefined)
+        cache.delete(oldest)
+    }
+
+    return pending
   }
 })

--- a/packages/bundler/test/minifyTransform.test.ts
+++ b/packages/bundler/test/minifyTransform.test.ts
@@ -13,14 +13,18 @@ const mockCSSMinifier: MinifyFn = async (code: string) => {
 
 async function transform(code: string | string[], opts: { js?: false | MinifyFn, css?: false | MinifyFn } = {}, id = '/app/some-id.js') {
   const plugin = MinifyTransform.vite(opts) as any
+  const res = await transformWithPlugin(plugin, code, id)
+  return res?.code
+}
+
+async function transformWithPlugin(plugin: any, code: string | string[], id = '/app/some-id.js') {
   if (plugin.transformInclude && !plugin.transformInclude(id))
     return undefined
-  const res = await plugin.transform.call(
+  return plugin.transform.call(
     {},
     Array.isArray(code) ? code.join('\n') : code,
     id,
   )
-  return res?.code
 }
 
 describe('minifyTransform', () => {
@@ -149,6 +153,43 @@ describe('minifyTransform', () => {
     expect(code).not.toContain('// comment')
   })
 
+  it('handles aliased imports', async () => {
+    const code = await transform([
+      `import { useHead as head } from 'unhead'`,
+      `head({`,
+      `  script: [{ innerHTML: '// comment\\nvar x = 1;  var y = 2;' }]`,
+      `})`,
+    ], { js: mockJSMinifier })
+
+    expect(code).toBeDefined()
+    expect(code).not.toContain('// comment')
+  })
+
+  it('handles namespace imports', async () => {
+    const code = await transform([
+      `import * as head from 'unhead'`,
+      `head.useHead({`,
+      `  script: [{ innerHTML: '// comment\\nvar x = 1;  var y = 2;' }]`,
+      `})`,
+    ], { js: mockJSMinifier })
+
+    expect(code).toBeDefined()
+    expect(code).not.toContain('// comment')
+  })
+
+  it('does not transform shadowed aliases or namespace imports', async () => {
+    const code = await transform([
+      `import { useHead as head } from 'unhead'`,
+      `import * as unhead from 'unhead'`,
+      `function setup(head, unhead) {`,
+      `  head({ script: [{ innerHTML: '// comment\\nvar x = 1;  var y = 2;' }] })`,
+      `  unhead.useHead({ style: [{ innerHTML: '/* comment */ body { margin: 0; }' }] })`,
+      `}`,
+    ], { js: mockJSMinifier, css: mockCSSMinifier })
+
+    expect(code).toBeUndefined()
+  })
+
   it('handles single object (non-array) script/style', async () => {
     const code = await transform([
       `import { useHead } from 'unhead'`,
@@ -195,6 +236,30 @@ describe('minifyTransform', () => {
     expect(code).not.toContain('// comment')
   })
 
+  it('handles comments between content property names and values', async () => {
+    const code = await transform([
+      `import { useHead } from 'unhead'`,
+      `useHead({`,
+      `  script: [{ innerHTML /* retained syntax */ : '// comment\\nvar x = 1;  var y = 2;' }]`,
+      `})`,
+    ], { js: mockJSMinifier })
+
+    expect(code).toBeDefined()
+    expect(code).not.toContain('// comment')
+  })
+
+  it('handles escaped content property names', async () => {
+    const code = await transform([
+      `import { useHead } from 'unhead'`,
+      `useHead({`,
+      `  script: [{ inner\\u0048TML: '// comment\\nvar x = 1;  var y = 2;' }]`,
+      `})`,
+    ], { js: mockJSMinifier })
+
+    expect(code).toBeDefined()
+    expect(code).not.toContain('// comment')
+  })
+
   it('handles both JS and CSS minification together', async () => {
     const code = await transform([
       `import { useHead } from 'unhead'`,
@@ -207,6 +272,45 @@ describe('minifyTransform', () => {
     expect(code).toBeDefined()
     expect(code).not.toContain('// comment')
     expect(code).not.toContain('/* comment */')
+  })
+
+  it('deduplicates identical minifications across concurrent transforms', async () => {
+    let calls = 0
+    const minifier: MinifyFn = async (code) => {
+      calls++
+      await Promise.resolve()
+      return code.replace(/\/\/.*$/gm, '').replace(/\s+/g, ' ').trim()
+    }
+    const plugin = MinifyTransform.vite({ js: minifier }) as any
+    const source = [
+      `import { useHead } from 'unhead'`,
+      `useHead({`,
+      `  script: [{ innerHTML: '// comment\\nvar x = 1;  var y = 2;' }]`,
+      `})`,
+    ]
+
+    const results = await Promise.all([
+      transformWithPlugin(plugin, source, '/app/one.ts'),
+      transformWithPlugin(plugin, source, '/app/two.ts'),
+    ])
+
+    expect(calls).toBe(1)
+    expect(results.every(result => result?.code.includes('var x = 1; var y = 2;'))).toBe(true)
+  })
+
+  it('preserves source content in generated sourcemaps', async () => {
+    const source = [
+      `import { useHead } from 'unhead'`,
+      `useHead({`,
+      `  style: [{ innerHTML: '/* comment */ body { margin: 0; }' }]`,
+      `})`,
+    ].join('\n')
+    const plugin = MinifyTransform.vite({ css: mockCSSMinifier }) as any
+    const result = await transformWithPlugin(plugin, source, '/app/source-map.ts')
+
+    expect(result?.map).toBeDefined()
+    expect(result.map.sources).toEqual(['/app/source-map.ts'])
+    expect(result.map.sourcesContent).toEqual([source])
   })
 
   it('transforms vue script blocks', async () => {


### PR DESCRIPTION
## Summary

This PR optimizes the `minify` transform with fast paths, caching, and broader import handling.
## Measurements

Measured on Node 24.17.0 / macOS, medians after warmup:

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| 156-file read-only Nuxt source corpus, 2.5 MB total, no-op minifiers | 160.13 ms | 31.06 ms | -80.6% |
| 156 false-positive modules, 6.7 KiB each | 116.12 ms | 1.08 ms | -99.1% |
| 156 identical literals with Rolldown, sequential transforms | 8.95 ms / 156 calls | 4.52 ms / 1 call | -49.5% |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of `useHead`/`useServerHead` calls across aliased, namespace, and member-expression import patterns.
  * Prevented unintended transforms when matching identifiers are shadowed by local parameters.

* **Performance**
  * Added a fast path to avoid unnecessary parsing when inline HTML/text isn’t likely present.
  * Upgraded inline `script`/`style` minification with cached, deduplicated concurrent requests and safer “only-shorter” replacements.

* **Tests**
  * Expanded coverage for comments between content keys and values, escaped content keys, concurrency deduplication, and sourcemap content preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->