### PR TITLE
perf(bundler): filter transforms by source

### DIFF
--- a/packages/bundler/src/unplugin/MinifyTransform.ts
+++ b/packages/bundler/src/unplugin/MinifyTransform.ts
@@ -6,6 +6,7 @@ import { parseSync } from 'oxc-parser'
 import { ScopeTracker, ScopeTrackerImport, walk } from 'oxc-walker'
 import { parseQuery, parseURL } from 'ufo'
 import { createUnplugin } from 'unplugin'
+import { withCodeFilter } from './utils'
 
 const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
@@ -49,7 +50,7 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
   // properties that hold inline content
   const CONTENT_PROPS = new Set(['innerHTML', 'textContent'])
 
-  return {
+  return withCodeFilter({
     name: 'unhead:minify-transform',
     enforce: 'post',
 
@@ -160,7 +161,7 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
         }
       }
     },
-  }
+  }, /\buse(?:Server)?Head\b/)
 
   function processScriptOrStyleObject(
     objectNode: any,

--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -12,6 +12,7 @@ import {
   resolvePackedMetaObjectValue,
 } from 'unhead/utils'
 import { createUnplugin } from 'unplugin'
+import { withCodeFilter } from './utils'
 
 const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
@@ -60,7 +61,7 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
     return [...(options.importPaths || [])].includes(s)
   }
 
-  return {
+  return withCodeFilter({
     name: 'unhead:use-seo-meta-transform',
     enforce: 'post',
 
@@ -370,5 +371,5 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
         }
       }
     },
-  }
+  }, /\buse(?:Server)?SeoMeta\b/)
 })

--- a/packages/bundler/src/unplugin/utils.ts
+++ b/packages/bundler/src/unplugin/utils.ts
@@ -1,0 +1,14 @@
+import type { UnpluginOptions } from 'unplugin'
+
+export function withCodeFilter(plugin: UnpluginOptions, code: RegExp): UnpluginOptions {
+  if (typeof plugin.transform !== 'function')
+    return plugin
+
+  return {
+    ...plugin,
+    transform: {
+      filter: { code },
+      handler: plugin.transform,
+    },
+  }
+}

--- a/packages/bundler/test/minifyTransform.test.ts
+++ b/packages/bundler/test/minifyTransform.test.ts
@@ -15,7 +15,8 @@ async function transform(code: string | string[], opts: { js?: false | MinifyFn,
   const plugin = MinifyTransform.vite(opts) as any
   if (plugin.transformInclude && !plugin.transformInclude(id))
     return undefined
-  const res = await plugin.transform.call(
+  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
+  const res = await handler.call(
     {},
     Array.isArray(code) ? code.join('\n') : code,
     id,
@@ -24,6 +25,11 @@ async function transform(code: string | string[], opts: { js?: false | MinifyFn,
 }
 
 describe('minifyTransform', () => {
+  it('filters modules without head composables', () => {
+    const plugin = MinifyTransform.vite({ js: mockJSMinifier }) as any
+    expect(plugin.transform.filter.code).toEqual(/\buse(?:Server)?Head\b/)
+  })
+
   it('minifies inline script innerHTML with provided js minifier', async () => {
     const code = await transform([
       `import { useHead } from 'unhead'`,

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -6,7 +6,8 @@ const TITLE_RE = /title:/
 
 async function transform(code: string | string[], id = 'some-id.js', opts: any = {}) {
   const plugin = UseSeoMetaTransform.vite(opts) as any
-  const res = await plugin.transform.call(
+  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
+  const res = await handler.call(
     {},
     Array.isArray(code) ? code.join('\n') : code,
     id,
@@ -43,6 +44,11 @@ describe('useSeoMetaTransform', () => {
     'import { useSeoMeta } from \'unhead\'',
     'useSeoMeta({ title: \'Hello\', description: \'World\' })',
   ]
+
+  it('filters modules without seo meta composables', () => {
+    const plugin = UseSeoMetaTransform.vite({}) as any
+    expect(plugin.transform.filter.code).toEqual(/\buse(?:Server)?SeoMeta\b/)
+  })
 
   it('ignores non-JS files', async () => {
     expect(await transform(couldTransform, 'test.css')).toBeUndefined()


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/e18e/ecosystem-issues/issues/171

Upstream port from https://github.com/nuxt/nuxt/pull/35396 (as @danielroe suggested)

### 📚 Description

Adds transform hook filters for the minify and SEO meta plugins, reducing Rust<>JS overhead for Rolldown and build time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized bundler transformations with code filtering to run only on files containing relevant composables, reducing unnecessary processing and improving build performance

* **Tests**
  * Added test coverage for new code filtering behavior in minification and SEO metadata transformations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->