### PR TITLE
perf(bundler): reduce unplugin transform overhead

### DIFF
--- a/bench/unplugin-transform.bench.ts
+++ b/bench/unplugin-transform.bench.ts
@@ -2,6 +2,7 @@ import type { MinifyFn } from '../packages/bundler/src/unplugin/MinifyTransform'
 import { bench, describe } from 'vitest'
 import { CreateHeadTransform, createHeadTransformContext } from '../packages/bundler/src/unplugin/CreateHeadTransform'
 import { MinifyTransform } from '../packages/bundler/src/unplugin/MinifyTransform'
+import { SSRStaticReplace } from '../packages/bundler/src/unplugin/SSRStaticReplace'
 import { TreeshakeServerComposables } from '../packages/bundler/src/unplugin/TreeshakeServerComposables'
 import { UseSeoMetaTransform } from '../packages/bundler/src/unplugin/UseSeoMetaTransform'
 import { unheadReactStreamingPlugin } from '../packages/react/src/stream/plugin'
@@ -46,9 +47,19 @@ const treeshakeCode = [
   ...Array.from({ length: 200 }, (_, i) => `useServerHead({ title: 'Page ${i}' });\nuseServerSeoMeta({ description: 'Description ${i}' });`),
 ].join('\n')
 
+const ssrStaticReplaceCode = [
+  `import { createHead } from 'unhead'`,
+  ...Array.from({ length: 200 }, (_, i) => `if (head.ssr) { console.log('server ${i}') }`),
+].join('\n')
+
 const createHeadCode = [
   `import { createHead } from '@unhead/vue/client'`,
   ...Array.from({ length: 120 }, (_, i) => `const head${i} = createHead()`),
+].join('\n')
+
+const unrelatedCode = [
+  `import { ref } from 'vue'`,
+  ...Array.from({ length: 300 }, (_, i) => `export const value${i} = ref(${i})`),
 ].join('\n')
 
 const jsxWithoutHeadCode = [
@@ -74,6 +85,10 @@ function transformHandler(plugin: any) {
 
 async function runPluginTransform(plugin: any, code: string, id: string, context: any = {}) {
   if (plugin.transformInclude && !plugin.transformInclude(id))
+    return undefined
+  const transform = plugin.transform
+  const codeFilter = typeof transform === 'function' ? undefined : transform?.filter?.code
+  if (codeFilter && !codeFilter.test(code))
     return undefined
   return await transformHandler(plugin).call(context, code, id)
 }
@@ -108,6 +123,23 @@ describe('unplugin transform CPU', () => {
   bench('treeshakeServerComposables many calls', async () => {
     const plugin = TreeshakeServerComposables.vite({}) as any
     await runPluginTransform(plugin, treeshakeCode, '/project/src/page.ts')
+  })
+
+  bench('treeshakeServerComposables skip unrelated code', async () => {
+    const plugin = TreeshakeServerComposables.vite({}) as any
+    await runPluginTransform(plugin, unrelatedCode, '/project/src/page.ts')
+  })
+
+  bench('ssrStaticReplace many head.ssr reads', async () => {
+    const plugin = SSRStaticReplace.vite({}) as any
+    plugin.apply({}, { command: 'build', isSsrBuild: false })
+    await runPluginTransform(plugin, ssrStaticReplaceCode, '/project/node_modules/unhead/dist/index.mjs')
+  })
+
+  bench('ssrStaticReplace skip unrelated code', async () => {
+    const plugin = SSRStaticReplace.vite({}) as any
+    plugin.apply({}, { command: 'build', isSsrBuild: false })
+    await runPluginTransform(plugin, unrelatedCode, '/project/node_modules/unhead/dist/index.mjs')
   })
 
   bench('createHeadTransform many createHead calls', async () => {

--- a/bench/unplugin-transform.bench.ts
+++ b/bench/unplugin-transform.bench.ts
@@ -1,0 +1,142 @@
+import type { MinifyFn } from '../packages/bundler/src/unplugin/MinifyTransform'
+import { bench, describe } from 'vitest'
+import { CreateHeadTransform, createHeadTransformContext } from '../packages/bundler/src/unplugin/CreateHeadTransform'
+import { MinifyTransform } from '../packages/bundler/src/unplugin/MinifyTransform'
+import { TreeshakeServerComposables } from '../packages/bundler/src/unplugin/TreeshakeServerComposables'
+import { UseSeoMetaTransform } from '../packages/bundler/src/unplugin/UseSeoMetaTransform'
+import { unheadReactStreamingPlugin } from '../packages/react/src/stream/plugin'
+import { unheadSolidStreamingPlugin } from '../packages/solid-js/src/stream/plugin'
+
+const ids = Array.from({ length: 1_000 }, (_, i) => {
+  if (i % 5 === 0)
+    return `/project/src/page-${i}.vue?type=script`
+  if (i % 5 === 1)
+    return `/project/src/page-${i}.vue?type=template`
+  if (i % 5 === 2)
+    return `/project/src/page-${i}.ts`
+  if (i % 5 === 3)
+    return `/project/node_modules/pkg-${i}/index.js`
+  return `/project/src/page-${i}.css`
+})
+
+const seoCode = [
+  `import { useSeoMeta } from 'unhead'`,
+  ...Array.from({ length: 80 }, (_, i) => `useSeoMeta({
+  title: 'Page ${i}',
+  description: 'Description ${i}',
+  ogImage: { url: '/og-${i}.png', width: 1200, height: 630, alt: 'Image ${i}' },
+  appleItunesApp: { appId: '${i}', appArgument: 'app-${i}' },
+})`),
+].join('\n')
+
+const minifyCode = [
+  `import { useHead } from 'unhead'`,
+  `useHead({`,
+  `  script: [`,
+  ...Array.from({ length: 40 }, (_, i) => `    { innerHTML: '// comment ${i}\\nvar value${i} = ${i};  var other${i} = value${i} + 1;' },`),
+  `  ],`,
+  `  style: [`,
+  ...Array.from({ length: 40 }, (_, i) => `    { innerHTML: '/* comment ${i} */ .class-${i} { color: red; margin: 0; padding: 0; }' },`),
+  `  ],`,
+  `})`,
+].join('\n')
+
+const treeshakeCode = [
+  `import { useServerHead, useServerSeoMeta } from 'unhead'`,
+  ...Array.from({ length: 200 }, (_, i) => `useServerHead({ title: 'Page ${i}' });\nuseServerSeoMeta({ description: 'Description ${i}' });`),
+].join('\n')
+
+const createHeadCode = [
+  `import { createHead } from '@unhead/vue/client'`,
+  ...Array.from({ length: 120 }, (_, i) => `const head${i} = createHead()`),
+].join('\n')
+
+const jsxWithoutHeadCode = [
+  `import React from 'react'`,
+  ...Array.from({ length: 160 }, (_, i) => `export function Component${i}() { return <main><h1>Page ${i}</h1></main> }`),
+].join('\n')
+
+const jsxWithHeadCode = [
+  `import React from 'react'`,
+  `import { useHead } from '@unhead/react'`,
+  ...Array.from({ length: 80 }, (_, i) => `export function Component${i}() { useHead({ title: 'Page ${i}' }); return <main><h1>Page ${i}</h1></main> }`),
+].join('\n')
+
+const mockJSMinifier: MinifyFn = async code =>
+  code.replace(/\/\/.*$/gm, '').replace(/\s+/g, ' ').trim()
+
+const mockCSSMinifier: MinifyFn = async code =>
+  code.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\s+/g, ' ').trim()
+
+function transformHandler(plugin: any) {
+  return typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
+}
+
+async function runPluginTransform(plugin: any, code: string, id: string, context: any = {}) {
+  if (plugin.transformInclude && !plugin.transformInclude(id))
+    return undefined
+  return await transformHandler(plugin).call(context, code, id)
+}
+
+describe('unplugin transform CPU', () => {
+  bench('transformInclude mixed ids', () => {
+    const seo = UseSeoMetaTransform.vite({}) as any
+    const minify = MinifyTransform.vite({ js: mockJSMinifier, css: mockCSSMinifier }) as any
+    const treeshake = TreeshakeServerComposables.vite({}) as any
+    let included = 0
+    for (const id of ids) {
+      if (seo.transformInclude(id))
+        included++
+      if (minify.transformInclude(id))
+        included++
+      if (treeshake.transformInclude(id))
+        included++
+    }
+    return included
+  })
+
+  bench('useSeoMetaTransform static calls', async () => {
+    const plugin = UseSeoMetaTransform.vite({}) as any
+    await runPluginTransform(plugin, seoCode, '/project/src/page.ts')
+  })
+
+  bench('minifyTransform inline script/style', async () => {
+    const plugin = MinifyTransform.vite({ js: mockJSMinifier, css: mockCSSMinifier }) as any
+    await runPluginTransform(plugin, minifyCode, '/project/src/page.ts')
+  })
+
+  bench('treeshakeServerComposables many calls', async () => {
+    const plugin = TreeshakeServerComposables.vite({}) as any
+    await runPluginTransform(plugin, treeshakeCode, '/project/src/page.ts')
+  })
+
+  bench('createHeadTransform many createHead calls', async () => {
+    const ctx = createHeadTransformContext()
+    ctx.addRuntimePlugin({
+      import: { name: 'ValidatePlugin', source: '@unhead/vue/plugins', as: '__validate' },
+      client: '_h.use(__validate({ root: __ROOT__ }))',
+    })
+    ctx.addRuntimePlugin({
+      import: { name: 'devtoolsPlugin', source: '@unhead/bundler', as: '__devtools' },
+      client: 'window.__unhead_devtools__=_h',
+    })
+    const plugin = CreateHeadTransform(ctx) as any
+    plugin.configResolved({ root: '/project' })
+    await plugin.transform.handler.call({ environment: { config: { consumer: 'client' } } }, createHeadCode, '/project/src/head.ts')
+  })
+
+  bench('react streaming skip JSX without head calls', async () => {
+    const plugin = unheadReactStreamingPlugin.vite({}) as any
+    await plugin.transform.handler.call({ environment: { name: 'client' } }, jsxWithoutHeadCode, '/project/src/page.tsx')
+  })
+
+  bench('react streaming transform JSX with head calls', async () => {
+    const plugin = unheadReactStreamingPlugin.vite({}) as any
+    await plugin.transform.handler.call({ environment: { name: 'client' } }, jsxWithHeadCode, '/project/src/page.tsx')
+  })
+
+  bench('solid streaming skip JSX without head calls', async () => {
+    const plugin = unheadSolidStreamingPlugin.vite({}) as any
+    await plugin.transform.handler.call({ environment: { name: 'client' } }, jsxWithoutHeadCode, '/project/src/page.tsx')
+  })
+})

--- a/packages/bundler/src/unplugin/CreateHeadTransform.ts
+++ b/packages/bundler/src/unplugin/CreateHeadTransform.ts
@@ -56,6 +56,13 @@ export function CreateHeadTransform(ctx: HeadTransformContext): Plugin {
         if (!envRegistrations.length)
           return
 
+        const rootLiteral = JSON.stringify(root)
+        const statements = envRegistrations
+          .map(r => (isServer ? r.server! : r.client!).replace(/__ROOT__/g, rootLiteral))
+          .join(',')
+        const imports = envRegistrations
+          .map(reg => `import { ${reg.import.name} as ${reg.import.as} } from '${reg.import.source}';\n`)
+          .join('')
         const s = new MagicString(code)
         let transformed = false
         const directCreateHeadNames = new Set<string>()
@@ -91,10 +98,6 @@ export function CreateHeadTransform(ctx: HeadTransformContext): Plugin {
             if (!isDirect && !isNamespaced)
               return
 
-            const statements = envRegistrations
-              .map(r => (isServer ? r.server! : r.client!).replace(/__ROOT__/g, JSON.stringify(root)))
-              .join(',')
-
             s.prependLeft(node.start, `((_h)=>(${statements},_h))(`)
             s.appendRight(node.end, `)`)
             transformed = true
@@ -104,9 +107,7 @@ export function CreateHeadTransform(ctx: HeadTransformContext): Plugin {
         if (!transformed)
           return
 
-        for (const reg of envRegistrations) {
-          s.prepend(`import { ${reg.import.name} as ${reg.import.as} } from '${reg.import.source}';\n`)
-        }
+        s.prepend(imports)
 
         return {
           code: s.toString(),

--- a/packages/bundler/src/unplugin/MinifyTransform.ts
+++ b/packages/bundler/src/unplugin/MinifyTransform.ts
@@ -1,12 +1,10 @@
 import type { SourceMapInput } from 'rollup'
 import type { BaseTransformerTypes } from './types'
-import { pathToFileURL } from 'node:url'
 import MagicString from 'magic-string'
 import { parseSync } from 'oxc-parser'
 import { ScopeTracker, ScopeTrackerImport, walk } from 'oxc-walker'
-import { parseQuery, parseURL } from 'ufo'
 import { createUnplugin } from 'unplugin'
-import { withCodeFilter } from './utils'
+import { isVueScriptRequest, splitTransformId, withCodeFilter } from './utils'
 
 const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
@@ -68,8 +66,7 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
     enforce: 'post',
 
     transformInclude(id) {
-      const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-      const { type } = parseQuery(search)
+      const { pathname, query } = splitTransformId(id)
 
       if (NODE_MODULES_RE.test(pathname))
         return false
@@ -81,7 +78,7 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
         return false
 
       // vue files
-      if (pathname.endsWith('.vue') && (type === 'script' || !search))
+      if (isVueScriptRequest(pathname, query))
         return true
 
       // js/ts files

--- a/packages/bundler/src/unplugin/SSRStaticReplace.ts
+++ b/packages/bundler/src/unplugin/SSRStaticReplace.ts
@@ -1,6 +1,7 @@
 import type { ConfigEnv, UserConfig } from 'vite'
 import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
+import { withCodeFilter } from './utils'
 
 const UNHEAD_MODULE_RE = /[\\/]node_modules[\\/](?:@unhead[\\/][^\\/]+|unhead)[\\/]/
 const HEAD_SSR_RE = /\bhead\.ssr\b/g
@@ -10,7 +11,7 @@ export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() 
   let ssr = false
   let enabled = true
 
-  return {
+  return withCodeFilter({
     name: 'unhead:ssr-static-replace',
     enforce: 'pre',
 
@@ -58,5 +59,5 @@ export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() 
         return true
       },
     },
-  }
+  }, /\bhead\.ssr\b/)
 })

--- a/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
+++ b/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
@@ -1,11 +1,10 @@
 import type { ConfigEnv, UserConfig } from 'vite'
 import type { BaseTransformerTypes } from './types'
-import { pathToFileURL } from 'node:url'
 import MagicString from 'magic-string'
 import { parseSync } from 'oxc-parser'
 import { walk } from 'oxc-walker'
-import { parseQuery, parseURL } from 'ufo'
 import { createUnplugin } from 'unplugin'
+import { isVueScriptRequest, splitTransformId } from './utils'
 
 const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
@@ -37,8 +36,7 @@ export const TreeshakeServerComposables = createUnplugin<TreeshakeServerComposab
       if (!options.enabled)
         return false
 
-      const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-      const { type } = parseQuery(search)
+      const { pathname, query } = splitTransformId(id)
 
       if (NODE_MODULES_RE.test(pathname))
         return false
@@ -52,7 +50,7 @@ export const TreeshakeServerComposables = createUnplugin<TreeshakeServerComposab
         return false
 
       // vue files
-      if (pathname.endsWith('.vue') && (type === 'script' || !search))
+      if (isVueScriptRequest(pathname, query))
         return true
 
       // js files

--- a/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
+++ b/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
@@ -4,7 +4,7 @@ import MagicString from 'magic-string'
 import { parseSync } from 'oxc-parser'
 import { walk } from 'oxc-walker'
 import { createUnplugin } from 'unplugin'
-import { isVueScriptRequest, splitTransformId } from './utils'
+import { isVueScriptRequest, splitTransformId, withCodeFilter } from './utils'
 
 const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
@@ -27,7 +27,7 @@ export interface TreeshakeServerComposablesOptions extends BaseTransformerTypes 
 export const TreeshakeServerComposables = createUnplugin<TreeshakeServerComposablesOptions, false>((options: TreeshakeServerComposablesOptions = {}) => {
   options.enabled = options.enabled !== undefined ? options.enabled : true
 
-  return {
+  return withCodeFilter({
     name: 'unhead:remove-server-composables',
     enforce: 'post',
 
@@ -106,5 +106,5 @@ export const TreeshakeServerComposables = createUnplugin<TreeshakeServerComposab
         return false
       },
     },
-  }
+  }, /\b(?:useServerHead|useServerHeadSafe|useServerSeoMeta|useSchemaOrg)\b/)
 })

--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -1,18 +1,16 @@
 import type { SourceMapInput } from 'rollup'
 import type { BaseTransformerTypes } from './types'
-import { pathToFileURL } from 'node:url'
 import { createContext, runInContext } from 'node:vm'
 import MagicString from 'magic-string'
 import { parseSync } from 'oxc-parser'
 import { ScopeTracker, ScopeTrackerImport, walk } from 'oxc-walker'
-import { parseQuery, parseURL } from 'ufo'
 import {
   resolveMetaKeyType,
   resolveMetaKeyValue,
   resolvePackedMetaObjectValue,
 } from 'unhead/utils'
 import { createUnplugin } from 'unplugin'
-import { withCodeFilter } from './utils'
+import { isVueScriptRequest, splitTransformId, withCodeFilter } from './utils'
 
 const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
@@ -53,12 +51,13 @@ const MEDIA_KEYS = new Set(['ogImage', 'ogVideo', 'ogAudio', 'twitterImage'])
  */
 export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, false>((options: UseSeoMetaTransformOptions = {}) => {
   options.imports = options.imports || true
+  const importPaths = options.importPaths?.length ? new Set(options.importPaths) : undefined
 
   function isValidPackage(s: string) {
     if (s === 'unhead' || s.startsWith('@unhead')) {
       return true
     }
-    return [...(options.importPaths || [])].includes(s)
+    return importPaths?.has(s) === true
   }
 
   return withCodeFilter({
@@ -66,8 +65,7 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
     enforce: 'post',
 
     transformInclude(id) {
-      const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-      const { type } = parseQuery(search)
+      const { pathname, query } = splitTransformId(id)
 
       if (NODE_MODULES_RE.test(pathname))
         return false
@@ -81,7 +79,7 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
         return false
 
       // vue files
-      if (pathname.endsWith('.vue') && (type === 'script' || !search))
+      if (isVueScriptRequest(pathname, query))
         return true
 
       // js files

--- a/packages/bundler/src/unplugin/utils.ts
+++ b/packages/bundler/src/unplugin/utils.ts
@@ -1,5 +1,36 @@
 import type { UnpluginOptions } from 'unplugin'
 
+export function splitTransformId(id: string): { pathname: string, query: string } {
+  const queryIndex = id.indexOf('?')
+  return queryIndex === -1
+    ? { pathname: id, query: '' }
+    : { pathname: id.slice(0, queryIndex), query: id.slice(queryIndex + 1) }
+}
+
+export function getQueryValue(query: string, key: string): string | undefined {
+  const keyLength = key.length
+  let start = 0
+  while (start < query.length) {
+    const ampIndex = query.indexOf('&', start)
+    const end = ampIndex === -1 ? query.length : ampIndex
+    const eqIndex = query.indexOf('=', start)
+
+    if (eqIndex === -1 || eqIndex > end) {
+      if (end - start === keyLength && query.startsWith(key, start))
+        return ''
+    }
+    else if (eqIndex - start === keyLength && query.startsWith(key, start)) {
+      return query.slice(eqIndex + 1, end)
+    }
+
+    start = end + 1
+  }
+}
+
+export function isVueScriptRequest(pathname: string, query: string): boolean {
+  return pathname.endsWith('.vue') && (!query || getQueryValue(query, 'type') === 'script')
+}
+
 export function withCodeFilter(plugin: UnpluginOptions, code: RegExp): UnpluginOptions {
   if (typeof plugin.transform !== 'function')
     return plugin

--- a/packages/bundler/test/ssrStaticReplace.test.ts
+++ b/packages/bundler/test/ssrStaticReplace.test.ts
@@ -11,7 +11,8 @@ function createPlugin(env: { isSsrBuild?: boolean, command?: string } = {}) {
 function transform(plugin: any, code: string, id: string) {
   if (plugin.transformInclude && !plugin.transformInclude(id))
     return undefined
-  return plugin.transform(code, id)
+  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
+  return handler.call({}, code, id)
 }
 
 const UNHEAD_MODULE_ID = '/node_modules/@unhead/vue/dist/index.mjs'
@@ -24,6 +25,11 @@ describe('ssrStaticReplace', () => {
     expect(plugin.transformInclude(USER_MODULE_ID)).toBe(false)
     expect(plugin.transformInclude('/node_modules/unhead/dist/index.mjs')).toBe(true)
     expect(plugin.transformInclude('/src/components/Head.vue')).toBe(false)
+  })
+
+  it('uses a code filter for head.ssr', () => {
+    const plugin = createPlugin()
+    expect(plugin.transform.filter.code).toEqual(/\bhead\.ssr\b/)
   })
 
   it('replaces head.ssr with false for client builds', () => {

--- a/packages/bundler/test/treeshakeServerComposables.test.ts
+++ b/packages/bundler/test/treeshakeServerComposables.test.ts
@@ -5,7 +5,10 @@ const USE_SERVER_HEAD_RE = /useServerHead/
 
 async function transform(code: string | string[], id = 'some-id.js') {
   const plugin = TreeshakeServerComposables.vite({}) as any
-  const res = await plugin.transform.call(
+  if (plugin.transformInclude && !plugin.transformInclude(id))
+    return
+  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
+  const res = await handler.call(
     {},
     Array.isArray(code) ? code.join('\n') : code,
     id,
@@ -18,6 +21,11 @@ describe('treeshakeServerComposables', () => {
     'import { useServerHead } from \'unhead\'',
     'useServerHead({ title: \'Hello\', description: \'World\' })',
   ]
+
+  it('uses a code filter for server-only composables', () => {
+    const plugin = TreeshakeServerComposables.vite({}) as any
+    expect(plugin.transform.filter.code).toEqual(/\b(?:useServerHead|useServerHeadSafe|useServerSeoMeta|useSchemaOrg)\b/)
+  })
 
   it('ignores non-JS files', async () => {
     expect(await transform(couldTransform, 'test.css')).toBeUndefined()

--- a/packages/react/src/stream/plugin.ts
+++ b/packages/react/src/stream/plugin.ts
@@ -6,6 +6,10 @@ import { createUnplugin } from 'unplugin'
 
 const FILTER_RE = /\.[jt]sx$/
 
+function hasHeadComposable(code: string): boolean {
+  return code.includes('useHead') || code.includes('useSeoMeta') || code.includes('useHeadSafe')
+}
+
 /**
  * Transforms React/JSX code to inject HeadStream components for streaming SSR support.
  *
@@ -16,6 +20,9 @@ const FILTER_RE = /\.[jt]sx$/
  * @returns `true` if transformations were applied, `false` otherwise
  */
 function transform(code: string, id: string, isSSR: boolean, s: MagicString): boolean {
+  if (!hasHeadComposable(code))
+    return false
+
   const lang = id.endsWith('.tsx') ? 'tsx' : id.endsWith('.jsx') ? 'jsx' : 'tsx'
 
   const returns: { jsxStart: number, jsxEnd: number }[] = []
@@ -54,7 +61,7 @@ function transform(code: string, id: string, isSSR: boolean, s: MagicString): bo
           return
         }
         const bodyCode = code.slice(node.body.start, node.body.end)
-        currentFnHasHead = bodyCode.includes('useHead') || bodyCode.includes('useSeoMeta') || bodyCode.includes('useHeadSafe')
+        currentFnHasHead = hasHeadComposable(bodyCode)
 
         if (currentFnHasHead && (node.body.type === 'JSXElement' || node.body.type === 'JSXFragment')) {
           returns.push({ jsxStart: node.body.start, jsxEnd: node.body.end })
@@ -125,6 +132,9 @@ export const unheadReactStreamingPlugin = createUnplugin<UnheadReactStreamingOpt
     filter: FILTER_RE,
     mode: options.mode,
     transform(code, id, opts) {
+      if (!hasHeadComposable(code))
+        return null
+
       const s = new MagicString(code)
       if (!transform(code, id, opts?.ssr ?? false, s))
         return null

--- a/packages/solid-js/src/stream/plugin.ts
+++ b/packages/solid-js/src/stream/plugin.ts
@@ -6,7 +6,14 @@ import { createUnplugin } from 'unplugin'
 
 const FILTER_RE = /\.[jt]sx$/
 
+function hasHeadComposable(code: string): boolean {
+  return code.includes('useHead') || code.includes('useSeoMeta') || code.includes('useHeadSafe')
+}
+
 function transform(code: string, id: string, isSSR: boolean, s: MagicString): boolean {
+  if (!hasHeadComposable(code))
+    return false
+
   const lang = id.endsWith('.tsx') ? 'tsx' : id.endsWith('.jsx') ? 'jsx' : 'tsx'
 
   const returns: { jsxStart: number, jsxEnd: number }[] = []
@@ -45,7 +52,7 @@ function transform(code: string, id: string, isSSR: boolean, s: MagicString): bo
           return
         }
         const bodyCode = code.slice(node.body.start, node.body.end)
-        currentFnHasHead = bodyCode.includes('useHead') || bodyCode.includes('useSeoMeta') || bodyCode.includes('useHeadSafe')
+        currentFnHasHead = hasHeadComposable(bodyCode)
 
         if (currentFnHasHead && (node.body.type === 'JSXElement' || node.body.type === 'JSXFragment')) {
           returns.push({ jsxStart: node.body.start, jsxEnd: node.body.end })
@@ -110,6 +117,9 @@ export const unheadSolidStreamingPlugin = createUnplugin<UnheadSolidStreamingOpt
     filter: FILTER_RE,
     mode: options.mode,
     transform(code, id, opts) {
+      if (!hasHeadComposable(code))
+        return null
+
       const s = new MagicString(code)
       if (!transform(code, id, opts?.ssr ?? false, s))
         return null

--- a/packages/svelte/src/stream/plugin.ts
+++ b/packages/svelte/src/stream/plugin.ts
@@ -8,8 +8,12 @@ const SCRIPT_CLOSE_RE = /<\/script>/
 const SCRIPT_RE = /<script[^>]*>/i
 const FILTER_RE = /\.svelte$/
 
+function hasHeadComposable(code: string): boolean {
+  return code.includes('useHead') || code.includes('useSeoMeta') || code.includes('useHeadSafe')
+}
+
 function transform(code: string, id: string, isSSR: boolean, s: MagicString): boolean {
-  if (!code.includes('useHead') && !code.includes('useSeoMeta') && !code.includes('useHeadSafe'))
+  if (!hasHeadComposable(code))
     return false
 
   const scriptCloseMatch = code.match(SCRIPT_CLOSE_RE)
@@ -70,6 +74,9 @@ export const unheadSvelteStreamingPlugin = createUnplugin<UnheadSvelteStreamingO
     filter: FILTER_RE,
     mode: options.mode,
     transform(code, id, opts) {
+      if (!hasHeadComposable(code))
+        return null
+
       const s = new MagicString(code)
       if (!transform(code, id, opts?.ssr ?? false, s))
         return null


### PR DESCRIPTION
### 🔗 Linked issue

None

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Speeds up the unplugin hot paths by replacing URL parsing in `transformInclude` with simple id/query parsing and skipping React/Solid/Svelte streaming AST work when files have no head composables.

Adds native code filters for the remaining server-composable and `head.ssr` transforms, while keeping the existing in-handler guards for bundlers that do not apply transform filters. Includes a Vitest benchmark for the transform filters, create-head wrapping, minify transform, SSR replacement, and streaming skip paths.

### 📊 Benchmarks

Ran locally with:

```bash
pnpm vitest bench bench/unplugin-transform.bench.ts --run
```

Vitest bench reports mean time per sample. Latest run on `perf/unplugin-cpu`:

| Case | Mean |
| --- | ---: |
| `transformInclude mixed ids` | `0.1281ms` |
| `useSeoMetaTransform static calls` | `1.4683ms` |
| `minifyTransform inline script/style` | `0.2526ms` |
| `treeshakeServerComposables many calls` | `1.3443ms` |
| `treeshakeServerComposables skip unrelated code` | `0.0009ms` |
| `ssrStaticReplace many head.ssr reads` | `0.1709ms` |
| `ssrStaticReplace skip unrelated code` | `0.0009ms` |
| `createHeadTransform many createHead calls` | `0.3197ms` |
| `react streaming skip JSX without head calls` | `0.0106ms` |
| `react streaming transform JSX with head calls` | `0.8371ms` |
| `solid streaming skip JSX without head calls` | `0.0107ms` |

Headline before/after from the initial baseline in this branch work:

| Case | Before | After | Change |
| --- | ---: | ---: | ---: |
| `transformInclude mixed ids` | `4.6990ms` | `0.1281ms` | `36.7x` faster |
| `react streaming skip JSX without head calls` | `0.9437ms` | `0.0106ms` | `89.0x` faster |
| `solid streaming skip JSX without head calls` | `0.9346ms` | `0.0107ms` | `87.3x` faster |
| `createHeadTransform many createHead calls` | `0.3569ms` | `0.3197ms` | `1.1x` faster |