### PR TITLE
perf(bundler): add further transform hook filters

### DIFF
--- a/packages/bundler/src/devtools/vite.ts
+++ b/packages/bundler/src/devtools/vite.ts
@@ -11,6 +11,7 @@ import { parseAndWalk } from 'oxc-walker'
 import { getConfigRpc, runLintRpc } from './rpc'
 
 const HEAD_COMPOSABLES = ['useHead', 'useSeoMeta', 'useHeadSafe', 'useScript']
+const HEAD_COMPOSABLE_RE = /useHead|useSeoMeta|useScript/
 const FILE_RE = /\.(vue|tsx?|jsx?|svelte)$/
 const LEADING_SLASH_RE = /^\//
 const UNHEAD_VERSION_RE = /__UNHEAD_VERSION__ = ['"]'?["']/
@@ -41,7 +42,7 @@ const DEVTOOLS_UI_ROUTE = '/__unhead/'
  * Transforms source code to inject `_source` metadata into head composable calls.
  */
 function transformSourceLocations(code: string, id: string, root: string): { code: string, map: any } | undefined {
-  if (!HEAD_COMPOSABLES.some(c => code.includes(c)))
+  if (!HEAD_COMPOSABLE_RE.test(code))
     return
 
   const s = new MagicString(code)
@@ -182,7 +183,7 @@ export function unheadDevtools(options?: UnheadDevtoolsInternalOptions): Plugin 
     },
 
     transform: {
-      filter: { id: FILE_RE },
+      filter: { id: FILE_RE, code: HEAD_COMPOSABLE_RE },
       handler(code, id) {
         if (!enabled)
           return

--- a/packages/bundler/src/devtools/vite.ts
+++ b/packages/bundler/src/devtools/vite.ts
@@ -11,7 +11,7 @@ import { parseAndWalk } from 'oxc-walker'
 import { getConfigRpc, runLintRpc } from './rpc'
 
 const HEAD_COMPOSABLES = ['useHead', 'useSeoMeta', 'useHeadSafe', 'useScript']
-const HEAD_COMPOSABLE_RE = /useHead|useSeoMeta|useScript/
+const HEAD_COMPOSABLE_RE = new RegExp(`\\b(?:${HEAD_COMPOSABLES.join('|')})\\b`)
 const FILE_RE = /\.(vue|tsx?|jsx?|svelte)$/
 const LEADING_SLASH_RE = /^\//
 const UNHEAD_VERSION_RE = /__UNHEAD_VERSION__ = ['"]'?["']/

--- a/packages/bundler/src/unplugin/CreateHeadTransform.ts
+++ b/packages/bundler/src/unplugin/CreateHeadTransform.ts
@@ -3,6 +3,7 @@ import MagicString from 'magic-string'
 import { parseAndWalk } from 'oxc-walker'
 
 const FILE_RE = /\.(vue|tsx?|jsx?|svelte)$/
+const CREATE_HEAD_RE = /createHead/
 const UNHEAD_SOURCE_RE = /^(?:@unhead\/[^/]+|unhead)(?:\/[^?]*)?$/
 
 export interface RuntimePluginRegistration {
@@ -43,12 +44,12 @@ export function CreateHeadTransform(ctx: HeadTransformContext): Plugin {
     },
 
     transform: {
-      filter: { id: FILE_RE },
+      filter: { id: FILE_RE, code: CREATE_HEAD_RE },
       handler(code, id) {
         const registrations = ctx.getRegistrations()
         if (!registrations.length)
           return
-        if (!code.includes('createHead'))
+        if (!CREATE_HEAD_RE.test(code))
           return
 
         const isServer = this.environment?.config?.consumer === 'server'

--- a/packages/bundler/src/unplugin/MinifyTransform.ts
+++ b/packages/bundler/src/unplugin/MinifyTransform.ts
@@ -4,10 +4,10 @@ import MagicString from 'magic-string'
 import { parseSync } from 'oxc-parser'
 import { ScopeTracker, ScopeTrackerImport, walk } from 'oxc-walker'
 import { createUnplugin } from 'unplugin'
-import { isVueScriptRequest, splitTransformId, withCodeFilter } from './utils'
+import { createJsVueTransformIdFilter, isVueScriptRequest, NODE_MODULES_RE, splitTransformId } from './utils'
 
-const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
+const HEAD_RE = /\buse(?:Server)?Head\b/
 
 const SKIP_JS_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
 const HEAD_FN_NAMES = new Set(['useHead', 'useServerHead'])
@@ -61,117 +61,131 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
     style: new Map(),
   }
 
-  return withCodeFilter({
+  function shouldTransformId(id: string): boolean {
+    const { pathname, query } = splitTransformId(id)
+
+    if (NODE_MODULES_RE.test(pathname))
+      return false
+
+    if (options.filter?.include?.some(pattern => id.match(pattern)))
+      return true
+
+    if (options.filter?.exclude?.some(pattern => id.match(pattern)))
+      return false
+
+    // vue files
+    if (isVueScriptRequest(pathname, query))
+      return true
+
+    // js/ts files
+    if (TRANSFORM_RE.test(pathname))
+      return true
+
+    return false
+  }
+
+  function shouldTransformCode(code: string): boolean {
+    return HEAD_RE.test(code)
+  }
+
+  return {
     name: 'unhead:minify-transform',
     enforce: 'post',
+    transformInclude: shouldTransformId,
 
-    transformInclude(id) {
-      const { pathname, query } = splitTransformId(id)
+    transform: {
+      filter: {
+        code: HEAD_RE,
+        id: createJsVueTransformIdFilter(options.filter?.include),
+      },
+      async handler(code, id) {
+        if (!shouldTransformId(id))
+          return
 
-      if (NODE_MODULES_RE.test(pathname))
-        return false
+        if (!shouldTransformCode(code))
+          return
 
-      if (options.filter?.include?.some(pattern => id.match(pattern)))
-        return true
+        // Escaped identifiers still need parsing because their source does not
+        // contain the decoded property name.
+        if (!CONTENT_PROP_NAMES.some(name => code.includes(name)) && !code.includes('\\u'))
+          return
 
-      if (options.filter?.exclude?.some(pattern => id.match(pattern)))
-        return false
+        let ast
+        try {
+          ast = parseSync(id, code)
+        }
+        catch {
+          return
+        }
 
-      // vue files
-      if (isVueScriptRequest(pathname, query))
-        return true
+        const scopeTracker = new ScopeTracker()
+        const pendingMinifications: PendingMinification[] = []
 
-      // js/ts files
-      if (TRANSFORM_RE.test(pathname))
-        return true
+        walk(ast.program, {
+          scopeTracker,
+          enter(node: any, _parent: any) {
+            if (node.type !== 'CallExpression')
+              return
 
-      return false
-    },
+            if (!resolveHeadFunctionName(node.callee, scopeTracker))
+              return
 
-    async transform(code, id) {
-      if (!code.includes('useHead') && !code.includes('useServerHead'))
-        return
+            const arg = node.arguments[0]
+            if (!arg || arg.type !== 'ObjectExpression')
+              return
 
-      // Escaped identifiers still need parsing because their source does not
-      // contain the decoded property name.
-      if (!CONTENT_PROP_NAMES.some(name => code.includes(name)) && !code.includes('\\u'))
-        return
-
-      let ast
-      try {
-        ast = parseSync(id, code)
-      }
-      catch {
-        return
-      }
-
-      const scopeTracker = new ScopeTracker()
-      const pendingMinifications: PendingMinification[] = []
-
-      walk(ast.program, {
-        scopeTracker,
-        enter(node: any, _parent: any) {
-          if (node.type !== 'CallExpression')
-            return
-
-          if (!resolveHeadFunctionName(node.callee, scopeTracker))
-            return
-
-          const arg = node.arguments[0]
-          if (!arg || arg.type !== 'ObjectExpression')
-            return
-
-          // look for script: [...] and style: [...] properties
-          for (const prop of arg.properties) {
-            if (prop.type !== 'Property' || prop.key?.type !== 'Identifier')
-              continue
-
-            const tagType = prop.key.name
-            if (tagType !== 'script' && tagType !== 'style')
-              continue
-
-            if (tagType === 'script' && !doJS)
-              continue
-            if (tagType === 'style' && !doCSS)
-              continue
-
-            // handle both array and single object: script: [{ innerHTML: '...' }] or script: { innerHTML: '...' }
-            const elements = prop.value?.type === 'ArrayExpression'
-              ? prop.value.elements
-              : [prop.value]
-
-            for (const element of elements) {
-              if (!element || element.type !== 'ObjectExpression')
+            // look for script: [...] and style: [...] properties
+            for (const prop of arg.properties) {
+              if (prop.type !== 'Property' || prop.key?.type !== 'Identifier')
                 continue
 
-              processScriptOrStyleObject(element, tagType, pendingMinifications)
+              const tagType = prop.key.name
+              if (tagType !== 'script' && tagType !== 'style')
+                continue
+
+              if (tagType === 'script' && !doJS)
+                continue
+              if (tagType === 'style' && !doCSS)
+                continue
+
+              // handle both array and single object: script: [{ innerHTML: '...' }] or script: { innerHTML: '...' }
+              const elements = prop.value?.type === 'ArrayExpression'
+                ? prop.value.elements
+                : [prop.value]
+
+              for (const element of elements) {
+                if (!element || element.type !== 'ObjectExpression')
+                  continue
+
+                processScriptOrStyleObject(element, tagType, pendingMinifications)
+              }
             }
-          }
-        },
-      })
+          },
+        })
 
-      if (!pendingMinifications.length)
-        return
+        if (!pendingMinifications.length)
+          return
 
-      const minified = await Promise.all(pendingMinifications.map(pending => pending.minified))
-      const s = new MagicString(code)
+        const minified = await Promise.all(pendingMinifications.map(pending => pending.minified))
+        const s = new MagicString(code)
 
-      for (let i = 0; i < pendingMinifications.length; i++) {
-        const pending = pendingMinifications[i]
-        const result = minified[i]
-        if (result && result.length < pending.raw.length)
-          s.overwrite(pending.start, pending.end, JSON.stringify(result))
-      }
+        for (let i = 0; i < pendingMinifications.length; i++) {
+          const pending = pendingMinifications[i]
+          const result = minified[i]
+          if (result && result.length < pending.raw.length)
+            s.overwrite(pending.start, pending.end, JSON.stringify(result))
+        }
 
-      if (!s.hasChanged())
-        return
+        if (!s.hasChanged())
+          return
 
-      return {
-        code: s.toString(),
-        map: s.generateMap({ includeContent: true, source: id }) as SourceMapInput,
-      }
+        return {
+          code: s.toString(),
+          map: s.generateMap({ includeContent: true, source: id }) as SourceMapInput,
+        }
+      },
     },
-  }, /\buse(?:Server)?Head\b/)
+  }
 
   function resolveHeadFunctionName(callee: any, scopeTracker: ScopeTracker): string | undefined {
     if (callee.type === 'Identifier') {

--- a/packages/bundler/src/unplugin/SSRStaticReplace.ts
+++ b/packages/bundler/src/unplugin/SSRStaticReplace.ts
@@ -4,7 +4,7 @@ import { createUnplugin } from 'unplugin'
 
 const UNHEAD_JS_MODULE_RE = /[\\/]node_modules[\\/](?:@unhead[\\/][^\\/]+|unhead)[\\/].*\.(?:c|m)?js$/
 const HEAD_SSR_FILTER_RE = /\bhead\.ssr\b/
-const HEAD_SSR_RE = /\bhead\.ssr\b/g
+const HEAD_SSR_RE = new RegExp(HEAD_SSR_FILTER_RE.source, 'g')
 
 export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() => {
   let ssr = false

--- a/packages/bundler/src/unplugin/SSRStaticReplace.ts
+++ b/packages/bundler/src/unplugin/SSRStaticReplace.ts
@@ -1,43 +1,54 @@
 import type { ConfigEnv, UserConfig } from 'vite'
 import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
-import { withCodeFilter } from './utils'
 
-const UNHEAD_MODULE_RE = /[\\/]node_modules[\\/](?:@unhead[\\/][^\\/]+|unhead)[\\/]/
+const UNHEAD_JS_MODULE_RE = /[\\/]node_modules[\\/](?:@unhead[\\/][^\\/]+|unhead)[\\/].*\.(?:c|m)?js$/
+const HEAD_SSR_FILTER_RE = /\bhead\.ssr\b/
 const HEAD_SSR_RE = /\bhead\.ssr\b/g
-const JS_RE = /\.(?:c|m)?js$/
 
 export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() => {
   let ssr = false
   let enabled = true
 
-  return withCodeFilter({
+  function shouldTransformId(id: string): boolean {
+    if (!enabled)
+      return false
+    return UNHEAD_JS_MODULE_RE.test(id)
+  }
+
+  function shouldTransformCode(code: string): boolean {
+    return HEAD_SSR_FILTER_RE.test(code)
+  }
+
+  return {
     name: 'unhead:ssr-static-replace',
     enforce: 'pre',
+    transformInclude: shouldTransformId,
 
-    transformInclude(id) {
-      if (!enabled)
-        return false
-      if (!UNHEAD_MODULE_RE.test(id))
-        return false
-      return JS_RE.test(id)
-    },
+    transform: {
+      filter: {
+        code: HEAD_SSR_FILTER_RE,
+        id: UNHEAD_JS_MODULE_RE,
+      },
+      handler(code, id) {
+        if (!shouldTransformId(id))
+          return
 
-    transform(code) {
-      if (!code.includes('head.ssr'))
-        return
+        if (!shouldTransformCode(code))
+          return
 
-      const s = new MagicString(code)
-      for (const match of code.matchAll(HEAD_SSR_RE)) {
-        s.overwrite(match.index!, match.index! + match[0].length, String(ssr))
-      }
-
-      if (s.hasChanged()) {
-        return {
-          code: s.toString(),
-          map: s.generateMap({ includeContent: true }),
+        const s = new MagicString(code)
+        for (const match of code.matchAll(HEAD_SSR_RE)) {
+          s.overwrite(match.index!, match.index! + match[0].length, String(ssr))
         }
-      }
+
+        if (s.hasChanged()) {
+          return {
+            code: s.toString(),
+            map: s.generateMap({ includeContent: true }),
+          }
+        }
+      },
     },
 
     webpack(ctx) {
@@ -59,5 +70,5 @@ export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() 
         return true
       },
     },
-  }, /\bhead\.ssr\b/)
+  }
 })

--- a/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
+++ b/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
@@ -4,10 +4,10 @@ import MagicString from 'magic-string'
 import { parseSync } from 'oxc-parser'
 import { walk } from 'oxc-walker'
 import { createUnplugin } from 'unplugin'
-import { isVueScriptRequest, splitTransformId, withCodeFilter } from './utils'
+import { createJsVueTransformIdFilter, isVueScriptRequest, NODE_MODULES_RE, splitTransformId } from './utils'
 
-const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
+const SERVER_COMPOSABLE_RE = /\b(?:useServerHead|useServerHeadSafe|useServerSeoMeta|useSchemaOrg)\b/
 
 const functionNames = [
   'useServerHead',
@@ -27,71 +27,80 @@ export interface TreeshakeServerComposablesOptions extends BaseTransformerTypes 
 export const TreeshakeServerComposables = createUnplugin<TreeshakeServerComposablesOptions, false>((options: TreeshakeServerComposablesOptions = {}) => {
   options.enabled = options.enabled !== undefined ? options.enabled : true
 
-  return withCodeFilter({
+  function shouldTransformId(id: string): boolean {
+    // should only run on client builds
+    if (!options.enabled)
+      return false
+
+    const { pathname, query } = splitTransformId(id)
+
+    if (NODE_MODULES_RE.test(pathname))
+      return false
+
+    // Included
+    if (options.filter?.include?.some(pattern => id.match(pattern)))
+      return true
+
+    // Excluded
+    if (options.filter?.exclude?.some(pattern => id.match(pattern)))
+      return false
+
+    // vue files
+    if (isVueScriptRequest(pathname, query))
+      return true
+
+    // js files
+    if (TRANSFORM_RE.test(pathname))
+      return true
+
+    return false
+  }
+
+  function shouldTransformCode(code: string): boolean {
+    return SERVER_COMPOSABLE_RE.test(code)
+  }
+
+  return {
     name: 'unhead:remove-server-composables',
     enforce: 'post',
+    transformInclude: shouldTransformId,
 
-    transformInclude(id) {
-      // should only run on client builds
-      if (!options.enabled)
-        return false
+    transform: {
+      filter: {
+        code: SERVER_COMPOSABLE_RE,
+        id: createJsVueTransformIdFilter(options.filter?.include),
+      },
+      handler(code, id) {
+        if (!shouldTransformId(id))
+          return
 
-      const { pathname, query } = splitTransformId(id)
-
-      if (NODE_MODULES_RE.test(pathname))
-        return false
-
-      // Included
-      if (options.filter?.include?.some(pattern => id.match(pattern)))
-        return true
-
-      // Excluded
-      if (options.filter?.exclude?.some(pattern => id.match(pattern)))
-        return false
-
-      // vue files
-      if (isVueScriptRequest(pathname, query))
-        return true
-
-      // js files
-      if (TRANSFORM_RE.test(pathname))
-        return true
-
-      return false
-    },
-
-    transform(code, id) {
-      if (
-        !code.includes('useServerHead')
-        && !code.includes('useServerHeadSafe')
-        && !code.includes('useServerSeoMeta')
-        && !code.includes('useSchemaOrg')
-      ) {
-        return
-      }
-
-      const ast = parseSync(id, code)
-      const s = new MagicString(code)
-
-      walk(ast.program, {
-        enter(node: any) {
-          if (
-            node.type === 'ExpressionStatement'
-            && node.expression.type === 'CallExpression'
-            && node.expression.callee.type === 'Identifier'
-            && functionNames.includes(node.expression.callee.name)
-          ) {
-            s.remove(node.start, node.end)
-          }
-        },
-      })
-
-      if (s.hasChanged()) {
-        return {
-          code: s.toString(),
-          map: s.generateMap({ includeContent: true, source: id }),
+        if (!shouldTransformCode(code)) {
+          return
         }
-      }
+
+        const ast = parseSync(id, code)
+        const s = new MagicString(code)
+
+        walk(ast.program, {
+          enter(node: any) {
+            if (
+              node.type === 'ExpressionStatement'
+              && node.expression.type === 'CallExpression'
+              && node.expression.callee.type === 'Identifier'
+              && functionNames.includes(node.expression.callee.name)
+            ) {
+              s.remove(node.start, node.end)
+            }
+          },
+        })
+
+        if (s.hasChanged()) {
+          return {
+            code: s.toString(),
+            map: s.generateMap({ includeContent: true, source: id }),
+          }
+        }
+      },
     },
     webpack(ctx) {
       if (ctx.name === 'server')
@@ -106,5 +115,5 @@ export const TreeshakeServerComposables = createUnplugin<TreeshakeServerComposab
         return false
       },
     },
-  }, /\b(?:useServerHead|useServerHeadSafe|useServerSeoMeta|useSchemaOrg)\b/)
+  }
 })

--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -10,10 +10,10 @@ import {
   resolvePackedMetaObjectValue,
 } from 'unhead/utils'
 import { createUnplugin } from 'unplugin'
-import { isVueScriptRequest, splitTransformId, withCodeFilter } from './utils'
+import { createJsVueTransformIdFilter, isVueScriptRequest, NODE_MODULES_RE, splitTransformId } from './utils'
 
-const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
+const SEO_META_RE = /\buse(?:Server)?SeoMeta\b/
 
 export interface UseSeoMetaTransformOptions extends BaseTransformerTypes {
   /**
@@ -60,314 +60,328 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
     return importPaths?.has(s) === true
   }
 
-  return withCodeFilter({
+  function shouldTransformId(id: string): boolean {
+    const { pathname, query } = splitTransformId(id)
+
+    if (NODE_MODULES_RE.test(pathname))
+      return false
+
+    // Included
+    if (options.filter?.include?.some(pattern => id.match(pattern)))
+      return true
+
+    // Excluded
+    if (options.filter?.exclude?.some(pattern => id.match(pattern)))
+      return false
+
+    // vue files
+    if (isVueScriptRequest(pathname, query))
+      return true
+
+    // js files
+    if (TRANSFORM_RE.test(pathname))
+      return true
+
+    return false
+  }
+
+  function shouldTransformCode(code: string): boolean {
+    return SEO_META_RE.test(code)
+  }
+
+  return {
     name: 'unhead:use-seo-meta-transform',
     enforce: 'post',
+    transformInclude: shouldTransformId,
 
-    transformInclude(id) {
-      const { pathname, query } = splitTransformId(id)
+    transform: {
+      filter: {
+        code: SEO_META_RE,
+        id: createJsVueTransformIdFilter(options.filter?.include),
+      },
+      async handler(code, id) {
+        if (!shouldTransformId(id))
+          return
 
-      if (NODE_MODULES_RE.test(pathname))
-        return false
+        if (!shouldTransformCode(code))
+          return
 
-      // Included
-      if (options.filter?.include?.some(pattern => id.match(pattern)))
-        return true
+        const scopeTracker = new ScopeTracker()
+        const ast = parseSync(id, code)
+        const s = new MagicString(code)
 
-      // Excluded
-      if (options.filter?.exclude?.some(pattern => id.match(pattern)))
-        return false
+        // Track which ImportDeclarations need specifier rewrites
+        // Key: ImportDeclaration node, Value: set of original imported names that were transformed
+        const importRewrites = new Map<any, Set<string>>()
+        // Track if seoMeta is referenced as a value (not just called), keyed by original imported name
+        const valueReferenced = new Set<string>()
+        // Track useSeoMeta/useServerSeoMeta calls that could not be transformed (e.g. dynamic first
+        // arg, spread properties). The original import must be preserved alongside the useHead rewrite.
+        const untransformedCallees = new Set<string>()
 
-      // vue files
-      if (isVueScriptRequest(pathname, query))
-        return true
-
-      // js files
-      if (TRANSFORM_RE.test(pathname))
-        return true
-
-      return false
-    },
-
-    async transform(code, id) {
-      if (!code.includes('useSeoMeta') && !code.includes('useServerSeoMeta'))
-        return
-
-      const scopeTracker = new ScopeTracker()
-      const ast = parseSync(id, code)
-      const s = new MagicString(code)
-
-      // Track which ImportDeclarations need specifier rewrites
-      // Key: ImportDeclaration node, Value: set of original imported names that were transformed
-      const importRewrites = new Map<any, Set<string>>()
-      // Track if seoMeta is referenced as a value (not just called), keyed by original imported name
-      const valueReferenced = new Set<string>()
-      // Track useSeoMeta/useServerSeoMeta calls that could not be transformed (e.g. dynamic first
-      // arg, spread properties). The original import must be preserved alongside the useHead rewrite.
-      const untransformedCallees = new Set<string>()
-
-      walk(ast.program, {
-        scopeTracker,
-        enter(node: any, parent: any) {
+        walk(ast.program, {
+          scopeTracker,
+          enter(node: any, parent: any) {
           // Track value references to seoMeta identifiers (e.g., console.log(useSeoMeta))
           // Skip: call callees (handled below), import specifiers (definitions, not references)
-          if (node.type === 'Identifier'
-            && !(parent?.type === 'CallExpression' && parent.callee === node)
-            && parent?.type !== 'ImportSpecifier') {
-            const decl = scopeTracker.getDeclaration(node.name)
-            if (decl instanceof ScopeTrackerImport
-              && isValidPackage(decl.importNode.source.value)
-              && decl.node.type === 'ImportSpecifier'
-              && decl.node.imported.type === 'Identifier'
-              && SEO_META_NAMES.has(decl.node.imported.name)) {
-              valueReferenced.add(decl.node.imported.name)
+            if (node.type === 'Identifier'
+              && !(parent?.type === 'CallExpression' && parent.callee === node)
+              && parent?.type !== 'ImportSpecifier') {
+              const decl = scopeTracker.getDeclaration(node.name)
+              if (decl instanceof ScopeTrackerImport
+                && isValidPackage(decl.importNode.source.value)
+                && decl.node.type === 'ImportSpecifier'
+                && decl.node.imported.type === 'Identifier'
+                && SEO_META_NAMES.has(decl.node.imported.name)) {
+                valueReferenced.add(decl.node.imported.name)
+              }
             }
-          }
 
-          if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier')
-            return
-
-          const decl = scopeTracker.getDeclaration(node.callee.name)
-
-          let originalName: string
-          let importDecl: any = null
-
-          if (decl instanceof ScopeTrackerImport) {
-            if (!isValidPackage(decl.importNode.source.value) || decl.node.type !== 'ImportSpecifier' || decl.node.imported.type !== 'Identifier')
+            if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier')
               return
-            originalName = decl.node.imported.name
-            importDecl = decl.importNode
-          }
-          else if (!decl && SEO_META_NAMES.has(node.callee.name)) {
+
+            const decl = scopeTracker.getDeclaration(node.callee.name)
+
+            let originalName: string
+            let importDecl: any = null
+
+            if (decl instanceof ScopeTrackerImport) {
+              if (!isValidPackage(decl.importNode.source.value) || decl.node.type !== 'ImportSpecifier' || decl.node.imported.type !== 'Identifier')
+                return
+              originalName = decl.node.imported.name
+              importDecl = decl.importNode
+            }
+            else if (!decl && SEO_META_NAMES.has(node.callee.name)) {
             // Auto-imported (no declaration found in scope)
-            originalName = node.callee.name
-          }
-          else {
-            return
-          }
-
-          if (!SEO_META_NAMES.has(originalName))
-            return
-
-          const properties = node.arguments[0]?.properties
-          if (!properties) {
-            if (importDecl)
-              untransformedCallees.add(originalName)
-            return
-          }
-
-          let output: string[] | false = []
-          const title = properties.find((property: any) => property.key?.name === 'title')
-          const titleTemplate = properties.find((property: any) => property.key?.name === 'titleTemplate')
-          const meta = properties.filter((property: any) => property.key?.name !== 'title' && property.key?.name !== 'titleTemplate')
-          if (title || titleTemplate || originalName === 'useSeoMeta') {
-            output.push('useHead({')
-            if (title) {
-              output.push(`  title: ${code.substring(title.value.start, title.value.end)},`)
+              originalName = node.callee.name
             }
-            if (titleTemplate) {
-              output.push(`  titleTemplate: ${code.substring(titleTemplate.value.start, titleTemplate.value.end)},`)
-            }
-          }
-          if (originalName === 'useServerSeoMeta') {
-            if (output.length) {
-              const secondArg = node.arguments[1]
-              if (secondArg)
-                output.push(`}, ${code.substring(secondArg.start, secondArg.end)});`)
-              else
-                output.push('});')
-            }
-            output.push('useServerHead({')
-          }
-
-          if (meta.length)
-            output.push('  meta: [')
-
-          meta.forEach((property: any) => {
-            if (property.type === 'SpreadElement') {
-              output = false
+            else {
               return
             }
-            if (property.key.type !== 'Identifier' || !property.value) {
-              output = false
-              return
-            }
-            if (output === false)
-              return
-            const propertyKey = property.key
-            let key: string = resolveMetaKeyType(propertyKey.name)
-            const keyValue = resolveMetaKeyValue(propertyKey.name)
-            let valueKey = 'content'
-            if (keyValue === 'charset') {
-              valueKey = 'charset'
-              key = 'charset'
-            }
-            let value = code.substring(property.value.start as number, property.value.end as number)
 
-            if (MEDIA_KEYS.has(propertyKey.name)) {
+            if (!SEO_META_NAMES.has(originalName))
+              return
+
+            const properties = node.arguments[0]?.properties
+            if (!properties) {
+              if (importDecl)
+                untransformedCallees.add(originalName)
+              return
+            }
+
+            let output: string[] | false = []
+            const title = properties.find((property: any) => property.key?.name === 'title')
+            const titleTemplate = properties.find((property: any) => property.key?.name === 'titleTemplate')
+            const meta = properties.filter((property: any) => property.key?.name !== 'title' && property.key?.name !== 'titleTemplate')
+            if (title || titleTemplate || originalName === 'useSeoMeta') {
+              output.push('useHead({')
+              if (title) {
+                output.push(`  title: ${code.substring(title.value.start, title.value.end)},`)
+              }
+              if (titleTemplate) {
+                output.push(`  titleTemplate: ${code.substring(titleTemplate.value.start, titleTemplate.value.end)},`)
+              }
+            }
+            if (originalName === 'useServerSeoMeta') {
+              if (output.length) {
+                const secondArg = node.arguments[1]
+                if (secondArg)
+                  output.push(`}, ${code.substring(secondArg.start, secondArg.end)});`)
+                else
+                  output.push('});')
+              }
+              output.push('useServerHead({')
+            }
+
+            if (meta.length)
+              output.push('  meta: [')
+
+            meta.forEach((property: any) => {
+              if (property.type === 'SpreadElement') {
+                output = false
+                return
+              }
+              if (property.key.type !== 'Identifier' || !property.value) {
+                output = false
+                return
+              }
+              if (output === false)
+                return
+              const propertyKey = property.key
+              let key: string = resolveMetaKeyType(propertyKey.name)
+              const keyValue = resolveMetaKeyValue(propertyKey.name)
+              let valueKey = 'content'
+              if (keyValue === 'charset') {
+                valueKey = 'charset'
+                key = 'charset'
+              }
+              let value = code.substring(property.value.start as number, property.value.end as number)
+
+              if (MEDIA_KEYS.has(propertyKey.name)) {
               // Expand an object literal `{ url, width, ... }` into `og:image`, `og:image:width`, ...
               // matching runtime `unpackMeta`. Leaf values may be dynamic; only the structure must
               // be statically known. Returns false when a prop key can't be resolved statically.
-              const expandObject = (objNode: any): string | false => {
-                const tags: string[] = []
-                for (const p of objNode.properties) {
+                const expandObject = (objNode: any): string | false => {
+                  const tags: string[] = []
+                  for (const p of objNode.properties) {
                   // Only plain `key: value` pairs can be reproduced statically. Spreads, getters,
                   // setters, methods, and computed/non-identifier keys bail to runtime.
-                  if (p.type === 'SpreadElement' || p.computed || p.method || p.kind !== 'init' || p.key?.type !== 'Identifier')
-                    return false
-                  // Match runtime `unpackMeta`: `url` -> bare property, `secureUrl` -> `:secure_url`.
-                  const name = p.key.name
-                  const suffix = name === 'url' ? '' : `:${name === 'secureUrl' ? 'secure_url' : name}`
-                  tags.push(`    { ${key}: '${keyValue}${suffix}', ${valueKey}: ${code.substring(p.value.start, p.value.end)} },`)
-                }
-                return tags.join('\n')
-              }
-              if (property.value.type === 'ObjectExpression') {
-                const expanded = expandObject(property.value)
-                if (expanded === false) {
-                  output = false
-                  return
-                }
-                output.push(expanded)
-                return
-              }
-              if (property.value.type === 'ArrayExpression') {
-                if (!property.value.elements.length)
-                  return
-                const parts: string[] = []
-                for (const element of property.value.elements) {
-                  if (!element || element.type !== 'ObjectExpression') {
-                    output = false
-                    return
+                    if (p.type === 'SpreadElement' || p.computed || p.method || p.kind !== 'init' || p.key?.type !== 'Identifier')
+                      return false
+                    // Match runtime `unpackMeta`: `url` -> bare property, `secureUrl` -> `:secure_url`.
+                    const name = p.key.name
+                    const suffix = name === 'url' ? '' : `:${name === 'secureUrl' ? 'secure_url' : name}`
+                    tags.push(`    { ${key}: '${keyValue}${suffix}', ${valueKey}: ${code.substring(p.value.start, p.value.end)} },`)
                   }
-                  const expanded = expandObject(element)
+                  return tags.join('\n')
+                }
+                if (property.value.type === 'ObjectExpression') {
+                  const expanded = expandObject(property.value)
                   if (expanded === false) {
                     output = false
                     return
                   }
-                  parts.push(expanded)
+                  output.push(expanded)
+                  return
                 }
-                output.push(parts.join('\n'))
+                if (property.value.type === 'ArrayExpression') {
+                  if (!property.value.elements.length)
+                    return
+                  const parts: string[] = []
+                  for (const element of property.value.elements) {
+                    if (!element || element.type !== 'ObjectExpression') {
+                      output = false
+                      return
+                    }
+                    const expanded = expandObject(element)
+                    if (expanded === false) {
+                      output = false
+                      return
+                    }
+                    parts.push(expanded)
+                  }
+                  output.push(parts.join('\n'))
+                  return
+                }
+                // Primitive literals (string/number/boolean) and template literals always resolve to a
+                // scalar -> a single safe tag. Anything else (identifier, ref(), computed(), getter,
+                // or a non-primitive literal like a regexp) could resolve to an object/array, so bail
+                // to runtime `unpackMeta`.
+                const v = property.value
+                const primitive = typeof v.value === 'string' || typeof v.value === 'number' || typeof v.value === 'boolean'
+                const isScalar = v.type === 'TemplateLiteral'
+                  || ((v.type === 'Literal' || v.type === 'StringLiteral' || v.type === 'NumericLiteral') && primitive)
+                if (!isScalar) {
+                  output = false
+                  return
+                }
+              }
+
+              if (property.value.type === 'ArrayExpression') {
+                const elements = property.value.elements
+                if (!elements.length)
+                  return
+
+                const metaTags = elements.map((element: any) => {
+                  if (element.type !== 'ObjectExpression')
+                    return `    { ${key}: '${keyValue}', ${valueKey}: ${code.substring(element.start, element.end)} },`
+
+                  return element.properties.map((p: any) => {
+                    const propKey = p.key.name
+                    const propValue = code.substring(p.value.start, p.value.end)
+                    return `    { ${key}: '${keyValue}:${propKey}', ${valueKey}: ${propValue} },`
+                  }).join('\n')
+                })
+
+                output.push(metaTags.join('\n'))
                 return
               }
-              // Primitive literals (string/number/boolean) and template literals always resolve to a
-              // scalar -> a single safe tag. Anything else (identifier, ref(), computed(), getter,
-              // or a non-primitive literal like a regexp) could resolve to an object/array, so bail
-              // to runtime `unpackMeta`.
-              const v = property.value
-              const primitive = typeof v.value === 'string' || typeof v.value === 'number' || typeof v.value === 'boolean'
-              const isScalar = v.type === 'TemplateLiteral'
-                || ((v.type === 'Literal' || v.type === 'StringLiteral' || v.type === 'NumericLiteral') && primitive)
-              if (!isScalar) {
-                output = false
-                return
+              else if (property.value.type === 'ObjectExpression') {
+                const isStatic = property.value.properties.every((p: any) => p.value.type === 'StringLiteral' && typeof p.value.value === 'string')
+                if (!isStatic) {
+                  output = false
+                  return
+                }
+                const context = createContext({
+                  resolvePackedMetaObjectValue,
+                })
+                const start = property.value.start as number
+                const end = property.value.end as number
+                try {
+                  value = JSON.stringify(runInContext(`resolvePackedMetaObjectValue(${code.slice(start, end)})`, context))
+                }
+                catch {
+                  output = false
+                  return
+                }
+              }
+              if (valueKey === 'charset')
+                output.push(`    { ${key}: ${value} },`)
+              else
+                output.push(`    { ${key}: '${keyValue}', ${valueKey}: ${value} },`)
+            })
+            if (output) {
+              if (meta.length)
+                output.push('  ]')
+              // Preserve the second argument (options like { head }) if present
+              if (node.arguments.length >= 2) {
+                const optionsArg = code.substring(node.arguments[1].start, node.arguments[1].end)
+                output.push(`}, ${optionsArg})`)
+              }
+              else {
+                output.push('})')
+              }
+              s.overwrite(node.start, node.end, output.join('\n'))
+
+              // Track import for rewriting
+              if (importDecl) {
+                if (!importRewrites.has(importDecl))
+                  importRewrites.set(importDecl, new Set())
+                importRewrites.get(importDecl)!.add(originalName)
               }
             }
-
-            if (property.value.type === 'ArrayExpression') {
-              const elements = property.value.elements
-              if (!elements.length)
-                return
-
-              const metaTags = elements.map((element: any) => {
-                if (element.type !== 'ObjectExpression')
-                  return `    { ${key}: '${keyValue}', ${valueKey}: ${code.substring(element.start, element.end)} },`
-
-                return element.properties.map((p: any) => {
-                  const propKey = p.key.name
-                  const propValue = code.substring(p.value.start, p.value.end)
-                  return `    { ${key}: '${keyValue}:${propKey}', ${valueKey}: ${propValue} },`
-                }).join('\n')
-              })
-
-              output.push(metaTags.join('\n'))
-              return
+            else if (importDecl) {
+              untransformedCallees.add(originalName)
             }
-            else if (property.value.type === 'ObjectExpression') {
-              const isStatic = property.value.properties.every((p: any) => p.value.type === 'StringLiteral' && typeof p.value.value === 'string')
-              if (!isStatic) {
-                output = false
-                return
+          },
+        })
+
+        // Rewrite import specifiers
+        if (options.imports && importRewrites.size > 0) {
+          for (const [importNode, transformedNames] of importRewrites) {
+            const newSpecifiers = new Set<string>()
+            for (const spec of importNode.specifiers) {
+              if (spec.type !== 'ImportSpecifier')
+                continue
+              const importedName = spec.imported.name
+              // Preserve the local alias (`useSeoMeta as usm`) so kept call sites stay bound.
+              const keepOriginal = importedName === spec.local.name ? importedName : `${importedName} as ${spec.local.name}`
+              if (transformedNames.has(importedName)) {
+                newSpecifiers.add(importedName.includes('Server') ? 'useServerHead' : 'useHead')
+                // Keep original import if it's still referenced as a value or called in a form we
+                // couldn't statically transform (dynamic first arg, spread properties, etc.).
+                if (valueReferenced.has(importedName) || untransformedCallees.has(importedName))
+                  newSpecifiers.add(keepOriginal)
               }
-              const context = createContext({
-                resolvePackedMetaObjectValue,
-              })
-              const start = property.value.start as number
-              const end = property.value.end as number
-              try {
-                value = JSON.stringify(runInContext(`resolvePackedMetaObjectValue(${code.slice(start, end)})`, context))
-              }
-              catch {
-                output = false
-                return
-              }
-            }
-            if (valueKey === 'charset')
-              output.push(`    { ${key}: ${value} },`)
-            else
-              output.push(`    { ${key}: '${keyValue}', ${valueKey}: ${value} },`)
-          })
-          if (output) {
-            if (meta.length)
-              output.push('  ]')
-            // Preserve the second argument (options like { head }) if present
-            if (node.arguments.length >= 2) {
-              const optionsArg = code.substring(node.arguments[1].start, node.arguments[1].end)
-              output.push(`}, ${optionsArg})`)
-            }
-            else {
-              output.push('})')
-            }
-            s.overwrite(node.start, node.end, output.join('\n'))
-
-            // Track import for rewriting
-            if (importDecl) {
-              if (!importRewrites.has(importDecl))
-                importRewrites.set(importDecl, new Set())
-              importRewrites.get(importDecl)!.add(originalName)
-            }
-          }
-          else if (importDecl) {
-            untransformedCallees.add(originalName)
-          }
-        },
-      })
-
-      // Rewrite import specifiers
-      if (options.imports && importRewrites.size > 0) {
-        for (const [importNode, transformedNames] of importRewrites) {
-          const newSpecifiers = new Set<string>()
-          for (const spec of importNode.specifiers) {
-            if (spec.type !== 'ImportSpecifier')
-              continue
-            const importedName = spec.imported.name
-            // Preserve the local alias (`useSeoMeta as usm`) so kept call sites stay bound.
-            const keepOriginal = importedName === spec.local.name ? importedName : `${importedName} as ${spec.local.name}`
-            if (transformedNames.has(importedName)) {
-              newSpecifiers.add(importedName.includes('Server') ? 'useServerHead' : 'useHead')
-              // Keep original import if it's still referenced as a value or called in a form we
-              // couldn't statically transform (dynamic first arg, spread properties, etc.).
-              if (valueReferenced.has(importedName) || untransformedCallees.has(importedName))
+              else {
                 newSpecifiers.add(keepOriginal)
+              }
             }
-            else {
-              newSpecifiers.add(keepOriginal)
-            }
+            s.overwrite(
+              importNode.specifiers[0].start,
+              importNode.specifiers.at(-1).end,
+              [...newSpecifiers].join(', '),
+            )
           }
-          s.overwrite(
-            importNode.specifiers[0].start,
-            importNode.specifiers.at(-1).end,
-            [...newSpecifiers].join(', '),
-          )
         }
-      }
 
-      if (s.hasChanged()) {
-        return {
-          code: s.toString(),
-          map: s.generateMap({ includeContent: true, source: id }) as SourceMapInput,
+        if (s.hasChanged()) {
+          return {
+            code: s.toString(),
+            map: s.generateMap({ includeContent: true, source: id }) as SourceMapInput,
+          }
         }
-      }
+      },
     },
-  }, /\buse(?:Server)?SeoMeta\b/)
+  }
 })

--- a/packages/bundler/src/unplugin/utils.ts
+++ b/packages/bundler/src/unplugin/utils.ts
@@ -1,4 +1,17 @@
-import type { UnpluginOptions } from 'unplugin'
+import type { HookFilter } from 'unplugin'
+
+export const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
+export const JS_VUE_RE = /\.(?:(?:c|m)?j|t)sx?(?:$|\?)|\.vue(?:$|\?)/
+
+export function createJsVueTransformIdFilter(include?: RegExp[]): HookFilter['id'] {
+  return {
+    include: [
+      JS_VUE_RE,
+      ...(include || []),
+    ],
+    exclude: NODE_MODULES_RE,
+  }
+}
 
 export function splitTransformId(id: string): { pathname: string, query: string } {
   const queryIndex = id.indexOf('?')
@@ -29,17 +42,4 @@ export function getQueryValue(query: string, key: string): string | undefined {
 
 export function isVueScriptRequest(pathname: string, query: string): boolean {
   return pathname.endsWith('.vue') && (!query || getQueryValue(query, 'type') === 'script')
-}
-
-export function withCodeFilter(plugin: UnpluginOptions, code: RegExp): UnpluginOptions {
-  if (typeof plugin.transform !== 'function')
-    return plugin
-
-  return {
-    ...plugin,
-    transform: {
-      filter: { code },
-      handler: plugin.transform,
-    },
-  }
 }

--- a/packages/bundler/test/createHeadTransform.test.ts
+++ b/packages/bundler/test/createHeadTransform.test.ts
@@ -12,6 +12,7 @@ function createPlugin(registrations: Parameters<ReturnType<typeof createHeadTran
     environment: { config: { consumer } },
   }
   return {
+    plugin,
     transform(code: string, id = 'entry.ts') {
       return plugin.transform.handler.call(mockContext, code, id)
     },
@@ -26,9 +27,6 @@ describe('createHeadTransform', () => {
     }])
     expect(await transform('const x = 1')).toBeUndefined()
   })
-
-  // Note: non-JS file filtering is handled by Vite's transform.filter.id at runtime,
-  // not by the handler itself, so we don't test it here.
 
   it('does nothing when no registrations exist', async () => {
     const { transform } = createPlugin([])

--- a/packages/bundler/test/minifyTransform.test.ts
+++ b/packages/bundler/test/minifyTransform.test.ts
@@ -29,11 +29,6 @@ async function transformWithPlugin(plugin: any, code: string | string[], id = '/
 }
 
 describe('minifyTransform', () => {
-  it('filters modules without head composables', () => {
-    const plugin = MinifyTransform.vite({ js: mockJSMinifier }) as any
-    expect(plugin.transform.filter.code).toEqual(/\buse(?:Server)?Head\b/)
-  })
-
   it('minifies inline script innerHTML with provided js minifier', async () => {
     const code = await transform([
       `import { useHead } from 'unhead'`,

--- a/packages/bundler/test/ssrStaticReplace.test.ts
+++ b/packages/bundler/test/ssrStaticReplace.test.ts
@@ -27,11 +27,6 @@ describe('ssrStaticReplace', () => {
     expect(plugin.transformInclude('/src/components/Head.vue')).toBe(false)
   })
 
-  it('uses a code filter for head.ssr', () => {
-    const plugin = createPlugin()
-    expect(plugin.transform.filter.code).toEqual(/\bhead\.ssr\b/)
-  })
-
   it('replaces head.ssr with false for client builds', () => {
     const plugin = createPlugin({ isSsrBuild: false, command: 'build' })
     const result = transform(plugin, 'if (head.ssr) { doServerThing() }', UNHEAD_MODULE_ID)

--- a/packages/bundler/test/treeshakeServerComposables.test.ts
+++ b/packages/bundler/test/treeshakeServerComposables.test.ts
@@ -22,11 +22,6 @@ describe('treeshakeServerComposables', () => {
     'useServerHead({ title: \'Hello\', description: \'World\' })',
   ]
 
-  it('uses a code filter for server-only composables', () => {
-    const plugin = TreeshakeServerComposables.vite({}) as any
-    expect(plugin.transform.filter.code).toEqual(/\b(?:useServerHead|useServerHeadSafe|useServerSeoMeta|useSchemaOrg)\b/)
-  })
-
   it('ignores non-JS files', async () => {
     expect(await transform(couldTransform, 'test.css')).toBeUndefined()
   })

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -45,11 +45,6 @@ describe('useSeoMetaTransform', () => {
     'useSeoMeta({ title: \'Hello\', description: \'World\' })',
   ]
 
-  it('filters modules without seo meta composables', () => {
-    const plugin = UseSeoMetaTransform.vite({}) as any
-    expect(plugin.transform.filter.code).toEqual(/\buse(?:Server)?SeoMeta\b/)
-  })
-
   it('ignores non-JS files', async () => {
     expect(await transform(couldTransform, 'test.css')).toBeUndefined()
   })

--- a/packages/react/src/stream/plugin.ts
+++ b/packages/react/src/stream/plugin.ts
@@ -5,9 +5,10 @@ import { buildStreamingPluginOptions } from 'unhead/stream/unplugin'
 import { createUnplugin } from 'unplugin'
 
 const FILTER_RE = /\.[jt]sx$/
+const HEAD_COMPOSABLE_RE = /useHead|useSeoMeta/
 
 function hasHeadComposable(code: string): boolean {
-  return code.includes('useHead') || code.includes('useSeoMeta') || code.includes('useHeadSafe')
+  return HEAD_COMPOSABLE_RE.test(code)
 }
 
 /**
@@ -130,6 +131,7 @@ export const unheadReactStreamingPlugin = createUnplugin<UnheadReactStreamingOpt
   buildStreamingPluginOptions({
     framework: '@unhead/react',
     filter: FILTER_RE,
+    codeFilter: HEAD_COMPOSABLE_RE,
     mode: options.mode,
     transform(code, id, opts) {
       if (!hasHeadComposable(code))

--- a/packages/react/src/stream/plugin.ts
+++ b/packages/react/src/stream/plugin.ts
@@ -5,7 +5,7 @@ import { buildStreamingPluginOptions } from 'unhead/stream/unplugin'
 import { createUnplugin } from 'unplugin'
 
 const FILTER_RE = /\.[jt]sx$/
-const HEAD_COMPOSABLE_RE = /useHead|useSeoMeta/
+const HEAD_COMPOSABLE_RE = /\b(?:useHead|useHeadSafe|useSeoMeta)\b/
 
 function hasHeadComposable(code: string): boolean {
   return HEAD_COMPOSABLE_RE.test(code)

--- a/packages/react/test/vite-plugin.test.ts
+++ b/packages/react/test/vite-plugin.test.ts
@@ -44,6 +44,19 @@ describe('unheadReactStreamingPlugin', () => {
       expect(result!.code).toContain('<HeadStream />')
     })
 
+    it('adds HeadStream to components with useHeadSafe', () => {
+      const code = `
+        import { useHeadSafe } from '@unhead/react'
+        export function App() {
+          useHeadSafe({ title: 'Test' })
+          return <div>Content</div>
+        }
+      `
+      const result = transform(code, 'app.tsx')
+      expect(result).not.toBeNull()
+      expect(result!.code).toContain('<HeadStream />')
+    })
+
     it('adds HeadStream import from client for non-SSR builds', () => {
       const code = `
         import { useHead } from '@unhead/react'

--- a/packages/react/test/vite-plugin.test.ts
+++ b/packages/react/test/vite-plugin.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import { unheadReactStreamingPlugin } from '../src/stream/plugin'
 import { unheadReactPlugin } from '../src/stream/vite'
 
-const FILTER_RE = /\.[jt]sx$/
 const HEAD_STREAM_RE = /<HeadStream \/>/g
 
 describe('unheadReactStreamingPlugin', () => {
@@ -20,10 +19,6 @@ describe('unheadReactStreamingPlugin', () => {
   })
 
   describe('transform', () => {
-    it('filters to jsx/tsx files only', () => {
-      expect(plugin.transform.filter.id).toEqual(FILTER_RE)
-    })
-
     it('skips files without Suspense', () => {
       const code = `
         export function App() {
@@ -31,7 +26,7 @@ describe('unheadReactStreamingPlugin', () => {
         }
       `
       const result = transform(code, 'app.tsx')
-      expect(result).toBeNull()
+      expect(result).toBeUndefined()
     })
 
     it('adds HeadStream to components with useHead', () => {
@@ -130,7 +125,7 @@ describe('unheadReactStreamingPlugin', () => {
         }
       `
       const result = transform(code, 'app.tsx')
-      expect(result).toBeNull()
+      expect(result).toBeUndefined()
     })
 
     it('generates source map', () => {

--- a/packages/solid-js/src/stream/plugin.ts
+++ b/packages/solid-js/src/stream/plugin.ts
@@ -5,7 +5,7 @@ import { buildStreamingPluginOptions } from 'unhead/stream/unplugin'
 import { createUnplugin } from 'unplugin'
 
 const FILTER_RE = /\.[jt]sx$/
-const HEAD_COMPOSABLE_RE = /useHead|useSeoMeta/
+const HEAD_COMPOSABLE_RE = /\b(?:useHead|useHeadSafe|useSeoMeta)\b/
 
 function hasHeadComposable(code: string): boolean {
   return HEAD_COMPOSABLE_RE.test(code)

--- a/packages/solid-js/src/stream/plugin.ts
+++ b/packages/solid-js/src/stream/plugin.ts
@@ -5,9 +5,10 @@ import { buildStreamingPluginOptions } from 'unhead/stream/unplugin'
 import { createUnplugin } from 'unplugin'
 
 const FILTER_RE = /\.[jt]sx$/
+const HEAD_COMPOSABLE_RE = /useHead|useSeoMeta/
 
 function hasHeadComposable(code: string): boolean {
-  return code.includes('useHead') || code.includes('useSeoMeta') || code.includes('useHeadSafe')
+  return HEAD_COMPOSABLE_RE.test(code)
 }
 
 function transform(code: string, id: string, isSSR: boolean, s: MagicString): boolean {
@@ -115,6 +116,7 @@ export const unheadSolidStreamingPlugin = createUnplugin<UnheadSolidStreamingOpt
   buildStreamingPluginOptions({
     framework: '@unhead/solid-js',
     filter: FILTER_RE,
+    codeFilter: HEAD_COMPOSABLE_RE,
     mode: options.mode,
     transform(code, id, opts) {
       if (!hasHeadComposable(code))

--- a/packages/solid-js/test/vite-plugin.test.ts
+++ b/packages/solid-js/test/vite-plugin.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from 'vitest'
 import { unheadSolidStreamingPlugin } from '../src/stream/plugin'
 import { unheadSolidPlugin } from '../src/stream/vite'
 
-const FILTER_RE = /\.[jt]sx$/
-
 describe('unheadSolidStreamingPlugin', () => {
   const plugin = unheadSolidStreamingPlugin.vite() as any
   const transform = plugin.transform.handler
@@ -19,10 +17,6 @@ describe('unheadSolidStreamingPlugin', () => {
   })
 
   describe('transform', () => {
-    it('filters to jsx/tsx files only', () => {
-      expect(plugin.transform.filter.id).toEqual(FILTER_RE)
-    })
-
     it('skips files without useHead', () => {
       const code = `
         export function App() {
@@ -30,7 +24,7 @@ describe('unheadSolidStreamingPlugin', () => {
         }
       `
       const result = transform(code, 'app.tsx')
-      expect(result).toBeNull()
+      expect(result).toBeUndefined()
     })
 
     it('wraps JSX return with HeadStream fragment', () => {

--- a/packages/solid-js/test/vite-plugin.test.ts
+++ b/packages/solid-js/test/vite-plugin.test.ts
@@ -94,6 +94,19 @@ describe('unheadSolidStreamingPlugin', () => {
       expect(result!.code).toContain('<><HeadStream />')
     })
 
+    it('transforms files with useHeadSafe', () => {
+      const code = `
+        import { useHeadSafe } from '@unhead/solid-js'
+        export function App() {
+          useHeadSafe({ title: 'Test' })
+          return <div>Hello</div>
+        }
+      `
+      const result = transform(code, 'app.tsx')
+      expect(result).not.toBeNull()
+      expect(result!.code).toContain('<><HeadStream />')
+    })
+
     it('handles arrow function with implicit return', () => {
       const code = `
         import { useHead } from '@unhead/solid-js'

--- a/packages/svelte/src/stream/plugin.ts
+++ b/packages/svelte/src/stream/plugin.ts
@@ -7,7 +7,7 @@ import { createUnplugin } from 'unplugin'
 const SCRIPT_CLOSE_RE = /<\/script>/
 const SCRIPT_RE = /<script[^>]*>/i
 const FILTER_RE = /\.svelte$/
-const HEAD_COMPOSABLE_RE = /useHead|useSeoMeta/
+const HEAD_COMPOSABLE_RE = /\b(?:useHead|useHeadSafe|useSeoMeta)\b/
 
 function hasHeadComposable(code: string): boolean {
   return HEAD_COMPOSABLE_RE.test(code)

--- a/packages/svelte/src/stream/plugin.ts
+++ b/packages/svelte/src/stream/plugin.ts
@@ -7,9 +7,10 @@ import { createUnplugin } from 'unplugin'
 const SCRIPT_CLOSE_RE = /<\/script>/
 const SCRIPT_RE = /<script[^>]*>/i
 const FILTER_RE = /\.svelte$/
+const HEAD_COMPOSABLE_RE = /useHead|useSeoMeta/
 
 function hasHeadComposable(code: string): boolean {
-  return code.includes('useHead') || code.includes('useSeoMeta') || code.includes('useHeadSafe')
+  return HEAD_COMPOSABLE_RE.test(code)
 }
 
 function transform(code: string, id: string, isSSR: boolean, s: MagicString): boolean {
@@ -72,6 +73,7 @@ export const unheadSvelteStreamingPlugin = createUnplugin<UnheadSvelteStreamingO
   buildStreamingPluginOptions({
     framework: '@unhead/svelte',
     filter: FILTER_RE,
+    codeFilter: HEAD_COMPOSABLE_RE,
     mode: options.mode,
     transform(code, id, opts) {
       if (!hasHeadComposable(code))

--- a/packages/svelte/test/vite-plugin.test.ts
+++ b/packages/svelte/test/vite-plugin.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from 'vitest'
 import { unheadSvelteStreamingPlugin } from '../src/stream/plugin'
 import { unheadSveltePlugin } from '../src/stream/vite'
 
-const FILTER_RE = /\.svelte$/
-
 describe('unheadSvelteStreamingPlugin', () => {
   const plugin = unheadSvelteStreamingPlugin.vite() as any
   const transform = plugin.transform.handler
@@ -19,10 +17,6 @@ describe('unheadSvelteStreamingPlugin', () => {
   })
 
   describe('transform', () => {
-    it('filters to .svelte files only', () => {
-      expect(plugin.transform.filter.id).toEqual(FILTER_RE)
-    })
-
     it('skips files without useHead', () => {
       const code = `
         <script>
@@ -31,7 +25,7 @@ describe('unheadSvelteStreamingPlugin', () => {
         <div>Hello {name}</div>
       `
       const result = transform(code, 'component.svelte')
-      expect(result).toBeNull()
+      expect(result).toBeUndefined()
     })
 
     it('injects HeadStream after script tag', () => {

--- a/packages/svelte/test/vite-plugin.test.ts
+++ b/packages/svelte/test/vite-plugin.test.ts
@@ -94,6 +94,19 @@ describe('unheadSvelteStreamingPlugin', () => {
       expect(result!.code).toContain('{@html HeadStream()}')
     })
 
+    it('transforms files with useHeadSafe', () => {
+      const code = `
+        <script>
+          import { useHeadSafe } from '@unhead/svelte'
+          useHeadSafe({ title: 'Test' })
+        </script>
+        <div>Hello</div>
+      `
+      const result = transform(code, 'component.svelte')
+      expect(result).not.toBeNull()
+      expect(result!.code).toContain('{@html HeadStream()}')
+    })
+
     it('generates source map', () => {
       const code = `
         <script>

--- a/packages/unhead/src/stream/unplugin.ts
+++ b/packages/unhead/src/stream/unplugin.ts
@@ -22,6 +22,8 @@ export interface StreamingPluginOptions {
    * source-level AST injection (React/Solid/Svelte). Vue does not use it.
    */
   filter?: RegExp
+  /** Optional source-code prefilter for transform hooks. */
+  codeFilter?: RegExp
   /** Transform handler called for files matching `filter`. */
   transform?: (code: string, id: string, options?: { ssr?: boolean }) => { code: string, map?: any } | null | undefined | void
   /**
@@ -197,7 +199,9 @@ export function buildStreamingPluginOptions(options: StreamingPluginOptions): Un
     ...(options.transform && options.filter
       ? {
           transform: {
-            filter: { id: options.filter },
+            filter: options.codeFilter
+              ? { id: options.filter, code: options.codeFilter }
+              : { id: options.filter },
             handler(this: any, code: string, id: string, opts?: { ssr?: boolean }) {
               return options.transform!(code, id, { ssr: isSSRCall(this, opts) })
             },


### PR DESCRIPTION

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The branch adds more native `transform.filter` goodies.

More `id`/`code` prefilters across the bundler transforms, Vite-only transforms, and React/Solid/Svelte streaming transforms while keeping `transformInclude` for unplugin adapter compatibility. 

I have removed the old wrapper helpers, centralizes shared and dropped tests that only asserted filter object shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened head/SEO transform conditions so they only run when relevant composable patterns (including `useHeadSafe`) are present.
  * Improved streaming composable detection and ensured skipped inputs consistently return no transform result across React, Solid, and Svelte.
  * Reduced unnecessary work in minification and SSR `head.ssr` replacement transforms for more reliable builds.
* **Tests**
  * Updated and removed filter-related assertions to match the new skip/targeting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->