### PR TITLE
perf(unhead): avoid fallback hash allocations

### DIFF
--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -40,6 +40,16 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
 }
 
 export function hashTag(tag: HeadTag) {
-  return tag._h || tag._d || tag.textContent || tag.innerHTML
-    || `${tag.tag}:${Object.entries(tag.props).map(([k, v]) => `${k}:${String(v)}`).join()}`
+  const identity = tag._h || tag._d || tag.textContent || tag.innerHTML
+  if (identity)
+    return identity
+  let hash = `${tag.tag}:`
+  let separator = ''
+  for (const key in tag.props) {
+    if (Object.hasOwn(tag.props, key)) {
+      hash += `${separator}${key}:${String(tag.props[key])}`
+      separator = ','
+    }
+  }
+  return hash
 }

--- a/packages/unhead/test/unit/dedupe.test.ts
+++ b/packages/unhead/test/unit/dedupe.test.ts
@@ -1,0 +1,30 @@
+import { hashTag } from '../../src/utils/dedupe'
+
+describe('hashTag', () => {
+  it('serializes fallback tag props in insertion order', () => {
+    expect(hashTag({
+      tag: 'link',
+      props: {
+        rel: 'stylesheet',
+        href: '/_nuxt/app.css',
+        crossorigin: true as any,
+      },
+    })).toBe('link:rel:stylesheet,href:/_nuxt/app.css,crossorigin:true')
+  })
+
+  it('ignores inherited props', () => {
+    const props = Object.create({ inherited: 'ignored' })
+    props.src = '/_nuxt/app.js'
+    expect(hashTag({ tag: 'script', props })).toBe('script:src:/_nuxt/app.js')
+  })
+
+  it('preserves the empty props fallback', () => {
+    expect(hashTag({ tag: 'link', props: {} })).toBe('link:')
+  })
+
+  it('preserves explicit tag identities', () => {
+    expect(hashTag({ tag: 'script', props: {}, _h: 'hash' })).toBe('hash')
+    expect(hashTag({ tag: 'meta', props: {}, _d: 'dedupe' })).toBe('dedupe')
+    expect(hashTag({ tag: 'style', props: {}, innerHTML: 'body{}' })).toBe('body{}')
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Avoid temporary allocations when deriving fallback dedupe hashes.

This could speed up a fresh Nuxt SSR request and asset-heavy prerendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag identity handling to better preserve explicit identifiers and content-based values.
  * Made fallback tag hashing more reliable by using only direct tag properties and keeping property order consistent.

* **Tests**
  * Added coverage for tag hashing behavior, including explicit identities, empty properties, property order, and inherited property handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->