### PR TITLE
fix: guard plugins against double registration

### DIFF
--- a/packages/schema-org/src/plugin.ts
+++ b/packages/schema-org/src/plugin.ts
@@ -159,5 +159,5 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
         },
       },
     }
-  })
+  }, 'schema-org')
 }

--- a/packages/unhead/src/plugins/defineHeadPlugin.ts
+++ b/packages/unhead/src/plugins/defineHeadPlugin.ts
@@ -1,5 +1,9 @@
 import type { HeadPluginInput } from '../types/head'
 
-export function defineHeadPlugin(plugin: HeadPluginInput): HeadPluginInput {
+export function defineHeadPlugin(plugin: HeadPluginInput, key?: string): HeadPluginInput {
+  // expose the key statically so registerPlugin can dedupe a function plugin
+  // before invoking its (potentially side-effecting) setup
+  if (key && typeof plugin === 'function')
+    plugin.key = key
   return plugin
 }

--- a/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
@@ -23,11 +23,6 @@ export interface InferSeoMetaPluginOptions {
 
 export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
   return defineHeadPlugin((head) => {
-    if (head.plugins.has('infer-seo-meta')) {
-      return {
-        key: 'infer-seo-meta',
-      }
-    }
     if (options.twitterCard !== false) {
       head.push({
         meta: [
@@ -79,5 +74,5 @@ export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
         },
       },
     }
-  })
+  }, 'infer-seo-meta')
 }

--- a/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
@@ -23,6 +23,11 @@ export interface InferSeoMetaPluginOptions {
 
 export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
   return defineHeadPlugin((head) => {
+    if (head.plugins.has('infer-seo-meta')) {
+      return {
+        key: 'infer-seo-meta',
+      }
+    }
     if (options.twitterCard !== false) {
       head.push({
         meta: [

--- a/packages/unhead/src/plugins/templateParams.ts
+++ b/packages/unhead/src/plugins/templateParams.ts
@@ -56,4 +56,4 @@ export const TemplateParamsPlugin = /* @__PURE__ */ defineHeadPlugin((head) => {
       },
     },
   }
-})
+}, 'template-params')

--- a/packages/unhead/src/plugins/validate.ts
+++ b/packages/unhead/src/plugins/validate.ts
@@ -523,5 +523,5 @@ export function ValidatePlugin(options: ValidatePluginOptions = {}) {
         },
       },
     }
-  })
+  }, 'validate')
 }

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -70,7 +70,7 @@ export interface HeadPluginOptions extends CreateHeadOptions {
   hooks?: Record<string, (...args: any[]) => any>
 }
 
-export type HeadPluginInput = HeadPluginOptions & { key: string } | ((head: Unhead) => HeadPluginOptions & { key: string })
+export type HeadPluginInput = HeadPluginOptions & { key: string } | (((head: Unhead) => HeadPluginOptions & { key: string }) & { key?: string })
 export type HeadPlugin = HeadPluginOptions & { key: string }
 
 /**

--- a/packages/unhead/src/unhead.ts
+++ b/packages/unhead/src/unhead.ts
@@ -1,6 +1,10 @@
 import type { ActiveHeadEntry, CreateHeadOptions, HeadEntry, HeadEntryOptions, HeadPlugin, HeadPluginInput, HeadRenderer, ResolvableHead, Unhead } from './types'
 
 export function registerPlugin(head: Unhead<any, any>, p: HeadPluginInput) {
+  // a function plugin can declare its key statically so we can bail before
+  // running its setup, which may push tags or wrap head methods as a side effect
+  if (typeof p === 'function' && p.key && head.plugins.has(p.key))
+    return
   const plugin = typeof p === 'function' ? p(head) : p
   const key = plugin.key || String(head.plugins.size + 1)
   if (!head.plugins.get(key)) {

--- a/packages/unhead/test/unit/plugins/dedupe.test.ts
+++ b/packages/unhead/test/unit/plugins/dedupe.test.ts
@@ -1,0 +1,35 @@
+import type { Unhead } from '../../../src/types'
+import { describe, expect, it } from 'vitest'
+import { defineHeadPlugin } from '../../../src/plugins/defineHeadPlugin'
+import { createServerHeadWithContext } from '../../util'
+
+describe('plugin dedupe', () => {
+  it('runs a keyed function plugin setup only once across re-registration', () => {
+    let setups = 0
+    const plugin = defineHeadPlugin((head: Unhead) => {
+      setups++
+      head.push({ meta: [{ name: 'generator', content: 'unhead' }] })
+      return { key: 'my-plugin' }
+    }, 'my-plugin')
+
+    const head = createServerHeadWithContext({ plugins: [plugin] })
+    head.use(plugin)
+    head.use(plugin)
+
+    expect(setups).toBe(1)
+    expect(head.plugins.has('my-plugin')).toBe(true)
+  })
+
+  it('does not dedupe function plugins without a static key', () => {
+    let setups = 0
+    const plugin = defineHeadPlugin(() => {
+      setups++
+      return { key: `anon-${setups}` }
+    })
+
+    const head = createServerHeadWithContext({ plugins: [plugin] })
+    head.use(plugin)
+
+    expect(setups).toBe(2)
+  })
+})

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -357,6 +357,28 @@ describe('inferSeoMetaPlugin', () => {
     expect(result.headTags).toMatchInlineSnapshot(`"<meta name="twitter:card" content="summary">"`)
   })
 
+  it('does not push default meta entries when registered more than once', () => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin()],
+    })
+
+    head.use(InferSeoMetaPlugin())
+    head.push({
+      title: 'My Title',
+      meta: [{ name: 'description', content: 'My Description' }],
+    })
+
+    const result = renderSSRHead(head)
+    expect(result.headTags).toMatchInlineSnapshot(`
+      "<title>My Title</title>
+      <meta name="description" content="My Description">
+      <meta name="twitter:card" content="summary_large_image">
+      <meta property="og:title" data-infer="" content="My Title">
+      <meta property="og:description" data-infer="" content="My Description">"
+    `)
+  })
+
   it('plugin twitterCard: false disables twitter:card output (#555)', () => {
     const head = createHead({
       disableDefaults: true,


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Registering `InferSeoMetaPlugin` more than once pushed duplicate default Twitter/OG meta entries.

The root cause was generic: `registerPlugin` already deduped by `key`, but it ran that check *after* invoking the plugin factory. A function plugin's side-effecting setup (`InferSeoMetaPlugin` pushing tags, `validate` wrapping `head.push`, `schema-org` calling `head.use`) had already fired by then, so the dedupe only ever protected hook registration, never the side effects.

Rather than guard a single plugin inline, this moves the dedupe ahead of factory invocation:

- `defineHeadPlugin(plugin, key?)` optionally stamps the key onto the function.
- `registerPlugin` bails on a re-registered keyed function plugin *before* invoking it.

Applied to all four function plugins (`infer-seo-meta`, `validate`, `template-params`, `schema-org`). `validate` previously double-wrapped `head.push` on re-registration; that is now fixed too. Object plugins were never affected (no side effects) and are unchanged.

Adds a regression test for the duplicate-meta case plus a generic test asserting a keyed function plugin's setup runs only once across re-registration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved plugin registration so plugins with a stable key are only set up once, preventing duplicate behavior when registered multiple times.
  * Added support for keyed plugin definitions across the head plugin system.

* **Bug Fixes**
  * Prevented repeated inferred SEO/meta tags from appearing when the same plugin is registered more than once.
  * Reduced the chance of duplicate plugin setup for key-based plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->