### PR TITLE
perf: optimize SSR hot paths

### DIFF
--- a/packages/unhead/src/composables.ts
+++ b/packages/unhead/src/composables.ts
@@ -25,10 +25,15 @@ export function useSeoMeta<T extends Unhead<any>>(unhead: T, input: UseSeoMetaIn
     if (input._flatMeta) {
       return input
     }
-    const { title, titleTemplate, ...meta } = input || {}
+    const meta: Record<string, any> = {}
+    for (const key in input) {
+      if (!Object.hasOwn(input, key) || key === 'title' || key === 'titleTemplate')
+        continue
+      meta[key] = input[key as keyof UseSeoMetaInput]
+    }
     return {
-      title,
-      titleTemplate,
+      title: input.title,
+      titleTemplate: input.titleTemplate,
       _flatMeta: meta,
     }
   }

--- a/packages/unhead/src/parser/index.ts
+++ b/packages/unhead/src/parser/index.ts
@@ -33,6 +33,8 @@ export const TagIdMap = /* @__PURE__ */ {
   base: TAG_BASE,
 } as const
 
+const HEAD_ELEMENTS_TO_EXTRACT = /* @__PURE__ */ new Set([TAG_TITLE, TAG_META, TAG_LINK, TAG_SCRIPT, TAG_STYLE, TAG_BASE])
+
 export interface PreparedHtmlTemplate {
   html: string
   input: SerializableHead
@@ -286,9 +288,6 @@ export function parseHtmlForUnheadExtraction(html: string): PreparedHtmlTemplate
     bodyCloseTagStart: -1,
   }
 
-  // Track which elements we're extracting from head
-  const headElementsToExtract = new Set([TAG_TITLE, TAG_META, TAG_LINK, TAG_SCRIPT, TAG_STYLE, TAG_BASE])
-
   // Helper function to copy accumulated text and update indexes
   function copyAccumulatedText() {
     if (lastCopyPosition < position) {
@@ -473,7 +472,7 @@ export function parseHtmlForUnheadExtraction(html: string): PreparedHtmlTemplate
       copyAccumulatedText()
       addText(html.substring(position, tagEnd))
     }
-    else if (inHead && headElementsToExtract.has(tagId)) {
+    else if (inHead && HEAD_ELEMENTS_TO_EXTRACT.has(tagId)) {
       // Extract head elements and don't include them in output
       if (tagId === TAG_TITLE) {
         // Extract title content if not self-closing

--- a/packages/unhead/src/plugins/flatMeta.ts
+++ b/packages/unhead/src/plugins/flatMeta.ts
@@ -6,20 +6,23 @@ export const FlatMetaPlugin = /* @__PURE__ */ defineHeadPlugin({
   key: 'flatMeta',
   hooks: {
     'entries:normalize': (ctx) => {
+      let hasFlatMeta = false
+      const tags: HeadTag[] = []
       const tagsToAdd: HeadTag[] = []
-      ctx.tags = [...ctx.tags.map((t: HeadTag) => {
+      for (const t of ctx.tags) {
         if (t.tag !== '_flatMeta') {
-          return t
+          tags.push(t)
+          continue
         }
+        hasFlatMeta = true
         // @ts-expect-error untyped
-        tagsToAdd.push(...unpackMeta(t.props).map(p => ({
-          ...t,
-          tag: 'meta',
-          props: p,
-        })))
-        return false
-      })
-        .filter(Boolean), ...tagsToAdd] as HeadTag[]
+        for (const props of unpackMeta(t.props))
+          tagsToAdd.push({ ...t, tag: 'meta', props })
+      }
+      if (!hasFlatMeta)
+        return
+      for (const tag of tagsToAdd) tags.push(tag)
+      ctx.tags = tags
     },
   },
 })

--- a/packages/unhead/src/server/util/propsToString.ts
+++ b/packages/unhead/src/server/util/propsToString.ts
@@ -6,6 +6,18 @@ function encodeAttribute(value: string) {
   return s.includes('"') ? s.replace(DOUBLE_QUOTE_RE, '&quot;') : s
 }
 
+function classToString(value: Iterable<string>) {
+  let out = ''
+  for (const c of value) out += out ? ` ${c}` : c
+  return out
+}
+
+function styleToString(value: Iterable<[string, string]>) {
+  let out = ''
+  for (const [k, v] of value) out += out ? `;${k}:${v}` : `${k}:${v}`
+  return out
+}
+
 /* @__PURE__ */
 export function propsToString(props: Record<string, any>) {
   let attrs = ''
@@ -19,9 +31,8 @@ export function propsToString(props: Record<string, any>) {
     // class (set) and style (map)
     if ((key === 'class' || key === 'style') && typeof value !== 'string') {
       value = key === 'class'
-        ? [...value].join(' ')
-        : Array.from(value as Map<string, string>, ([k, v]) => `${k}:${v}`)
-            .join(';')
+        ? classToString(value)
+        : styleToString(value)
     }
 
     if (value !== false && value !== null) {

--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -5,7 +5,11 @@ const META_NOREWRITE_RE = /^(?:viewport|description|keywords|robots)$/
 const META_KEY_ATTRS = ['name', 'property', 'http-equiv'] as const
 
 export function isMetaArrayDupeKey(v: string) {
-  return MetaTagsArrayable.has(v.split(':')[1])
+  const i = v.indexOf(':')
+  if (i === -1)
+    return false
+  const j = v.indexOf(':', i + 1)
+  return MetaTagsArrayable.has(v.slice(i + 1, j === -1 ? v.length : j))
 }
 
 export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {

--- a/packages/unhead/src/utils/hooks.ts
+++ b/packages/unhead/src/utils/hooks.ts
@@ -11,5 +11,8 @@ export function createHooks<T extends CoreHeadHooks>(hooks?: Partial<T>): Hookab
 }
 
 export function callHook(head: Unhead<any, any>, hook: string, ctx: any) {
+  const hooks = (head.hooks as any)?._hooks?.[hook]
+  if (!hooks?.length)
+    return
   return head.hooks?.callHook(hook as any, ctx)
 }

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -90,7 +90,23 @@ function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string
     tag.innerHTML = JSON.stringify(tag.innerHTML)
     tag.props.type = tag.props.type || 'application/json'
   }
-  return Array.isArray(tag.props.content) ? tag.props.content.map(v => ({ ...tag, props: { ...tag.props, content: v } })) : tag
+  if (Array.isArray(tag.props.content)) {
+    const tags: HeadTag[] = []
+    for (const content of tag.props.content) {
+      tags.push({ ...tag, props: { ...tag.props, content } })
+    }
+    return tags
+  }
+  return tag
+}
+
+function pushNormalizedTag(tags: HeadTag[], tag: HeadTag | HeadTag[]) {
+  if (Array.isArray(tag)) {
+    for (const t of tag) tags.push(t)
+  }
+  else {
+    tags.push(tag)
+  }
 }
 
 export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]): HeadTag[] {
@@ -112,12 +128,17 @@ export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]):
     input = resolve(undefined, input)
   }
   input = walkResolver(input, resolve)
-  const tags: (HeadTag | HeadTag[])[] = []
+  const tags: HeadTag[] = []
   for (const key in input) {
     const value = input[key]
     if (value !== undefined) {
-      for (const v of (Array.isArray(value) ? value : [value])) tags.push(normalizeTag(key as keyof ResolvableHead, v))
+      if (Array.isArray(value)) {
+        for (const v of value) pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, v))
+      }
+      else {
+        pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, value))
+      }
     }
   }
-  return tags.flat()
+  return tags
 }

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -27,10 +27,45 @@ export interface ResolveTagsOptions {
   tagWeight?: (tag: HeadTag) => number
 }
 
+function pushEntryTags(ctx: ResolveTagsContext, entries: HeadTag[][], needsClone: boolean) {
+  for (const tags of entries) {
+    for (const t of tags) {
+      if (needsClone) {
+        const props: Record<string, any> = { ...t.props }
+        // class/style are containers; copy them so hooks can't mutate the entry cache
+        if (props.class instanceof Set)
+          props.class = new Set(props.class)
+        if (props.style instanceof Map)
+          props.style = new Map(props.style)
+        ctx.tags.push({ ...t, props })
+      }
+      else {
+        ctx.tags.push(t)
+      }
+    }
+  }
+}
+
+function valuesToTags(ctx: ResolveTagsContext, sortFlatMeta: boolean) {
+  ctx.tags = []
+  for (const value of ctx.tagMap.values()) {
+    if (Array.isArray(value)) {
+      for (const tag of value) ctx.tags.push(tag)
+    }
+    else {
+      ctx.tags.push(value)
+    }
+  }
+  if (sortFlatMeta)
+    ctx.tags.sort(sortTags)
+}
+
 export function dedupeTags(ctx: ResolveTagsContext): boolean {
   let hasFlatMeta = false
   for (const next of ctx.tags.sort(sortTags)) {
     const k = next._d || hashTag(next)
+    if (!k)
+      continue
     const prev = ctx.tagMap.get(k)
     if (!prev) {
       ctx.tagMap.set(k, next)
@@ -122,22 +157,28 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
     }
   }
   callHook(head, 'entries:resolve', { entries, ...ctx })
+  const entryTags: HeadTag[][] = []
   for (const e of entries) {
     if (!e._tags) {
+      const tags = normalizeEntryToTags(e.input, head.resolvedOptions.propResolvers || [])
+      for (const t of tags)
+        Object.assign(t, e.options)
       const normalizeCtx = {
-        tags: normalizeEntryToTags(e.input, head.resolvedOptions.propResolvers || []).map(t => Object.assign(t, e.options)),
+        tags,
         entry: e,
       }
       callHook(head, 'entries:normalize', normalizeCtx)
-      e._tags = normalizeCtx.tags.map((t, i) => {
+      for (let i = 0; i < normalizeCtx.tags.length; i++) {
+        const t = normalizeCtx.tags[i]
         t._w = weightFn(t)
         t._p = (e._i << 10) + i
         t._d = dedupeKey(t)
         if (!t._d)
           t._h = hashTag(t)
-        return t
-      })
+      }
+      e._tags = normalizeCtx.tags
     }
+    entryTags.push(e._tags)
   }
   let needsClone = false
   for (const k in hooks) {
@@ -146,22 +187,10 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
       break
     }
   }
-  ctx.tags = needsClone
-    ? entries.flatMap(e => (e._tags || []).map((t) => {
-        const props: Record<string, any> = { ...t.props }
-        // class/style are containers; copy them so hooks can't mutate the entry cache
-        if (props.class instanceof Set)
-          props.class = new Set(props.class)
-        if (props.style instanceof Map)
-          props.style = new Map(props.style)
-        return { ...t, props }
-      }))
-    : entries.flatMap(e => e._tags || [])
+  pushEntryTags(ctx, entryTags, needsClone)
   const hasFlatMeta = dedupeTags(ctx)
   resolveTitleTemplate(ctx, head)
-  ctx.tags = [...ctx.tagMap.values()]
-  if (hasFlatMeta)
-    ctx.tags = ctx.tags.flat().sort(sortTags)
+  valuesToTags(ctx, hasFlatMeta)
   callHook(head, 'tags:beforeResolve', ctx)
   callHook(head, 'tags:resolve', ctx)
   callHook(head, 'tags:afterResolve', ctx)

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -12,6 +12,14 @@ const sortTags = (a: HeadTag, b: HeadTag) => a._w === b._w ? a._p - b._p : a._w 
 
 const DEFAULT_TAG_WEIGHT = () => 100
 
+// emptiness check without allocating an Object.keys array (runs per tag in sanitizeTags)
+function isEmptyProps(props: Record<string, any>): boolean {
+  // eslint-disable-next-line no-unreachable-loop -- intentional: any key means non-empty
+  for (const _ in props)
+    return false
+  return true
+}
+
 // matches the hooks that receive references to resolved tags and may mutate them in place
 // (tags:beforeResolve, tags:resolve, tags:afterResolve, ssr:render, ssr:rendered, dom:rendered
 // and deprecated dom:renderTag — but not *:beforeRender, entries:* or script:updated);
@@ -121,7 +129,7 @@ export function sanitizeTags(tags: HeadTag[]): HeadTag[] {
   const out: HeadTag[] = []
   for (let t of tags) {
     const { innerHTML, tag, props } = t
-    if (!ValidHeadTags.has(tag) || (!Object.keys(props).length && !innerHTML && !t.textContent))
+    if (!ValidHeadTags.has(tag) || (isEmptyProps(props) && !innerHTML && !t.textContent))
       continue
     if (tag === 'meta' && !props.content && !props['http-equiv'] && !props.charset)
       continue


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Hot-path micro-optimizations across the SSR pipeline. `useSeoMeta` flattening, `FlatMetaPlugin`, `dedupe`, `normalize`, `resolve`, `propsToString` and the parser avoid intermediate spreads and `filter(Boolean)` passes, and `callHook` skips dispatch when a hook has no listeners.

Scope is limited to `packages/unhead/src/*` (8 files); no behaviour change, no public API change. All bench tooling and the memory/size/perf reporting that validates these wins lives in #793, so the two PRs are independent and can merge in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization and resolution of title, meta, link, script, style, and base tags for more consistent head output.
  * Fixed edge cases where meta content provided as multiple values now renders as separate entries.
  * Enhanced flat-meta handling and meta deduplication to produce more reliable merged results.
  * Improved server-side string generation for `class` and `style`, yielding more consistent output and better hook-driven behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->