### PR TITLE
chore(ci): repair bundle-perf report (harness path + empty-perf crash)

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -49,10 +49,9 @@ jobs:
           # snapshot the whole base dist; report.ts diffs PR dist against it by path
           rm -rf /tmp/base-dist
           cp -r bench/bundle/dist /tmp/base-dist
-          # measure base perf against the base-built packages, then clean up
-          cp /tmp/perf-ci.mjs bench/perf-ci.mjs
-          node --expose-gc bench/perf-ci.mjs > /tmp/base-perf.json || echo '{}' > /tmp/base-perf.json
-          rm -f bench/perf-ci.mjs
+          # measure base perf with the PR's harness against the base-built packages;
+          # run from /tmp so the working tree stays clean across the checkout back
+          node --expose-gc /tmp/perf-ci.mjs > /tmp/base-perf.json || echo '{}' > /tmp/base-perf.json
           git checkout -
 
       - name: Build PR bundles

--- a/bench/bundle/perf-report.ts
+++ b/bench/bundle/perf-report.ts
@@ -72,7 +72,7 @@ function deltaCell(row: Row): string {
 }
 
 export function renderPerfReport(base: PerfRun | null, pr: PerfRun): string {
-  const rows = pr.benches.map(b => classify(b, base?.benches.find(x => x.id === b.id)))
+  const rows = pr.benches.map(b => classify(b, base?.benches?.find(x => x.id === b.id)))
   const changed = rows.filter(r => r.status === 'slower' || r.status === 'faster')
   const slower = changed.filter(r => r.status === 'slower')
 

--- a/bench/bundle/report.ts
+++ b/bench/bundle/report.ts
@@ -12,8 +12,9 @@ function readPerf(p?: string) {
   return p && fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')) : null
 }
 
+// guard on benches: a perf run that failed writes `{}`, which must skip the section, not crash
 const prPerf = readPerf(process.env.PR_PERF)
-if (prPerf)
+if (prPerf?.benches?.length)
   sections.push(renderPerfReport(readPerf(process.env.BASE_PERF), prPerf))
 
 let out = sections.join('\n\n---\n\n')

--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -4,8 +4,13 @@
 //  - SSR retained heap over a fixed run (leak indicator, needs --expose-gc)
 // It imports built dist on purpose (measures shipped output), hence the .mjs +
 // eslint ignore. Output is a single JSON line; keep stdout clean.
-import { useHead, useSeoMeta } from '../packages/unhead/dist/index.mjs'
-import { createHead, renderSSRHead } from '../packages/unhead/dist/server.mjs'
+import { pathToFileURL } from 'node:url'
+
+// resolve built dist from the repo root (cwd) so this harness can run from anywhere
+// (e.g. /tmp during the base-branch measurement) without a relative path back to packages/
+const dist = name => import(pathToFileURL(`${process.cwd()}/packages/unhead/dist/${name}`).href)
+const { useHead, useSeoMeta } = await dist('index.mjs')
+const { createHead, renderSSRHead } = await dist('server.mjs')
 
 function renderMediumSsrHead() {
   const head = createHead({ disableDefaults: true })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `analyze-bundle-size` workflow (added in #793) fails on every PR. Two bugs:

1. The base-perf step copied `perf-ci.mjs` into `bench/` and then `rm`'d it before `git checkout -`. Git carries that working-tree deletion across the checkout, so the **PR build can't find the harness** (`Cannot find module .../bench/perf-ci.mjs`); the PR perf run writes `{}`.
2. `report.ts` then calls `renderPerfReport` on the empty `{}`, crashing on `pr.benches.map` (`undefined is not an object`) and failing the job.

Fixes:
- **perf-ci.mjs**: resolve built `dist` from `process.cwd()` (repo root) via a file URL, so the harness runs straight from `/tmp` during the base measurement, no working-tree juggling.
- **bundle-size.yml**: run `/tmp/perf-ci.mjs` for the base build; drop the cp-into-`bench/` + `rm`.
- **report.ts**: skip the perf section when the JSON has no `benches` (a failed run writes `{}`) rather than crashing, so the bundle comment always posts.
- **perf-report.ts**: guard `base?.benches?.find` against a benchless base.

Verified locally: harness runs from `/tmp`; report with `{}` perf skips the section without crashing; report with valid perf renders it.