### PR TITLE
chore(bench): add CSR re-render benchmarks (DOM mutations + time)

### DIFF
--- a/bench/bundle/perf-report.ts
+++ b/bench/bundle/perf-report.ts
@@ -62,10 +62,11 @@ function classify(pr: PerfBench, base?: PerfBench): Row {
     significant = Math.abs(deltaPct) > threshold
   }
   else if (pr.kind === 'count') {
-    significant = Math.abs(deltaPct) > COUNT_FLOOR_PCT && Math.abs(delta) > COUNT_FLOOR_UNITS
+    // a zero baseline (0 -> N) has no meaningful percentage; fall back to the absolute floor
+    significant = Math.abs(delta) > COUNT_FLOOR_UNITS && (base.value === 0 || Math.abs(deltaPct) > COUNT_FLOOR_PCT)
   }
   else {
-    significant = Math.abs(deltaPct) > ALLOC_FLOOR_PCT && Math.abs(delta) > ALLOC_FLOOR_BYTES
+    significant = Math.abs(delta) > ALLOC_FLOOR_BYTES && (base.value === 0 || Math.abs(deltaPct) > ALLOC_FLOOR_PCT)
   }
   if (!significant)
     return { bench: pr, base, status: 'same', deltaPct }
@@ -94,7 +95,7 @@ export function renderPerfReport(base: PerfRun | null, pr: PerfRun): string {
 
   const out: string[] = ['## ⚡ Performance _(directional)_', '']
   if (slower.length)
-    out.push(`⚠️ **${slower.length} slower** · gated at \`|Δ| > max(10%, 2×RME)\``)
+    out.push(`⚠️ **${slower.length} slower** · past the per-metric noise gate`)
   else if (changed.length)
     out.push(`🟢 **${changed.length} faster**`)
   else

--- a/bench/bundle/perf-report.ts
+++ b/bench/bundle/perf-report.ts
@@ -3,11 +3,13 @@
 //           noisy on shared runners, so the gate is RME-bound; small gains stay hidden.
 //  - alloc: |Δ| > max(2%, 1 KiB). Bytes allocated per render is near-deterministic
 //           (~0 noise), so a tight gate surfaces the marginal gains time can't show.
+//  - count: |Δ| > max(2%, 0.5). DOM mutations per CSR navigation; deterministic,
+//           so a half-op change is real (a renderer touching more of the DOM).
 
 export interface PerfBench {
   id: string
   name: string
-  kind: 'time' | 'alloc'
+  kind: 'time' | 'alloc' | 'count'
   value: number
   rme?: number
   runs?: number
@@ -20,6 +22,8 @@ export interface PerfRun {
 const TIME_FLOOR_PCT = 5
 const ALLOC_FLOOR_PCT = 2
 const ALLOC_FLOOR_BYTES = 1024
+const COUNT_FLOOR_PCT = 2
+const COUNT_FLOOR_UNITS = 0.5
 
 type Status = 'new' | 'slower' | 'faster' | 'same'
 
@@ -33,6 +37,8 @@ interface Row {
 function fmtValue(b: PerfBench): string {
   if (b.kind === 'time')
     return `${b.value.toFixed(3)} ms`
+  if (b.kind === 'count')
+    return `${Math.round(b.value * 10) / 10}`
   const kib = Math.round((b.value / 1024) * 10) / 10
   return `${kib} KiB`
 }
@@ -55,12 +61,15 @@ function classify(pr: PerfBench, base?: PerfBench): Row {
     const threshold = Math.max(TIME_FLOOR_PCT, 2 * ((base.rme || 0) + (pr.rme || 0)))
     significant = Math.abs(deltaPct) > threshold
   }
+  else if (pr.kind === 'count') {
+    significant = Math.abs(deltaPct) > COUNT_FLOOR_PCT && Math.abs(delta) > COUNT_FLOOR_UNITS
+  }
   else {
     significant = Math.abs(deltaPct) > ALLOC_FLOOR_PCT && Math.abs(delta) > ALLOC_FLOOR_BYTES
   }
   if (!significant)
     return { bench: pr, base, status: 'same', deltaPct }
-  // higher is worse for both time and allocation
+  // higher is worse for time, allocation and DOM-mutation count
   return { bench: pr, base, status: delta > 0 ? 'slower' : 'faster', deltaPct }
 }
 
@@ -73,6 +82,8 @@ function deltaCell(row: Row): string {
   if (row.bench.kind === 'time')
     return `${emoji} ${fmtPct(row.deltaPct)}`
   const delta = row.bench.value - (row.base?.value ?? 0)
+  if (row.bench.kind === 'count')
+    return `${emoji} ${delta > 0 ? '+' : ''}${Math.round(delta * 10) / 10} (${fmtPct(row.deltaPct)})`
   return `${emoji} ${delta > 0 ? '+' : '-'}${fmtKib(Math.abs(delta))} (${fmtPct(row.deltaPct)})`
 }
 

--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -104,8 +104,11 @@ async function csrBenches() {
     const req = createRequire(`${process.cwd()}/`)
     ;({ JSDOM } = await import(pathToFileURL(req.resolve('jsdom')).href))
   }
-  catch {
-    return []
+  catch (e) {
+    // skip CSR only when jsdom genuinely isn't installed; surface any other failure
+    if (e?.code === 'MODULE_NOT_FOUND' || e?.code === 'ERR_MODULE_NOT_FOUND')
+      return []
+    throw e
   }
   const { createHead } = await dist('client.mjs')
 
@@ -130,7 +133,8 @@ async function csrBenches() {
   let muts = 0
   const obs = new W.MutationObserver((records) => {
     for (const r of records)
-      muts += r.type === 'attributes' ? 1 : r.addedNodes.length + r.removedNodes.length
+      // childList counts each node touched; attribute and characterData (title/text) are one op each
+      muts += r.type === 'childList' ? r.addedNodes.length + r.removedNodes.length : 1
   })
   obs.observe(W.document.documentElement, { attributes: true, childList: true, subtree: true, characterData: true })
   const N = 200

--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -92,6 +92,60 @@ function measureAlloc(fn, { warmup = 50, reps = 25, runs = 60 } = {}) {
 if (typeof globalThis.gc !== 'function')
   throw new TypeError('Run with node --expose-gc so allocation can be measured.')
 
+// CSR: client re-render (SPA navigation) against a jsdom document. The faithful,
+// browser-agnostic signal is DOM mutation count (a good diff touches only what
+// changed); jsdom heap alloc is NOT measured here because it's dominated by jsdom
+// internals, not the renderer. Time is directional. Skipped if jsdom is absent.
+async function csrBenches() {
+  let JSDOM
+  try {
+    // resolve jsdom from cwd (repo root), not this script's dir — base perf runs it from /tmp
+    const { createRequire } = await import('node:module')
+    const req = createRequire(`${process.cwd()}/`)
+    ;({ JSDOM } = await import(pathToFileURL(req.resolve('jsdom')).href))
+  }
+  catch {
+    return []
+  }
+  const { createHead } = await dist('client.mjs')
+
+  const pageHead = i => ({
+    title: `Page ${i}`,
+    titleTemplate: '%s | Site',
+    htmlAttrs: { class: `theme-${i % 3} loaded` },
+    meta: Array.from({ length: 20 }, (_, j) => ({ name: `m${j}`, content: `v${i}-${j}` })),
+    link: Array.from({ length: 6 }, (_, j) => ({ rel: 'preload', as: 'script', href: `/_nuxt/c${i}-${j}.js` })),
+    script: [{ src: `/app-${i}.js`, defer: true }],
+  })
+
+  const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>')
+  const W = dom.window
+  const head = createHead({ document: W.document })
+  const entry = head.push(pageHead(0))
+  let i = 1
+  const nav = () => entry.patch(pageHead(i++))
+
+  // DOM mutations per navigation (deterministic): observe a fixed window of navs
+  for (let w = 0; w < 20; w++) nav()
+  let muts = 0
+  const obs = new W.MutationObserver((records) => {
+    for (const r of records)
+      muts += r.type === 'attributes' ? 1 : r.addedNodes.length + r.removedNodes.length
+  })
+  obs.observe(W.document.documentElement, { attributes: true, childList: true, subtree: true, characterData: true })
+  const N = 200
+  for (let k = 0; k < N; k++) nav()
+  await new Promise(r => setTimeout(r, 0)) // flush the observer's microtask queue
+  obs.disconnect()
+
+  const t = measureTimes(nav, { warmup: 50, reps: 30, runs: 60 })
+  return [
+    { id: 'csr-nav-mutations', name: 'CSR DOM mutations / nav', kind: 'count', value: muts / N },
+    { id: 'csr-nav-cpu', name: 'CSR re-render (CPU)', kind: 'time', value: t.cpu.value, rme: t.cpu.rme },
+    { id: 'csr-nav-wall', name: 'CSR re-render (wall)', kind: 'time', value: t.wall.value, rme: t.wall.rme },
+  ]
+}
+
 const times = measureTimes(renderMediumSsrHead)
 const alloc = measureAlloc(renderMediumSsrHead)
 
@@ -100,6 +154,7 @@ const result = {
     { id: 'ssr-medium-cpu', name: 'SSR render (CPU)', kind: 'time', value: times.cpu.value, rme: times.cpu.rme },
     { id: 'ssr-medium-wall', name: 'SSR render (wall)', kind: 'time', value: times.wall.value, rme: times.wall.rme },
     { id: 'ssr-medium-alloc', name: 'SSR allocated / render', kind: 'alloc', value: alloc.value },
+    ...await csrBenches(),
   ],
 }
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The perf harness only measured SSR. This adds **client re-render (CSR)** coverage so DOM-renderer changes (e.g. #787) are measured on every PR.

What it measures, per simulated SPA navigation (`entry.patch(...)` against a jsdom document):
- **CSR DOM mutations / nav** — the browser-faithful, deterministic signal. A good diff touches only what changed; a regression here means the renderer mutates more of the DOM than necessary. Tight gate (`max(2%, 0.5 ops)`).
- **CSR re-render CPU / wall time** — directional (RME-gated).

It deliberately does **not** measure jsdom heap allocation for CSR: a heap-sampling profile showed ~90% of CSR allocation is jsdom internals (SymbolTree, AttrImpl, query-cache invalidation), not the renderer, so it's a misleading proxy for real-browser cost.

Implementation notes:
- jsdom is resolved from `cwd` (so the base-branch measurement, run from `/tmp`, still finds it) and the whole section is skipped if jsdom is unavailable.
- Adds a `count` kind to `perf-report.ts`.

### Context

Built while validating #787 (client DOM renderer). On this metric, #787 is at **parity with main** (38 mutations/nav both) — confirming its diff is exactly as efficient — which the earlier jsdom-allocation scare had obscured. After this merges, #787 rebased will show CSR in its comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a count-based benchmark metric alongside existing time and allocation metrics.
  * Extended performance report tables to display count values and count delta details.
  * Added client-side navigation benchmarks, including DOM mutation counts and re-render timing (CPU and wall time).

* **Bug Fixes**
  * Updated “significant change” noise suppression to correctly handle count-based deltas, including zero baseline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->