### PR TITLE
perf(bench): make perf signals trustworthy (wall informational + alloc hardening)

### DIFF
--- a/bench/bundle/perf-report.ts
+++ b/bench/bundle/perf-report.ts
@@ -5,6 +5,9 @@
 //           (~0 noise), so a tight gate surfaces the marginal gains time can't show.
 //  - count: |Δ| > max(2%, 0.5). DOM mutations per CSR navigation; deterministic,
 //           so a half-op change is real (a renderer touching more of the DOM).
+// Wall time is `informational`: shown for reference but it never drives the verdict, because
+// it's the noisiest signal (GC/scheduling) and would false-alarm while CPU and the
+// deterministic metrics agree. CPU is the gated time authority.
 
 export interface PerfBench {
   id: string
@@ -13,6 +16,8 @@ export interface PerfBench {
   value: number
   rme?: number
   runs?: number
+  // reported for reference but excluded from the verdict (e.g. wall time)
+  informational?: boolean
 }
 
 export interface PerfRun {
@@ -77,6 +82,9 @@ function classify(pr: PerfBench, base?: PerfBench): Row {
 function deltaCell(row: Row): string {
   if (row.status === 'new')
     return '🆕 new'
+  // informational metrics (wall time) report their delta neutrally, never as slower/faster
+  if (row.bench.informational)
+    return row.status === 'same' ? '~ noise' : `ℹ️ ${fmtPct(row.deltaPct)}`
   if (row.status === 'same')
     return '~ noise'
   const emoji = row.status === 'slower' ? '🔴' : '🟢'
@@ -90,7 +98,8 @@ function deltaCell(row: Row): string {
 
 export function renderPerfReport(base: PerfRun | null, pr: PerfRun): string {
   const rows = pr.benches.map(b => classify(b, base?.benches?.find(x => x.id === b.id)))
-  const changed = rows.filter(r => r.status === 'slower' || r.status === 'faster')
+  // informational benches (wall time) are shown in the details but never drive the verdict
+  const changed = rows.filter(r => !r.bench.informational && (r.status === 'slower' || r.status === 'faster'))
   const slower = changed.filter(r => r.status === 'slower')
 
   const out: string[] = ['## ⚡ Performance _(directional)_', '']

--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -146,7 +146,7 @@ async function csrBenches() {
   return [
     { id: 'csr-nav-mutations', name: 'CSR DOM mutations / nav', kind: 'count', value: muts / N },
     { id: 'csr-nav-cpu', name: 'CSR re-render (CPU)', kind: 'time', value: t.cpu.value, rme: t.cpu.rme },
-    { id: 'csr-nav-wall', name: 'CSR re-render (wall)', kind: 'time', value: t.wall.value, rme: t.wall.rme },
+    { id: 'csr-nav-wall', name: 'CSR re-render (wall)', kind: 'time', value: t.wall.value, rme: t.wall.rme, informational: true },
   ]
 }
 
@@ -156,7 +156,7 @@ const alloc = measureAlloc(renderMediumSsrHead)
 const result = {
   benches: [
     { id: 'ssr-medium-cpu', name: 'SSR render (CPU)', kind: 'time', value: times.cpu.value, rme: times.cpu.rme },
-    { id: 'ssr-medium-wall', name: 'SSR render (wall)', kind: 'time', value: times.wall.value, rme: times.wall.rme },
+    { id: 'ssr-medium-wall', name: 'SSR render (wall)', kind: 'time', value: times.wall.value, rme: times.wall.rme, informational: true },
     { id: 'ssr-medium-alloc', name: 'SSR allocated / render', kind: 'alloc', value: alloc.value },
     ...await csrBenches(),
   ],


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Wall time is the noisiest perf signal (it includes GC pauses and time the process was descheduled), so it false-alarmed a `⚠️ 1 slower` verdict on #787 (`CSR re-render (wall) +10.5%`) while **CPU** and **DOM mutations/nav** — the reliable signals — both showed no change.

This marks the wall benches `informational`: they still appear in the details table with their delta (rendered neutrally as `ℹ️ +10.4%`), but they no longer drive the verdict or the surfaced-changes table. CPU stays the gated time authority; alloc and mutation count keep their deterministic gates.

Verified:
- The exact #787 case (wall +10.5%, CPU/mutations flat) now reads **✅ No significant change**, with wall shown as `ℹ️ +10.4%`.
- A real CPU +18% / alloc +5% still flags **⚠️ 2 slower**, so gating on the trustworthy signals is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance report labeling so informational metrics no longer affect faster/slower verdicts.
  * Wall-time benchmarks now display as informational, while still showing their measured deltas.
  * Informational benchmarks remain visible in the full benchmark list, but are excluded from directional summary counts and warning details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->