### PR TITLE
perf(ssr): self-closing tag hot path

### DIFF
--- a/packages/unhead/src/server/util/tagToString.ts
+++ b/packages/unhead/src/server/util/tagToString.ts
@@ -15,12 +15,16 @@ export function escapeHtml(str: string) {
 export function tagToString<T extends HeadTag>(tag: T) {
   const attrs = propsToString(tag.props)
   const openTag = `<${tag.tag}${attrs}>`
-  // get the encoding depending on the tag type
+  // self-closing (meta/link/base) is the common SSR tag: one Set lookup, no close tag.
+  // SelfClosingTags and TagsWithInnerContent are disjoint, so the second SelfClosingTags.has()
+  // the content branch used to do was provably dead.
+  if (SelfClosingTags.has(tag.tag))
+    return openTag
   if (!TagsWithInnerContent.has(tag.tag))
-    return SelfClosingTags.has(tag.tag) ? openTag : `${openTag}</${tag.tag}>`
+    return `${openTag}</${tag.tag}>`
 
   // dangerously using innerHTML, we don't encode this
   let content = String(tag.textContent || tag.innerHTML || '')
   content = tag.tag === 'title' ? escapeHtml(content) : content.replace(CLOSE_TAG_RE[tag.tag] ||= new RegExp(`<\/${tag.tag}`, 'gi'), `<\\/${tag.tag}`)
-  return SelfClosingTags.has(tag.tag) ? openTag : `${openTag}${content}</${tag.tag}>`
+  return `${openTag}${content}</${tag.tag}>`
 }


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`SelfClosingTags` (`{meta, link, base}`) and `TagsWithInnerContent` (`{title, titleTemplate, script, style, noscript}`) are **disjoint sets**, so the `SelfClosingTags.has(tag.tag)` check inside the content branch (only reached for content tags) was **provably always false** — dead code.

Reordering to check self-closing first means the common SSR tag (meta/link/base) resolves in **one** Set lookup instead of two, and the dead branch is removed. Output is byte-identical (a tag in neither set still emits `<tag></tag>` both ways; `htmlAttrs`/`bodyAttrs` are filtered before `tagToString`). All 704 unit tests pass.

### Context

Found during a render-path optimization sweep. Note: the same sweep flagged dropping `propsToString`'s `Object.hasOwn` guard as 'dead', but the test suite correctly caught that it's load-bearing (it skips inherited/prototype-polluted enumerable props like `onload`), so that was left untouched. This PR is only the genuinely-dead `tagToString` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how server-rendered tags are converted to strings, ensuring self-closing tags and empty tags are handled correctly.
  * Preserved proper escaping for tag content, including special handling for titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->