### PR TITLE
fix(angular): correct package type exports

### DIFF
--- a/packages/angular/client.d.ts
+++ b/packages/angular/client.d.ts
@@ -1,1 +1,1 @@
-export * from './dist/client'
+export * from './dist/types/unhead-angular-client'

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -25,27 +25,27 @@
       "default": "./package.json"
     },
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/unhead-angular.d.ts",
       "default": "./dist/fesm2022/unhead-angular.mjs"
     },
     "./client": {
-      "types": "./dist/client/index.d.ts",
+      "types": "./dist/types/unhead-angular-client.d.ts",
       "default": "./dist/fesm2022/unhead-angular-client.mjs"
     },
     "./server": {
-      "types": "./dist/server/index.d.ts",
+      "types": "./dist/types/unhead-angular-server.d.ts",
       "default": "./dist/fesm2022/unhead-angular-server.mjs"
     }
   },
   "module": "dist/fesm2022/unhead-angular.mjs",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/unhead-angular.d.ts",
   "typesVersions": {
     "*": {
       "server": [
-        "dist/server"
+        "dist/types/unhead-angular-server.d.ts"
       ],
       "client": [
-        "dist/client"
+        "dist/types/unhead-angular-client.d.ts"
       ]
     }
   },
@@ -62,7 +62,7 @@
     "test:attw": "true",
     "prepack": "pnpm run build"
   },
-  "typings": "./dist/index.d.ts",
+  "typings": "./dist/types/unhead-angular.d.ts",
   "peerDependencies": {
     "@angular/common": "^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/core": "^19.0.0 || ^20.0.0 || ^21.0.0"

--- a/packages/angular/server.d.ts
+++ b/packages/angular/server.d.ts
@@ -1,1 +1,1 @@
-export * from './dist/server'
+export * from './dist/types/unhead-angular-server'

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,10 +1,28 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import * as yaml from 'js-yaml'
 import { x } from 'tinyexec'
 import { describe, expect, it } from 'vitest'
 import { getPackageExportsManifest } from 'vitest-package-exports'
 
+interface WorkspacePackage {
+  name: string
+  path: string
+  private?: boolean
+}
+
+interface PackageJson {
+  exports?: Record<string, unknown>
+  types?: string
+  typings?: string
+}
+
+function hasTypesExport(value: unknown): value is { types: string } {
+  return !!value && typeof value === 'object' && !Array.isArray(value) && typeof (value as { types?: unknown }).types === 'string'
+}
+
 describe('exports-snapshot', async () => {
-  const packages: { name: string, path: string, private?: boolean }[] = JSON.parse(
+  const packages: WorkspacePackage[] = JSON.parse(
     await x('pnpm', ['ls', '-r', '--json', '--depth', '-1']).then(r => r.stdout),
   )
 
@@ -18,6 +36,36 @@ describe('exports-snapshot', async () => {
       })
       await expect(yaml.dump(manifest.exports, { sortKeys: (a, b) => a.localeCompare(b) }))
         .toMatchFileSnapshot(`./exports/${pkg.name.split('/').pop()}.yaml`)
+    })
+  }
+})
+
+describe('package type paths', async () => {
+  const packages: WorkspacePackage[] = JSON.parse(
+    await x('pnpm', ['ls', '-r', '--json', '--depth', '-1']).then(r => r.stdout),
+  )
+
+  for (const pkg of packages) {
+    if (pkg.private || pkg.path.includes('packages-aliased'))
+      continue
+    it(`${pkg.name} references existing type files`, () => {
+      const packageJson = JSON.parse(readFileSync(join(pkg.path, 'package.json'), 'utf8')) as PackageJson
+      const typePaths: { label: string, path: string }[] = []
+
+      if (packageJson.types)
+        typePaths.push({ label: 'types', path: packageJson.types })
+      if (packageJson.typings)
+        typePaths.push({ label: 'typings', path: packageJson.typings })
+
+      for (const [name, value] of Object.entries(packageJson.exports || {})) {
+        if (hasTypesExport(value))
+          typePaths.push({ label: `exports ${name}`, path: value.types })
+      }
+
+      const missing = typePaths
+        .filter(typePath => !existsSync(join(pkg.path, typePath.path)))
+        .map(typePath => `${typePath.label}: ${typePath.path}`)
+      expect(missing).toEqual([])
     })
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #796

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@unhead/angular` exported declaration paths that did not exist in the published package layout. This points the root, client, and server type metadata at the `dist/types` files generated by ng-packagr and adds a package metadata check so missing type paths fail in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Angular package entry points so published client and server types resolve correctly.
  * Improved type path consistency for package consumers, helping prevent broken imports in TypeScript projects.

* **Tests**
  * Added coverage to verify all published type references in package metadata point to files that actually exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->