### PR TITLE
test: validate package typesVersions paths

### DIFF
--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -23,11 +23,12 @@ function hasTypesExport(value: unknown): value is { types: string } {
 }
 
 function hasTypeDeclaration(packagePath: string, typePath: string) {
-  const candidates = [
-    typePath,
-    `${typePath}.d.ts`,
-    join(typePath, 'index.d.ts'),
-  ]
+  const candidates = typePath.endsWith('.d.ts')
+    ? [typePath]
+    : [
+        `${typePath}.d.ts`,
+        join(typePath, 'index.d.ts'),
+      ]
   return candidates.some(candidate => existsSync(join(packagePath, candidate)))
 }
 

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -14,11 +14,21 @@ interface WorkspacePackage {
 interface PackageJson {
   exports?: Record<string, unknown>
   types?: string
+  typesVersions?: Record<string, Record<string, string[]>>
   typings?: string
 }
 
 function hasTypesExport(value: unknown): value is { types: string } {
   return !!value && typeof value === 'object' && !Array.isArray(value) && typeof (value as { types?: unknown }).types === 'string'
+}
+
+function hasTypeDeclaration(packagePath: string, typePath: string) {
+  const candidates = [
+    typePath,
+    `${typePath}.d.ts`,
+    join(typePath, 'index.d.ts'),
+  ]
+  return candidates.some(candidate => existsSync(join(packagePath, candidate)))
 }
 
 describe('exports-snapshot', async () => {
@@ -27,7 +37,7 @@ describe('exports-snapshot', async () => {
   )
 
   for (const pkg of packages) {
-    if (pkg.private || pkg.path.includes('packages-aliased') || pkg.path.includes('angular'))
+    if (pkg.private || pkg.path.includes('packages-aliased') || pkg.name === '@unhead/angular')
       continue
     it(`${pkg.name}`, async () => {
       const manifest = await getPackageExportsManifest({
@@ -62,8 +72,15 @@ describe('package type paths', async () => {
           typePaths.push({ label: `exports ${name}`, path: value.types })
       }
 
+      for (const [range, mappings] of Object.entries(packageJson.typesVersions || {})) {
+        for (const [specifier, mappedPaths] of Object.entries(mappings)) {
+          for (const mappedPath of mappedPaths)
+            typePaths.push({ label: `typesVersions ${range} ${specifier}`, path: mappedPath })
+        }
+      }
+
       const missing = typePaths
-        .filter(typePath => !existsSync(join(pkg.path, typePath.path)))
+        .filter(typePath => !hasTypeDeclaration(pkg.path, typePath.path))
         .map(typePath => `${typePath.label}: ${typePath.path}`)
       expect(missing).toEqual([])
     })


### PR DESCRIPTION
### 🔗 Linked issue

Related to #796
Follow-up to #802

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds `typesVersions` coverage to the package type-path guardrail introduced for `@unhead/angular`. The check now handles TypeScript's extensionless declaration paths, so entries like `dist/server` are validated against `dist/server.d.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of package metadata used for type-declaration checks, including support for additional type-mapping fields.
  * Enhanced missing-type detection to account for multiple common declaration layouts (e.g., direct `.d.ts` files and `index.d.ts`-style entries), leading to more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->