### PR TITLE
fix(solid-js): harden streaming wrapper

### DIFF
--- a/examples/vite-ssr-solidjs-streaming/index.html
+++ b/examples/vite-ssr-solidjs-streaming/index.html
@@ -139,5 +139,5 @@
     </script>
     <script type="module" src="/src/entry-client.tsx"></script>
   </head>
-  <body></body>
+  <body><div id="root"><!--app-html--></div></body>
 </html>

--- a/examples/vite-ssr-solidjs-streaming/src/components/Reviews.tsx
+++ b/examples/vite-ssr-solidjs-streaming/src/components/Reviews.tsx
@@ -20,20 +20,19 @@ export default function Reviews() {
 
   const avgStars = () => '★'.repeat(Math.floor(data()?.avgRating || 0))
 
-  // Only add progress style during loading, add JSON-LD when data is ready
   useHead({
     title: 'StreamShop 10/11 - Almost there...',
-    script: data() ? [
+    script: [
       {
         type: 'application/ld+json',
         innerHTML: JSON.stringify({
           '@context': 'https://schema.org',
           '@type': 'AggregateRating',
-          ratingValue: data()!.avgRating,
-          reviewCount: data()!.reviews.length,
+          ratingValue: DATA.avgRating,
+          reviewCount: DATA.reviews.length,
         }),
       },
-    ] : [],
+    ],
     style: [{ key: 'progress', innerHTML: '.stream-progress::after{width:91%}' }],
   })
 

--- a/examples/vite-ssr-solidjs-streaming/src/components/Reviews.tsx
+++ b/examples/vite-ssr-solidjs-streaming/src/components/Reviews.tsx
@@ -25,7 +25,7 @@ export default function Reviews() {
     script: [
       {
         type: 'application/ld+json',
-        innerHTML: JSON.stringify({
+        textContent: JSON.stringify({
           '@context': 'https://schema.org',
           '@type': 'AggregateRating',
           ratingValue: DATA.avgRating,

--- a/examples/vite-ssr-solidjs-streaming/src/entry-client.tsx
+++ b/examples/vite-ssr-solidjs-streaming/src/entry-client.tsx
@@ -10,5 +10,5 @@ hydrate(
       <App url={window.location.pathname} />
     </UnheadContext.Provider>
   ),
-  document.getElementById('app')!
+  document.getElementById('root')!
 )

--- a/examples/vite-ssr-solidjs-streaming/vite.config.ts
+++ b/examples/vite-ssr-solidjs-streaming/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite'
 import solid from 'vite-plugin-solid'
-import unhead from '@unhead/solid-js/vite'
+import { Unhead } from '@unhead/solid-js/vite'
 
 export default defineConfig({
   plugins: [
     // MUST come before solid() to see JSX before it's compiled to function calls
-    unhead({ streaming: true }),
+    Unhead({ streaming: true }),
     solid({ ssr: true }),
   ],
   build: {

--- a/packages/solid-js/src/stream/server.ts
+++ b/packages/solid-js/src/stream/server.ts
@@ -77,25 +77,148 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
     },
     wrapStream: (stream: ReadableStream<Uint8Array>, template: string) => {
       const encoder = new TextEncoder()
+      let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
+      let readerReleased = false
+      let settled = false
+      let pumpDone: Promise<void> = Promise.resolve()
+      let cancelInner: (reason: unknown) => Promise<unknown> = async () => undefined
+      let resolveSettled = () => {}
+      const settledSignal = new Promise<void>((resolve) => {
+        resolveSettled = resolve
+      })
+
+      const settle = () => {
+        if (settled)
+          return false
+        settled = true
+        resolveSettled()
+        return true
+      }
 
       return new ReadableStream<Uint8Array>({
-        async start(controller) {
-          // Wait for shell to be ready before writing
-          const shellState = await shellReady
-          const { shell, end } = prepareStreamingTemplate(head, template, shellState)
-          controller.enqueue(encoder.encode(shell))
+        start(controller) {
+          let shellResolved = false
+          let shellFlushed = false
+          let innerDone = false
+          let end = ''
+          let shellState: SSRHeadPayload | undefined
+          const bufferedChunks: Uint8Array[] = []
 
-          const reader = stream.getReader()
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done)
-              break
-            controller.enqueue(value)
+          const fail = (error: unknown) => {
+            if (!settle())
+              return
+            controller.error(error)
           }
-          reader.releaseLock()
 
-          controller.enqueue(encoder.encode(end))
-          controller.close()
+          const releaseReader = () => {
+            if (!reader || readerReleased)
+              return
+            reader.releaseLock()
+            readerReleased = true
+          }
+
+          cancelInner = async (reason: unknown): Promise<unknown> => {
+            if (!reader || readerReleased)
+              return
+            try {
+              await reader.cancel(reason)
+            }
+            catch (error) {
+              return error
+            }
+          }
+
+          const flushShellAndChunks = () => {
+            if (settled || !shellResolved)
+              return
+
+            try {
+              if (!shellFlushed) {
+                const prepared = prepareStreamingTemplate(head, template, shellState)
+                controller.enqueue(encoder.encode(prepared.shell))
+                end = prepared.end
+                shellFlushed = true
+              }
+
+              while (bufferedChunks.length) {
+                controller.enqueue(bufferedChunks.shift()!)
+              }
+
+              if (innerDone) {
+                controller.enqueue(encoder.encode(end))
+                settle()
+                controller.close()
+              }
+            }
+            catch (error) {
+              fail(error)
+              void cancelInner(error)
+            }
+          }
+
+          try {
+            reader = stream.getReader()
+          }
+          catch (error) {
+            fail(error)
+            return
+          }
+
+          // Read immediately so app stream failures before onCompleteShell do not hang the wrapper.
+          pumpDone = (async () => {
+            try {
+              while (true) {
+                if (settled)
+                  break
+                const { done, value } = await reader!.read()
+                if (settled)
+                  break
+                if (done) {
+                  innerDone = true
+                  flushShellAndChunks()
+                  break
+                }
+                if (shellFlushed) {
+                  controller.enqueue(value)
+                }
+                else {
+                  bufferedChunks.push(value)
+                  flushShellAndChunks()
+                }
+              }
+            }
+            catch (error) {
+              fail(error)
+            }
+            finally {
+              releaseReader()
+            }
+          })()
+
+          void (async () => {
+            try {
+              const ready = await Promise.race([
+                shellReady.then(state => ({ state })),
+                settledSignal.then(() => undefined),
+              ])
+              if (!ready)
+                return
+              shellState = ready.state
+              shellResolved = true
+              flushShellAndChunks()
+            }
+            catch (error) {
+              fail(error)
+              void cancelInner(error)
+            }
+          })()
+        },
+        async cancel(reason?: unknown) {
+          settle()
+          const cancelError = await cancelInner(reason)
+          await pumpDone
+          if (cancelError)
+            throw cancelError
         },
       })
     },

--- a/packages/solid-js/src/stream/server.ts
+++ b/packages/solid-js/src/stream/server.ts
@@ -79,21 +79,24 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
       const encoder = new TextEncoder()
       let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
       let readerReleased = false
-      let settled = false
+      let stopped = false
+      let terminalDelivered = false
       let pumpDone: Promise<void> = Promise.resolve()
       let cancelInner: (reason: unknown) => Promise<unknown> = async () => undefined
-      let resolveSettled = () => {}
-      const settledSignal = new Promise<void>((resolve) => {
-        resolveSettled = resolve
+      let resolveStopped = () => {}
+      const stoppedSignal = new Promise<void>((resolve) => {
+        resolveStopped = resolve
       })
 
-      const settle = () => {
-        if (settled)
+      const stop = () => {
+        if (stopped)
           return false
-        settled = true
-        resolveSettled()
+        stopped = true
+        resolveStopped()
         return true
       }
+
+      let flushOutput = () => {}
 
       return new ReadableStream<Uint8Array>({
         start(controller) {
@@ -103,11 +106,59 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
           let end = ''
           let shellState: SSRHeadPayload | undefined
           const bufferedChunks: Uint8Array[] = []
+          const outputChunks: Uint8Array[] = []
+          let outputChunkIndex = 0
+          let hasOutputError = false
+          let outputError: unknown
+          let outputClosed = false
+
+          flushOutput = () => {
+            if (terminalDelivered)
+              return
+            while (outputChunkIndex < outputChunks.length && (controller.desiredSize ?? 0) > 0) {
+              controller.enqueue(outputChunks[outputChunkIndex++]!)
+            }
+            if (outputChunkIndex === outputChunks.length) {
+              outputChunks.length = 0
+              outputChunkIndex = 0
+            }
+            if (outputChunks.length)
+              return
+            if (hasOutputError) {
+              if ((controller.desiredSize ?? 0) <= 0)
+                return
+              terminalDelivered = true
+              controller.error(outputError)
+              return
+            }
+            if (outputClosed) {
+              terminalDelivered = true
+              controller.close()
+            }
+          }
+
+          const enqueueOutput = (chunk: Uint8Array) => {
+            if (hasOutputError || outputClosed || terminalDelivered)
+              return
+            outputChunks.push(chunk)
+            flushOutput()
+          }
+
+          const closeOutput = () => {
+            if (hasOutputError || terminalDelivered)
+              return
+            outputClosed = true
+            stop()
+            flushOutput()
+          }
 
           const fail = (error: unknown) => {
-            if (!settle())
+            if (terminalDelivered)
               return
-            controller.error(error)
+            stop()
+            hasOutputError = true
+            outputError = error
+            flushOutput()
           }
 
           const releaseReader = () => {
@@ -129,25 +180,27 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
           }
 
           const flushShellAndChunks = () => {
-            if (settled || !shellResolved)
+            if (stopped || !shellResolved)
               return
 
             try {
               if (!shellFlushed) {
                 const prepared = prepareStreamingTemplate(head, template, shellState)
-                controller.enqueue(encoder.encode(prepared.shell))
+                enqueueOutput(encoder.encode(prepared.shell))
                 end = prepared.end
                 shellFlushed = true
               }
 
-              while (bufferedChunks.length) {
-                controller.enqueue(bufferedChunks.shift()!)
+              if (bufferedChunks.length) {
+                for (const chunk of bufferedChunks) {
+                  enqueueOutput(chunk)
+                }
+                bufferedChunks.length = 0
               }
 
               if (innerDone) {
-                controller.enqueue(encoder.encode(end))
-                settle()
-                controller.close()
+                enqueueOutput(encoder.encode(end))
+                closeOutput()
               }
             }
             catch (error) {
@@ -168,10 +221,10 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
           pumpDone = (async () => {
             try {
               while (true) {
-                if (settled)
+                if (stopped)
                   break
                 const { done, value } = await reader!.read()
-                if (settled)
+                if (stopped)
                   break
                 if (done) {
                   innerDone = true
@@ -179,7 +232,7 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
                   break
                 }
                 if (shellFlushed) {
-                  controller.enqueue(value)
+                  enqueueOutput(value)
                 }
                 else {
                   bufferedChunks.push(value)
@@ -199,7 +252,7 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
             try {
               const ready = await Promise.race([
                 shellReady.then(state => ({ state })),
-                settledSignal.then(() => undefined),
+                stoppedSignal.then(() => undefined),
               ])
               if (!ready)
                 return
@@ -213,8 +266,12 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
             }
           })()
         },
+        pull() {
+          flushOutput()
+        },
         async cancel(reason?: unknown) {
-          settle()
+          stop()
+          terminalDelivered = true
           const cancelError = await cancelInner(reason)
           await pumpDone
           if (cancelError)

--- a/packages/solid-js/test/e2e-streaming.test.ts
+++ b/packages/solid-js/test/e2e-streaming.test.ts
@@ -6,7 +6,11 @@ import {
   renderSSRHeadSuspenseChunk,
 } from '../src/stream/server'
 
-const XSS_RE = /<title>.*<script>alert.*<\/title>/i
+const XSS_RE = /<script\b/i
+
+function extractTitleContent(html: string): string {
+  return html.match(/<title>([\s\S]*?)<\/title>/i)?.[1] || ''
+}
 
 describe('solid-js streaming SSR e2e', () => {
   describe('full streaming workflow', () => {
@@ -97,9 +101,10 @@ describe('solid-js streaming SSR e2e', () => {
       const [htmlStart] = template.split('<!--app-html-->')
 
       const shell = await renderSSRHeadShell(head, htmlStart)
+      const title = extractTitleContent(shell)
 
       expect(shell).toContain('<title>')
-      expect(shell).not.toMatch(XSS_RE)
+      expect(title).not.toMatch(XSS_RE)
     })
 
     it('handles nested suspense with head updates', async () => {

--- a/packages/solid-js/test/e2e-streaming.test.ts
+++ b/packages/solid-js/test/e2e-streaming.test.ts
@@ -1,10 +1,10 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
 import {
   createStreamableHead,
   renderSSRHeadShell,
   renderSSRHeadSuspenseChunk,
-} from 'unhead/stream/server'
-// @vitest-environment node
-import { describe, expect, it } from 'vitest'
+} from '../src/stream/server'
 
 const XSS_RE = /<title>.*<script>alert.*<\/title>/i
 

--- a/packages/solid-js/test/streaming.test.ts
+++ b/packages/solid-js/test/streaming.test.ts
@@ -88,6 +88,37 @@ describe('solid-js streaming SSR', () => {
       expect(appStream.locked).toBe(false)
     })
 
+    it('drains queued chunks before rejecting after an inner stream error', async () => {
+      const { head, onCompleteShell, wrapStream } = createStreamableHead()
+      const error = new Error('queued stream failure')
+      let appController!: ReadableStreamDefaultController<Uint8Array>
+      const appStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          appController = controller
+        },
+      })
+
+      head.push({ title: 'Queued Shell' })
+      const reader = wrapStream(appStream, STREAM_TEMPLATE).getReader()
+      onCompleteShell()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      appController.enqueue(encoder.encode('<main>queued app</main>'))
+      appController.error(error)
+
+      const shellChunk = await withTimeout(reader.read(), 'queued shell chunk was not emitted')
+      expect(shellChunk.done).toBe(false)
+      expect(decodeChunk(shellChunk.value)).toContain('<title>Queued Shell</title>')
+
+      const appChunk = await withTimeout(reader.read(), 'queued app chunk was not emitted')
+      expect(appChunk.done).toBe(false)
+      expect(decodeChunk(appChunk.value)).toBe('<main>queued app</main>')
+
+      await expect(withTimeout(reader.read(), 'queued stream error did not reject after chunks drained')).rejects.toBe(error)
+      expect(appStream.locked).toBe(false)
+    })
+
     it('cancels the inner reader when the outer reader is cancelled', async () => {
       const { wrapStream } = createStreamableHead()
       const reason = new Error('client aborted')

--- a/packages/solid-js/test/streaming.test.ts
+++ b/packages/solid-js/test/streaming.test.ts
@@ -6,6 +6,25 @@ import {
   renderSSRHeadSuspenseChunk,
 } from '../src/stream/server'
 
+const STREAM_TEMPLATE = '<html><head></head><body><!--app-html--></body></html>'
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+function decodeChunk(chunk: Uint8Array | undefined): string {
+  return chunk ? decoder.decode(chunk) : ''
+}
+
+function withTimeout<T>(promise: Promise<T>, message: string, ms = 1000): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), ms)
+  })
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout)
+      clearTimeout(timeout)
+  })
+}
+
 describe('solid-js streaming SSR', () => {
   describe('createStreamableHead', () => {
     it('uses custom stream key', async () => {
@@ -22,6 +41,96 @@ describe('solid-js streaming SSR', () => {
 
       const shell = await renderSSRHeadShell(head, '<html><head></head><body>')
       expect(shell).toContain('window.__unhead__')
+    })
+  })
+
+  describe('wrapStream', () => {
+    it('rejects when the inner stream errors before shell is ready', async () => {
+      const { wrapStream } = createStreamableHead()
+      const error = new Error('pre-shell stream failure')
+      const appStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(error)
+        },
+      })
+
+      const reader = wrapStream(appStream, STREAM_TEMPLATE).getReader()
+
+      await expect(withTimeout(reader.read(), 'pre-shell stream error did not reject')).rejects.toBe(error)
+      expect(appStream.locked).toBe(false)
+    })
+
+    it('rejects when the inner stream errors after shell is ready', async () => {
+      const { head, onCompleteShell, wrapStream } = createStreamableHead()
+      const error = new Error('post-shell stream failure')
+      let appController!: ReadableStreamDefaultController<Uint8Array>
+      const appStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          appController = controller
+        },
+      })
+
+      head.push({ title: 'Shell Ready' })
+      const reader = wrapStream(appStream, STREAM_TEMPLATE).getReader()
+      onCompleteShell()
+
+      const shellChunk = await withTimeout(reader.read(), 'shell chunk was not emitted')
+      expect(shellChunk.done).toBe(false)
+      expect(decodeChunk(shellChunk.value)).toContain('<title>Shell Ready</title>')
+
+      appController.enqueue(encoder.encode('<main>app</main>'))
+      const appChunk = await withTimeout(reader.read(), 'app chunk was not emitted')
+      expect(appChunk.done).toBe(false)
+      expect(decodeChunk(appChunk.value)).toBe('<main>app</main>')
+
+      appController.error(error)
+      await expect(withTimeout(reader.read(), 'post-shell stream error did not reject')).rejects.toBe(error)
+      expect(appStream.locked).toBe(false)
+    })
+
+    it('cancels the inner reader when the outer reader is cancelled', async () => {
+      const { wrapStream } = createStreamableHead()
+      const reason = new Error('client aborted')
+      let cancelReason: unknown
+      let cancelCount = 0
+      const appStream = new ReadableStream<Uint8Array>({
+        pull() {
+          return Promise.resolve()
+        },
+        cancel(cancelledReason) {
+          cancelCount++
+          cancelReason = cancelledReason
+        },
+      })
+
+      const reader = wrapStream(appStream, STREAM_TEMPLATE).getReader()
+
+      await withTimeout(reader.cancel(reason), 'outer stream cancel did not resolve')
+      expect(cancelCount).toBe(1)
+      expect(cancelReason).toBe(reason)
+      expect(appStream.locked).toBe(false)
+    })
+
+    it('flushes buffered chunks and releases the inner reader after normal completion', async () => {
+      const { head, onCompleteShell, wrapStream } = createStreamableHead()
+      const appStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode('<main>buffered app</main>'))
+          controller.close()
+        },
+      })
+
+      head.push({ title: 'Buffered Shell' })
+      const textPromise = new Response(wrapStream(appStream, STREAM_TEMPLATE)).text()
+
+      await Promise.resolve()
+      onCompleteShell()
+
+      const text = await withTimeout(textPromise, 'normal stream completion did not resolve')
+      expect(text).toContain('<title>Buffered Shell</title>')
+      expect(text).toContain('<main>buffered app</main>')
+      expect(text).toContain('</html>')
+      expect(appStream.locked).toBe(false)
     })
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

Related to #789

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Splits the Solid streaming wrapper work from the broader streaming contracts branch into a focused `@unhead/solid-js` PR.

`wrapStream` now reads the app stream as soon as the wrapper starts, buffers app chunks until `onCompleteShell`, forwards inner stream errors before and after shell completion, cancels the inner reader when the outer stream is cancelled, and releases the inner reader on completion. The Solid streaming tests cover those cases, and the existing Solid e2e streaming test now imports the Solid integration instead of the core stream helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming head rendering by starting output earlier and flushing buffered chunks in order once the head shell is ready.
  * Strengthened coordination for errors, cancellation, and normal completion to avoid hangs and ensure correct end-of-stream behavior.
* **Tests**
  * Added local streaming helpers and expanded `wrapStream` coverage for inner errors (before/after shell readiness), cancellation propagation, and completion behavior.
  * Improved streaming e2e test stability for XSS title assertions and test setup order.
* **Examples**
  * Updated the SSR streaming example to mount into `#root` and adjust JSON-LD injection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->