### PR TITLE
fix(vue): normalize useSeoMeta patches

### DIFF
--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -90,20 +90,37 @@ export function useHeadSafe(input: UseHeadSafeInput = {}, options: UseHeadOption
   return useHead<UseHeadSafeInput>(input as UseHeadInput, options)
 }
 
-export function useSeoMeta(input: UseSeoMetaInput = {}, options: UseHeadOptions = {}): ActiveHeadEntry<UseSeoMetaInput> {
-  const head = options.head || injectHead()
-  head.use(FlatMetaPlugin)
+function normalizeSeoMetaInput(input: UseSeoMetaInput) {
+  // @ts-expect-error untyped
+  if (input._flatMeta)
+    return input
+
   const meta: Record<string, any> = {}
   for (const key in input) {
     if (!Object.hasOwn(input, key) || key === 'title' || key === 'titleTemplate')
       continue
     meta[key] = input[key as keyof UseSeoMetaInput]
   }
-  return useHead({
+
+  return {
     title: input.title,
     titleTemplate: input.titleTemplate,
     _flatMeta: meta,
-  } as UseSeoMetaInput, options)
+  } as UseSeoMetaInput
+}
+
+export function useSeoMeta(input: UseSeoMetaInput = {}, options: UseHeadOptions = {}): ActiveHeadEntry<UseSeoMetaInput> {
+  const head = options.head || injectHead()
+  head.use(FlatMetaPlugin)
+  const entry = useHead<UseSeoMetaInput>(normalizeSeoMetaInput(input), options)
+  const corePatch = entry.patch
+  // @ts-expect-error runtime
+  if (!entry.__patched) {
+    entry.patch = input => corePatch(normalizeSeoMetaInput(input))
+    // @ts-expect-error runtime
+    entry.__patched = true
+  }
+  return entry
 }
 
 export { useScript } from './scripts/useScript'

--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -93,10 +93,15 @@ export function useHeadSafe(input: UseHeadSafeInput = {}, options: UseHeadOption
 export function useSeoMeta(input: UseSeoMetaInput = {}, options: UseHeadOptions = {}): ActiveHeadEntry<UseSeoMetaInput> {
   const head = options.head || injectHead()
   head.use(FlatMetaPlugin)
-  const { title, titleTemplate, ...meta } = input
+  const meta: Record<string, any> = {}
+  for (const key in input) {
+    if (!Object.hasOwn(input, key) || key === 'title' || key === 'titleTemplate')
+      continue
+    meta[key] = input[key as keyof UseSeoMetaInput]
+  }
   return useHead({
-    title,
-    titleTemplate,
+    title: input.title,
+    titleTemplate: input.titleTemplate,
     _flatMeta: meta,
   } as UseSeoMetaInput, options)
 }

--- a/packages/vue/test/unit/e2e/useSeoMeta.test.ts
+++ b/packages/vue/test/unit/e2e/useSeoMeta.test.ts
@@ -24,13 +24,16 @@ describe('unhead vue e2e useSeoMeta', () => {
 
     entry!.patch({
       title: 'Updated',
+      titleTemplate: '%s - Site',
       description: 'Updated description',
       ogTitle: 'Updated OG title',
     })
     renderDOMHead(head, { document: dom.window.document })
 
-    expect(dom.window.document.title).toBe('Updated')
+    expect(dom.window.document.title).toBe('Updated - Site')
+    expect(dom.window.document.querySelectorAll('meta[name="description"]').length).toBe(1)
     expect(dom.window.document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Updated description')
+    expect(dom.window.document.querySelectorAll('meta[property="og:title"]').length).toBe(1)
     expect(dom.window.document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe('Updated OG title')
   })
 

--- a/packages/vue/test/unit/e2e/useSeoMeta.test.ts
+++ b/packages/vue/test/unit/e2e/useSeoMeta.test.ts
@@ -8,6 +8,32 @@ import { useDom } from '../../../../unhead/test/fixtures'
 import { csrVueAppWithUnhead, ssrVueAppWithUnhead } from '../../util'
 
 describe('unhead vue e2e useSeoMeta', () => {
+  it('normalizes flat meta patches', async () => {
+    const dom = useDom()
+    let entry: ReturnType<typeof useSeoMeta> | undefined
+    const head = csrVueAppWithUnhead(dom, () => {
+      entry = useSeoMeta({
+        title: 'Initial',
+        description: 'Initial description',
+      })
+    })
+    renderDOMHead(head, { document: dom.window.document })
+
+    expect(dom.window.document.title).toBe('Initial')
+    expect(dom.window.document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Initial description')
+
+    entry!.patch({
+      title: 'Updated',
+      description: 'Updated description',
+      ogTitle: 'Updated OG title',
+    })
+    renderDOMHead(head, { document: dom.window.document })
+
+    expect(dom.window.document.title).toBe('Updated')
+    expect(dom.window.document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Updated description')
+    expect(dom.window.document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe('Updated OG title')
+  })
+
   it('duplicate articleTag', async () => {
     const ssrHead = await ssrVueAppWithUnhead(() => {
       useSeoMeta({


### PR DESCRIPTION
### 🔗 Linked issue

Related to #788

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Moves the Vue `useSeoMeta` cleanup out of #788 and brings the adapter closer to core behavior. Vue now normalizes flat SEO input before calling `useHead()` and wraps `entry.patch()`, so `patch({ description, ogTitle })` still produces `_flatMeta` tags instead of unsupported top-level keys.

The normalizer also keeps the own-property loop from #805, avoiding object rest destructuring while excluding `title` and `titleTemplate` from `_flatMeta`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SEO metadata normalization to ensure titles and title templates are handled more reliably.
  * Refined how non-title metadata is assembled, preventing unintended fields from being included.
  * Updated metadata patching behavior to consistently apply normalized (“flat”) meta updates after `entry.patch()`.
* **Tests**
  * Added an end-to-end test covering normalization and “flat” meta updates for `useSeoMeta`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->