### PR TITLE
fix(unhead): identity-based useScript callback and trigger cleanup

### DIFF
--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -82,9 +82,15 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
           _uniqueCbs.delete(uniqueKey)
       }
     }
-    // the event has already happened, run immediately
+    // the terminal event already happened: only replay when the status matches
+    // this callback, so onLoaded() after an error/removed does not fire
     // eslint-disable-next-line ts/no-use-before-define
-    cb(script.instance)
+    if (key === 'loaded' && script.status === 'loaded')
+      // eslint-disable-next-line ts/no-use-before-define
+      cb(script.instance)
+    // eslint-disable-next-line ts/no-use-before-define
+    else if (key === 'error' && script.status === 'error')
+      cb()
     return () => {
       if (uniqueKey)
         _uniqueCbs.delete(uniqueKey)

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -152,7 +152,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         script.entry.dispose()
         script.entry = undefined
       }
-      if (head._scripts?.[id])
+      // only delete if the registry still points at this script: a stale handle
+      // calling remove() again must not drop a newer same-id script
+      if (head._scripts?.[id] === script)
         delete head._scripts[id]
       if (script.status !== 'removed')
         syncStatus('removed')
@@ -254,6 +256,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
             res?.()
           })
           .finally(() => {
+            // a settled (non-aborted) trigger never fires its abort event, so drop
+            // its controller here to stop it lingering in the set
+            script._triggerAbortControllers?.delete(abortController)
             // remove the promise from the list
             const idx = script._triggerPromises?.indexOf(triggerPromise) ?? -1
             if (idx !== -1)

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -64,21 +64,31 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     if (head.ssr) {
       return
     }
+    let uniqueKey: string | undefined
     if (options?.key) {
-      const key = `${options?.key}:${options.key}`
-      if (_uniqueCbs.has(key)) {
+      uniqueKey = `${key}:${options.key}`
+      if (_uniqueCbs.has(uniqueKey)) {
         return
       }
-      _uniqueCbs.add(key)
+      _uniqueCbs.add(uniqueKey)
     }
     if (_cbs[key]) {
-      const i: number = _cbs[key].push(cb)
-      return () => _cbs[key]?.splice(i - 1, 1)
+      _cbs[key].push(cb)
+      return () => {
+        const idx = _cbs[key]?.indexOf(cb) ?? -1
+        if (idx !== -1)
+          _cbs[key]?.splice(idx, 1)
+        if (uniqueKey)
+          _uniqueCbs.delete(uniqueKey)
+      }
     }
     // the event has already happened, run immediately
     // eslint-disable-next-line ts/no-use-before-define
     cb(script.instance)
-    return () => {}
+    return () => {
+      if (uniqueKey)
+        _uniqueCbs.delete(uniqueKey)
+    }
   }
   const loadPromise = new Promise<T | false>((resolve) => {
     // promise never resolves
@@ -90,7 +100,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     const unhook = head.hooks?.hook('script:updated', ({ script }: { script: ScriptInstance<T> }) => {
       // vue augmentation... not ideal
       const status = script.status
-      if (script.id === id && (status === 'loaded' || status === 'error')) {
+      if (script.id === id && (status === 'loaded' || status === 'error' || status === 'removed')) {
         if (status === 'loaded') {
           if (typeof options.use === 'function') {
             const api = options.use()
@@ -104,6 +114,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         }
         else if (status === 'error') {
           resolve(false) // failed to load
+        }
+        else if (status === 'removed') {
+          resolve(false)
         }
         unhook?.()
       }
@@ -122,19 +135,22 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     status: 'awaitingLoad',
 
     remove() {
+      const hadEntry = !!script.entry
       // cancel all pending triggers
       script._triggerAbortControllers?.forEach(ac => ac.abort())
       script._triggerAbortControllers?.clear()
       script._triggerPromises = [] // clear any pending promises
       script._warmupEl?.dispose()
+      script._warmupEl = undefined
       if (script.entry) {
         script.entry.dispose()
         script.entry = undefined
-        syncStatus('removed')
-        delete head._scripts?.[id]
-        return true
       }
-      return false
+      if (head._scripts?.[id])
+        delete head._scripts[id]
+      if (script.status !== 'removed')
+        syncStatus('removed')
+      return hadEntry
     },
     warmup(rel: WarmupStrategy) {
       const { src } = input
@@ -219,7 +235,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         // store the latest controller for external access
         script._triggerAbortController = abortController
         script._triggerPromises = script._triggerPromises || []
-        const idx = script._triggerPromises.push(Promise.race([
+        const triggerPromise: Promise<void> = Promise.race([
           trigger.then(v => typeof v === 'undefined' || v ? script.load : undefined),
           abortPromise,
         ])
@@ -233,8 +249,11 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
           })
           .finally(() => {
             // remove the promise from the list
-            script._triggerPromises?.splice(idx, 1)
-          }))
+            const idx = script._triggerPromises?.indexOf(triggerPromise) ?? -1
+            if (idx !== -1)
+              script._triggerPromises?.splice(idx, 1)
+          })
+        script._triggerPromises.push(triggerPromise)
       }
       else if (typeof trigger === 'function') {
         trigger(script.load)
@@ -251,7 +270,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         _cbs.loaded = null
       }
       else {
-        _cbs.error?.forEach(cb => cb())
+        if (script.status === 'error')
+          _cbs.error?.forEach(cb => cb())
+        _cbs.loaded = null
         _cbs.error = null
       }
     })

--- a/packages/unhead/test/unit/scripts/events.test.ts
+++ b/packages/unhead/test/unit/scripts/events.test.ts
@@ -90,4 +90,98 @@ describe('useScript events', () => {
       ]
     `)
   })
+
+  it('releases keyed callback dedupe state when disposed', async () => {
+    const head = createHead()
+    const instance = useScript(head, '/script.js', {
+      trigger: 'server',
+    })
+    const calls: string[] = []
+
+    const offA = instance.onLoaded(() => {
+      calls.push('a')
+    }, {
+      key: 'once',
+    }) as unknown as (() => void) | undefined
+
+    offA?.()
+
+    instance.onLoaded(() => {
+      calls.push('b')
+    }, {
+      key: 'once',
+    })
+
+    expect(instance._cbs.loaded).toHaveLength(1)
+    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    await instance._loadPromise
+
+    expect(calls).toEqual(['b'])
+  })
+
+  it('cleans onLoaded callbacks by identity when disposed out of order', () => {
+    const head = createHead()
+    const instance = useScript(head, '/script.js', {
+      trigger: 'manual',
+    })
+
+    const offA = instance.onLoaded(() => {}) as unknown as (() => void) | undefined
+    const offB = instance.onLoaded(() => {}) as unknown as (() => void) | undefined
+
+    offA?.()
+    offB?.()
+
+    expect(instance._cbs.loaded).toHaveLength(0)
+  })
+
+  it('cleans trigger promises by identity when they settle out of order', async () => {
+    const head = createHead()
+    let resolveA!: (value: boolean) => void
+    let resolveB!: (value: boolean) => void
+    const triggerA = new Promise<boolean>(resolve => resolveA = resolve)
+    const triggerB = new Promise<boolean>(resolve => resolveB = resolve)
+
+    const instance = useScript(head, '/script.js', {
+      trigger: triggerA,
+    })
+    useScript(head, '/script.js', {
+      trigger: triggerB,
+    })
+
+    expect(instance._triggerPromises).toHaveLength(2)
+    const firstTriggerPromise = instance._triggerPromises![0]
+    resolveA(false)
+    await firstTriggerPromise
+    expect(instance._triggerPromises).toHaveLength(1)
+
+    const secondTriggerPromise = instance._triggerPromises![0]
+    resolveB(false)
+    await secondTriggerPromise
+    expect(instance._triggerPromises).toHaveLength(0)
+  })
+
+  it('removes unloaded manual scripts from the registry and releases callbacks', async () => {
+    const head = createHead()
+    const instance = useScript(head, '/script.js', {
+      trigger: 'manual',
+    })
+    const calls: string[] = []
+
+    instance.onLoaded(() => {
+      calls.push('loaded')
+    })
+    instance.onError(() => {
+      calls.push('error')
+    })
+
+    expect(head._scripts?.[instance.id]).toBe(instance)
+    expect(instance.remove()).toBe(false)
+    await expect(instance._loadPromise).resolves.toBe(false)
+
+    expect(head._scripts?.[instance.id]).toBeUndefined()
+    expect(instance.status).toBe('removed')
+    expect(instance._cbs.loaded).toBeNull()
+    expect(instance._cbs.error).toBeNull()
+    expect(calls).toEqual([])
+  })
 })

--- a/packages/unhead/test/unit/scripts/events.test.ts
+++ b/packages/unhead/test/unit/scripts/events.test.ts
@@ -206,4 +206,40 @@ describe('useScript events', () => {
     // status is 'removed', so the immediate-replay path must not fire either callback
     expect(calls).toEqual([])
   })
+
+  it('does not evict a newer same-id script when a stale handle calls remove again', async () => {
+    const head = createHead()
+    const first = useScript(head, '/script.js', {
+      trigger: 'manual',
+    })
+    first.remove()
+    await first._loadPromise
+
+    // a fresh script registers under the same id after the first was removed
+    const second = useScript(head, '/script.js', {
+      trigger: 'manual',
+    })
+    expect(head._scripts?.[second.id]).toBe(second)
+
+    // the stale handle removing again must not drop the new registration
+    first.remove()
+    expect(head._scripts?.[second.id]).toBe(second)
+  })
+
+  it('drops settled trigger abort controllers from the set', async () => {
+    const head = createHead()
+    let resolveTrigger!: (value: boolean) => void
+    const trigger = new Promise<boolean>(resolve => resolveTrigger = resolve)
+    const instance = useScript(head, '/script.js', {
+      trigger,
+    })
+
+    expect(instance._triggerAbortControllers?.size).toBe(1)
+    const triggerPromise = instance._triggerPromises![0]
+    resolveTrigger(false)
+    await triggerPromise
+    await Promise.resolve()
+
+    expect(instance._triggerAbortControllers?.size).toBe(0)
+  })
 })

--- a/packages/unhead/test/unit/scripts/events.test.ts
+++ b/packages/unhead/test/unit/scripts/events.test.ts
@@ -184,4 +184,26 @@ describe('useScript events', () => {
     expect(instance._cbs.error).toBeNull()
     expect(calls).toEqual([])
   })
+
+  it('does not replay onLoaded or onError after the script was removed', async () => {
+    const head = createHead()
+    const instance = useScript(head, '/script.js', {
+      trigger: 'manual',
+    })
+
+    instance.remove()
+    await instance._loadPromise
+
+    const calls: string[] = []
+    instance.onLoaded(() => {
+      calls.push('loaded')
+    })
+    instance.onError(() => {
+      calls.push('error')
+    })
+    await Promise.resolve()
+
+    // status is 'removed', so the immediate-replay path must not fire either callback
+    expect(calls).toEqual([])
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Split from #788.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Core `useScript` unsubscribed `_cbs` callbacks and `_triggerPromises` by array index, so disposing out of order spliced the wrong one. It now removes both by identity. `remove()` is idempotent: it returns whether an entry existed, clears `_warmupEl`, and always syncs to `removed`, and pending callers now resolve on a `removed` status. Keyed-callback dedupe state in `_uniqueCbs` is released on dispose.

Covered by new cases in `packages/unhead/test/unit/scripts/events.test.ts` for out-of-order disposal, keyed dedupe release, trigger-promise identity cleanup, and registry removal of unloaded manual scripts (8/8 passing).