### PR TITLE
fix(vue,svelte,angular,solid): dispose useScript callbacks by identity

### DIFF
--- a/packages/angular/src/composables.ts
+++ b/packages/angular/src/composables.ts
@@ -49,7 +49,8 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
 
   effect(() => {
     isMounted = true
-    mountCbs.forEach(i => i())
+    // drain so a re-invoked effect does not run the same callback twice
+    mountCbs.splice(0).forEach(i => i())
   })
 
   if (typeof options.trigger === 'undefined') {
@@ -65,33 +66,45 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
 
   // @ts-expect-error untyped
   const script = baseUseScript(head, input as BaseUseScriptInput, options)
+  // capture the controller at registration time so destroy aborts the controller
+  // that was active when this component registered, not a newer one
+  const triggerAbortController = script._triggerAbortController
 
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    let i: number | null
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
-      }
+  // core's onLoaded/onError register by identity and return an identity-based
+  // disposer; we defer registration to mount and tie the disposer to destroy
+  // core returns an identity-based disposer at runtime although the type says void
+  const baseOnLoaded = script.onLoaded as unknown as (cb: any) => (() => void) | undefined
+  const baseOnError = script.onError as unknown as (cb: any) => (() => void) | undefined
+  const _registerCb = (register: () => (() => void) | undefined) => {
+    let disposed = false
+    let off: (() => void) | undefined
+    const run = () => {
+      if (disposed)
+        return
+      off = register() ?? (() => {})
+      sideEffects.push(off)
     }
-    mountCbs.push(() => {
-      if (!script._cbs[key]) {
-        cb(script.instance)
-        return () => {}
-      }
-      i = script._cbs[key].push(cb)
-      sideEffects.push(destroy)
-      return destroy
-    })
+    if (isMounted)
+      run()
+    else
+      mountCbs.push(run)
+    return () => {
+      if (disposed)
+        return
+      disposed = true
+      const idx = mountCbs.indexOf(run)
+      if (idx !== -1)
+        mountCbs.splice(idx, 1)
+      off?.()
+    }
   }
 
   destroyRef.onDestroy(() => {
     isMounted = false
-    script._triggerAbortController?.abort()
+    triggerAbortController?.abort()
     sideEffects.forEach(i => i())
   })
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb(() => baseOnLoaded(cb))
+  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb(() => baseOnError(cb))
   return script
 }

--- a/packages/angular/src/use-script.spec.ts
+++ b/packages/angular/src/use-script.spec.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { TestBed } from '@angular/core/testing'
+import { createHead } from 'unhead/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useScript } from './composables'
+
+describe('angular useScript callback disposal', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+  })
+
+  it('fires an onLoaded callback that is left registered', async () => {
+    const head = createHead({ document })
+    const calls: string[] = []
+
+    TestBed.runInInjectionContext(() => {
+      const script = useScript({ src: '//angular-loaded.js' }, { trigger: 'manual', head })
+      script.onLoaded(() => {
+        calls.push('only')
+      })
+    })
+    // run the mount effect so the deferred registration lands in the callback queue
+    TestBed.flushEffects()
+
+    const script = (head as any)._scripts['//angular-loaded.js']
+    head.hooks?.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    await script._loadPromise
+
+    expect(calls).toEqual(['only'])
+  })
+
+  it('disposes the correct onLoaded callback when handles are removed out of order', async () => {
+    const head = createHead({ document })
+
+    const calls: string[] = []
+    let offFirst!: () => void
+    let offSecond!: () => void
+
+    TestBed.runInInjectionContext(() => {
+      const script = useScript({ src: '//angular-ordered.js' }, { trigger: 'manual', head })
+      offFirst = script.onLoaded(() => {
+        calls.push('first')
+      }) as unknown as () => void
+      offSecond = script.onLoaded(() => {
+        calls.push('second')
+      }) as unknown as () => void
+    })
+    TestBed.flushEffects()
+
+    // dispose out of order: index-based cleanup spliced a stale index here,
+    // removing `first` but leaving `second` registered
+    offFirst()
+    offSecond()
+
+    const script = (head as any)._scripts['//angular-ordered.js']
+    head.hooks?.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    await script._loadPromise
+
+    // both handles disposed, so neither callback should fire
+    expect(calls).toEqual([])
+  })
+})

--- a/packages/solid-js/src/composables.ts
+++ b/packages/solid-js/src/composables.ts
@@ -40,9 +40,9 @@ function withSideEffects<T extends ActiveHeadEntry<any>>(input: any, options: an
     createEffect(() => {
       entrySignal().patch(input)
     })
-    createEffect(() => {
-      return () => entry.dispose()
-    })
+    // createEffect does not treat a returned function as cleanup, so the entry
+    // was never disposed; onCleanup runs when the owning root is disposed
+    onCleanup(() => entry.dispose())
   }
   return entry
 }
@@ -69,7 +69,8 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   let isMounted = false
   onMount(() => {
     isMounted = true
-    mountCbs.forEach(i => i())
+    // drain so callbacks registered before mount run exactly once
+    mountCbs.splice(0).forEach(i => i())
   })
 
   if (typeof options.trigger === 'undefined') {
@@ -84,34 +85,46 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   }
   // @ts-expect-error untyped
   const script = baseUseScript(head, input as BaseUseScriptInput, options)
+  // capture the controller at registration time so cleanup aborts the controller
+  // that was active when this owner registered, not a newer one
+  const triggerAbortController = script._triggerAbortController
   // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
   const sideEffects: (() => void)[] = []
   onCleanup(() => {
     isMounted = false
-    script._triggerAbortController?.abort()
+    triggerAbortController?.abort()
     sideEffects.forEach(i => i())
   })
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    let i: number | null
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
-      }
+  // core's onLoaded/onError register by identity and return an identity-based
+  // disposer; we defer registration to mount and tie the disposer to cleanup
+  // core returns an identity-based disposer at runtime although the type says void
+  const baseOnLoaded = script.onLoaded as unknown as (cb: any) => (() => void) | undefined
+  const baseOnError = script.onError as unknown as (cb: any) => (() => void) | undefined
+  const _registerCb = (register: () => (() => void) | undefined) => {
+    let disposed = false
+    let off: (() => void) | undefined
+    const run = () => {
+      if (disposed)
+        return
+      off = register() ?? (() => {})
+      sideEffects.push(off)
     }
-    mountCbs.push(() => {
-      if (!script._cbs[key]) {
-        cb(script.instance)
-        return () => {}
-      }
-      i = script._cbs[key].push(cb)
-      sideEffects.push(destroy)
-      return destroy
-    })
+    if (isMounted)
+      run()
+    else
+      mountCbs.push(run)
+    return () => {
+      if (disposed)
+        return
+      disposed = true
+      const idx = mountCbs.indexOf(run)
+      if (idx !== -1)
+        mountCbs.splice(idx, 1)
+      off?.()
+    }
   }
   // if we have a scope we should make these callbacks reactive
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb(() => baseOnLoaded(cb))
+  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb(() => baseOnError(cb))
   return script
 }

--- a/packages/solid-js/test/composables.test.ts
+++ b/packages/solid-js/test/composables.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { createRoot } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+import { useHead, useHeadSafe, useSeoMeta } from '../src'
+import { createHead } from '../src/client'
+
+// Guards the shared withSideEffects disposal path used by useHead, useHeadSafe
+// and useSeoMeta: the entry must be removed when its Solid owner is disposed.
+describe('solid head composables lifecycle', () => {
+  it('disposes a useHead entry when the owner is disposed', () => {
+    const head = createHead()
+    let dispose!: () => void
+
+    createRoot((d) => {
+      dispose = d
+      useHead({
+        title: 'Solid',
+        meta: [{ name: 'description', content: 'solid description' }],
+      }, { head })
+    })
+
+    expect(head.entries.size).toBe(1)
+
+    dispose()
+    expect(head.entries.size).toBe(0)
+  })
+
+  it('disposes useSeoMeta and useHeadSafe entries when the owner is disposed', () => {
+    const head = createHead()
+    let dispose!: () => void
+
+    createRoot((d) => {
+      dispose = d
+      useSeoMeta({ title: 'SEO', description: 'seo description' }, { head })
+      useHeadSafe({ meta: [{ name: 'safe', content: 'value' }] }, { head })
+    })
+
+    expect(head.entries.size).toBe(2)
+
+    dispose()
+    expect(head.entries.size).toBe(0)
+  })
+
+  it('only disposes the entry owned by the disposed root', () => {
+    const head = createHead()
+    let disposeInner!: () => void
+
+    createRoot(() => {
+      useHead({ title: 'Outer' }, { head })
+      createRoot((d) => {
+        disposeInner = d
+        useHead({ title: 'Inner' }, { head })
+      })
+    })
+
+    expect(head.entries.size).toBe(2)
+
+    // disposing the inner owner must leave the outer entry intact
+    disposeInner()
+    expect(head.entries.size).toBe(1)
+  })
+})

--- a/packages/solid-js/vitest.config.ts
+++ b/packages/solid-js/vitest.config.ts
@@ -5,6 +5,8 @@ import { defineProject } from 'vitest/config'
 
 export default defineProject({
   resolve: {
+    // resolve solid-js to its client build so the client composable path runs in tests
+    conditions: ['browser'],
     alias: {
       '@unhead/bundler/framework': resolve(__dirname, '../bundler/src/unplugin/framework.ts'),
       '@unhead/bundler': resolve(__dirname, '../bundler/src'),

--- a/packages/svelte/src/composables.ts
+++ b/packages/svelte/src/composables.ts
@@ -56,30 +56,27 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   }
   // @ts-expect-error untyped
   const script = baseUseScript(head, input as BaseUseScriptInput, options)
+  // capture the controller at registration time so unmount aborts the controller
+  // that was active when this component registered, not a newer one
+  const triggerAbortController = script._triggerAbortController
   // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
   const sideEffects: (() => void)[] = []
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    if (!script._cbs[key]) {
-      cb(script.instance)
-      return () => {}
-    }
-    let i: number | null = script._cbs[key].push(cb)
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
-      }
-    }
-    sideEffects.push(destroy)
-    return destroy
+  // core's onLoaded/onError register by identity and return an identity-based
+  // disposer; we only tie that disposer to the component lifecycle
+  const bind = (base: (cb: any) => (() => void) | undefined) => (cb: any) => {
+    const off = base(cb) ?? (() => {})
+    sideEffects.push(off)
+    return off
   }
+  // core returns an identity-based disposer at runtime although the type says void
+  const baseOnLoaded = script.onLoaded as unknown as (cb: any) => (() => void) | undefined
+  const baseOnError = script.onError as unknown as (cb: any) => (() => void) | undefined
   // if we have a scope we should make these callbacks reactive
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  script.onLoaded = bind(baseOnLoaded)
+  script.onError = bind(baseOnError)
   onDestroy(() => {
     // stop any trigger promises
-    script._triggerAbortController?.abort()
+    triggerAbortController?.abort()
     sideEffects.forEach(i => i())
   })
   return script

--- a/packages/vue/src/scripts/useScript.ts
+++ b/packages/vue/src/scripts/useScript.ts
@@ -42,25 +42,20 @@ function registerVueScopeHandlers<T extends Record<symbol | string, any> = Recor
   if (!scope) {
     return
   }
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    if (!script._cbs[key]) {
-      cb(script.instance)
-      return () => {}
-    }
-    let i: number | null = script._cbs[key].push(cb)
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
-      }
-    }
-    onScopeDispose(destroy)
-    return destroy
+  // core's onLoaded/onError already register the callback by identity and return
+  // an identity-based disposer; we only tie that disposer to the Vue scope so the
+  // callback is removed when the owning component unmounts
+  const bind = (base: (cb: any) => (() => void) | undefined) => (cb: any) => {
+    const off = base(cb) ?? (() => {})
+    onScopeDispose(off)
+    return off
   }
+  // core returns an identity-based disposer at runtime although the type says void
+  const baseOnLoaded = script.onLoaded as unknown as (cb: any) => (() => void) | undefined
+  const baseOnError = script.onError as unknown as (cb: any) => (() => void) | undefined
   // if we have a scope we should make these callbacks reactive
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  script.onLoaded = bind(baseOnLoaded)
+  script.onError = bind(baseOnError)
   // capture the controller at registration time so this scope only aborts
   // the controller it was associated with, not a newer one created by a later scope
   const triggerAbortController = script._triggerAbortController

--- a/packages/vue/test/unit/useScript.test.ts
+++ b/packages/vue/test/unit/useScript.test.ts
@@ -212,6 +212,49 @@ describe('vue e2e scripts', () => {
     script.remove()
   })
 
+  it('disposes the correct onLoaded callback when handles are removed out of order', async () => {
+    const dom = useDom()
+    const head = createHead({
+      document: dom.window.document,
+    })
+
+    const calls: string[] = []
+    let offFirst!: () => void
+    let offSecond!: () => void
+
+    const el = dom.window.document.createElement('div')
+    const app = createApp({
+      setup() {
+        const script = useScript({
+          src: '//ordered-callbacks.js',
+        }, {
+          trigger: 'manual',
+          head,
+        })
+        offFirst = script.onLoaded(() => {
+          calls.push('first')
+        }) as unknown as () => void
+        offSecond = script.onLoaded(() => {
+          calls.push('second')
+        }) as unknown as () => void
+        return () => h('div')
+      },
+    })
+    app.mount(el)
+
+    // dispose out of order: index-based cleanup spliced a stale index here,
+    // removing `first` but leaving `second` registered
+    offFirst()
+    offSecond()
+
+    const script = (head as any)._scripts['//ordered-callbacks.js']
+    head.hooks?.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    await script._loadPromise
+
+    // both handles disposed, so neither callback should fire
+    expect(calls).toEqual([])
+  })
+
   it('setupTriggerHandler race condition: old scope disposal should not abort new scope trigger', async () => {
     const dom = useDom()
     const head = createHead({


### PR DESCRIPTION
### 🔗 Linked issue

Split from #788. Builds on #807 (core identity-based callback/trigger cleanup).

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Vue, Svelte, Solid and Angular composables re-implemented `onLoaded`/`onError` removal by array index, so out-of-order disposal removed the wrong callback (registering A then B, then disposing A then B, left B registered and it fired on load).

Since core now registers callbacks by identity and returns an identity-based disposer (#807), the wrappers no longer touch `script._cbs` themselves: they delegate to `script.onLoaded`/`onError` and tie the returned disposer to the framework scope (`onScopeDispose` / `onDestroy` / `onCleanup` / `DestroyRef`). This makes core the single source of truth and inherits its terminal-replay gating (a late `onLoaded` after an error/removed no longer fires).

Additional fixes folded in:

- Capture `script._triggerAbortController` eagerly so unmount aborts the controller that was active at registration, not a newer one created by a later scope (Svelte/Solid/Angular previously read it lazily at teardown).
- Solid: dispose head entries via `onCleanup` instead of a cleanup-returning `createEffect`. Solid does not treat a `createEffect` return value as cleanup, so `useHead`/`useHeadSafe`/`useSeoMeta` entries were never disposed when the owner was disposed.
- Solid/Angular: drain `mountCbs` (`splice(0)`) so a re-invoked Angular `effect()` cannot register the same callback twice.

### 🧪 Tests

- `packages/vue/test/unit/useScript.test.ts` and `packages/angular/src/use-script.spec.ts`: register two `onLoaded` handles and dispose them out of order; both fail against the old index-based splice.
- `packages/solid-js/test/composables.test.ts`: guards the shared `withSideEffects` disposal path; `conditions: ['browser']` so the client composable path actually runs in tests.

Verified: full Vue (164), Svelte (56), Solid (49) and Angular suites pass; all five packages build/typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup for script load/error callbacks so removed handlers no longer fire unexpectedly.
  * Fixed callback handling when multiple listeners are added or removed out of order.
  * Ensured head entries are disposed correctly when components or scopes unmount.

* **Tests**
  * Added coverage for script callback disposal behavior across Angular, Solid, and Vue.
  * Added lifecycle tests to verify nested scope cleanup and isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->