### PR TITLE
fix(react): make composables StrictMode double-invoke safe

### DIFF
--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import type { ClientUnhead } from 'unhead/client'
 import type { CreateClientHeadOptions, Unhead } from 'unhead/types'
-import { createElement } from 'react'
+import { createElement, useRef } from 'react'
 import { createHead as _createHead, createDebouncedFn, createDomRenderer } from 'unhead/client'
 import { UnheadContext } from './context'
 
@@ -16,7 +16,10 @@ export function createHead(options: CreateClientHeadOptions = {}): ClientUnhead 
 }
 
 export function UnheadProvider({ children, head }: { children: ReactNode, head?: Unhead<any, any> }) {
-  return createElement(UnheadContext.Provider, { value: head || createHead() }, children)
+  const headRef = useRef<Unhead<any, any> | null>(null)
+  if (!head && !headRef.current)
+    headRef.current = createHead()
+  return createElement(UnheadContext.Provider, { value: head || headRef.current }, children)
 }
 
 export type {

--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -57,18 +57,20 @@ const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
     return input
   }, [processedElements, titleTemplate])
 
-  const headRef = useRef<ActiveHeadEntry<any> | null>(
-    head.push(getHeadChanges()),
-  )
+  const headRef = useRef<ActiveHeadEntry<any> | null>(null)
 
+  // Server: create entry during render since useEffect doesn't run in SSR.
+  if (head.ssr && !headRef.current)
+    headRef.current = head.push(getHeadChanges())
+
+  // Client: create entry in effect to avoid orphaned entries in React 18 StrictMode.
   useEffect(() => {
+    headRef.current = head.push(getHeadChanges())
     return () => {
-      if (headRef.current?.dispose) {
-        headRef.current.dispose()
-      }
+      headRef.current?.dispose()
       headRef.current = null
     }
-  }, [])
+  }, [head])
 
   useEffect(() => {
     headRef.current?.patch(getHeadChanges())

--- a/packages/react/src/composables.ts
+++ b/packages/react/src/composables.ts
@@ -13,6 +13,16 @@ import { useContext, useEffect, useRef } from 'react'
 import { useHead as baseHead, useHeadSafe as baseHeadSafe, useSeoMeta as baseSeoMeta, useScript as baseUseScript } from 'unhead'
 import { UnheadContext } from './context'
 
+interface ScriptCallbackRecord {
+  active: boolean
+  handler: any
+  key: 'loaded' | 'error'
+  registered: boolean
+  renderScoped: boolean
+  renderId: number
+  script: UseScriptReturn<any>
+}
+
 export function useUnhead(): Unhead {
   // fallback to react context
   const instance = useContext<Unhead | null>(UnheadContext)
@@ -83,57 +93,108 @@ export function useSeoMeta(input: UseSeoMetaInput = {}, options: HeadEntryOption
 export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptReturn<T> {
   const input = (typeof _input === 'string' ? { src: _input } : _input) as UseScriptInput
   const options = _options || {} as UseScriptOptions<T>
-  const head = options?.head || useUnhead()
-  options.head = head
+  const head = options.head || useUnhead()
+  const trigger = options.trigger
+  const resolvedOptions = {
+    ...options,
+    head,
+    trigger: head.ssr && trigger === 'server' ? 'server' : 'manual',
+  } as UseScriptOptions<T>
 
-  const mountCbs: (() => void)[] = []
-  let isMounted = false
-  useEffect(() => {
-    isMounted = true
-    mountCbs.forEach(i => i())
-    return () => {
-      isMounted = false
-    }
-  }, [])
+  const callbackRecords = useRef<ScriptCallbackRecord[]>([])
+  const isMounted = useRef(false)
+  const renderId = useRef(0)
+  const committedRenderId = useRef(0)
+  const currentRenderId = ++renderId.current
 
-  if (typeof options.trigger === 'undefined') {
-    options.trigger = (load) => {
-      if (isMounted) {
-        load()
-      }
-      else {
-        mountCbs.push(load)
-      }
-    }
-  }
   // @ts-expect-error untyped
-  const script = baseUseScript(head, input as BaseUseScriptInput, options)
-  // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
-  const sideEffects: (() => void)[] = []
+  const script = baseUseScript(head, input as BaseUseScriptInput, resolvedOptions)
+
   useEffect(() => {
+    isMounted.current = true
+    committedRenderId.current = currentRenderId
+    reconcileScriptCallbacks(currentRenderId)
+    callbackRecords.current.forEach(registerScriptCallback)
     return () => {
-      script._triggerAbortController?.abort()
-      sideEffects.forEach(i => i())
+      isMounted.current = false
+      callbackRecords.current.forEach(unregisterScriptCallback)
     }
-  }, [])
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    let i: number | null
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
-      }
+  })
+
+  useEffect(() => {
+    const existingControllers = new Set(script._triggerAbortControllers)
+    script.setupTriggerHandler(trigger)
+    const triggerAbortControllers = script._triggerAbortControllers
+      ? [...script._triggerAbortControllers].filter(controller => !existingControllers.has(controller))
+      : []
+
+    return () => {
+      triggerAbortControllers.forEach(controller => controller.abort())
     }
-    mountCbs.push(() => {
-      if (!script._cbs[key]) {
-        cb(script.instance)
-        return () => {}
+  }, [script, trigger])
+
+  function reconcileScriptCallbacks(activeRenderId: number) {
+    callbackRecords.current.forEach((record) => {
+      if (record.renderScoped && record.renderId !== activeRenderId) {
+        record.active = false
+        unregisterScriptCallback(record)
       }
-      i = script._cbs[key].push(cb)
-      sideEffects.push(destroy)
-      return destroy
     })
+    callbackRecords.current = callbackRecords.current.filter(record => record.active && (!record.renderScoped || record.renderId === activeRenderId))
+  }
+
+  function registerScriptCallback(record: ScriptCallbackRecord) {
+    if (!record.active || record.registered)
+      return
+    const cbs = record.script._cbs[record.key]
+    if (!cbs) {
+      record.handler(record.script.instance)
+      return
+    }
+    cbs.push(record.handler)
+    record.registered = true
+  }
+
+  function unregisterScriptCallback(record: ScriptCallbackRecord) {
+    if (!record.registered)
+      return
+    const idx = record.script._cbs[record.key]?.indexOf(record.handler) ?? -1
+    if (idx !== -1)
+      record.script._cbs[record.key]?.splice(idx, 1)
+    record.registered = false
+  }
+
+  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
+    const renderScoped = !(isMounted.current && committedRenderId.current === currentRenderId)
+    const record: ScriptCallbackRecord = {
+      active: true,
+      handler: (...args: any[]) => {
+        if (!record.active)
+          return
+        record.active = false
+        record.registered = false
+        cb(...args)
+      },
+      key,
+      registered: false,
+      renderScoped,
+      renderId: currentRenderId,
+      script,
+    }
+    callbackRecords.current.push(record)
+    if (isMounted.current && committedRenderId.current === currentRenderId)
+      registerScriptCallback(record)
+    return destroy
+
+    function destroy() {
+      if (!record.active)
+        return
+      record.active = false
+      unregisterScriptCallback(record)
+      const idx = callbackRecords.current.indexOf(record)
+      if (idx !== -1)
+        callbackRecords.current.splice(idx, 1)
+    }
   }
   // if we have a scope we should make these callbacks reactive
   script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)

--- a/packages/react/test/unmount-cleanup.test.tsx
+++ b/packages/react/test/unmount-cleanup.test.tsx
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
 import { act, fireEvent, render } from '@testing-library/react'
-import React, { useState } from 'react'
+import React, { StrictMode, useState } from 'react'
+import { renderToString } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { useHead } from '../src'
+import { useHead, useScript } from '../src'
 import { createHead, renderDOMHead, UnheadProvider } from '../src/client'
+import { Head } from '../src/components'
+import { createHead as createServerHead, renderSSRHead } from '../src/server'
 
 /**
  * Reproduction of https://github.com/unjs/unhead/issues/558
@@ -190,5 +193,262 @@ describe('issue #558 - unmount cleanup', () => {
 
     // After unmount, back to 1 entry (init only)
     expect(head.entries.size).toBe(1)
+  })
+
+  it('head component keeps one entry in StrictMode and disposes on unmount', async () => {
+    const head = createHead({
+      init: [{
+        title: 'Init',
+      }],
+    })
+
+    function PageWithHead() {
+      return (
+        <Head>
+          <title>Component</title>
+          <meta name="description" content="component description" />
+        </Head>
+      )
+    }
+
+    expect(head.entries.size).toBe(1)
+
+    const { unmount } = render(
+      <StrictMode>
+        <UnheadProvider head={head}>
+          <PageWithHead />
+        </UnheadProvider>
+      </StrictMode>,
+    )
+
+    await act(async () => {
+      await wait()
+    })
+
+    expect(head.entries.size).toBe(2)
+    let rendered = await renderSSRHead(head)
+    expect(rendered.headTags).toContain('<title>Component</title>')
+    expect(rendered.headTags).toContain('component description')
+
+    await act(async () => {
+      unmount()
+      await wait()
+    })
+
+    expect(head.entries.size).toBe(1)
+    rendered = await renderSSRHead(head)
+    expect(rendered.headTags).toContain('<title>Init</title>')
+    expect(rendered.headTags).not.toContain('Component')
+  })
+
+  it('head component pushes during React server rendering', async () => {
+    const head = createServerHead({ disableDefaults: true })
+
+    renderToString(
+      <UnheadProvider head={head}>
+        <Head>
+          <title>Server Component</title>
+          <meta name="description" content="server description" />
+        </Head>
+      </UnheadProvider>,
+    )
+
+    expect(head.entries.size).toBe(1)
+    const rendered = await renderSSRHead(head)
+    expect(rendered.headTags).toContain('<title>Server Component</title>')
+    expect(rendered.headTags).toContain('server description')
+  })
+
+  it('head component patches the same StrictMode entry on prop updates', async () => {
+    const head = createHead({
+      init: [{
+        title: 'Init',
+      }],
+    })
+
+    function PageWithHead({ title }: { title: string }) {
+      return (
+        <Head>
+          <title>{title}</title>
+        </Head>
+      )
+    }
+
+    const renderApp = (title: string) => (
+      <StrictMode>
+        <UnheadProvider head={head}>
+          <PageWithHead title={title} />
+        </UnheadProvider>
+      </StrictMode>
+    )
+
+    const { rerender } = render(renderApp('First'))
+
+    await act(async () => {
+      await wait()
+    })
+
+    expect(head.entries.size).toBe(2)
+    const entryKeys = [...head.entries.keys()]
+    let rendered = await renderSSRHead(head)
+    expect(rendered.headTags).toContain('<title>First</title>')
+
+    rerender(renderApp('Second'))
+    await act(async () => {
+      await wait()
+    })
+
+    expect(head.entries.size).toBe(2)
+    expect([...head.entries.keys()]).toEqual(entryKeys)
+    rendered = await renderSSRHead(head)
+    expect(rendered.headTags).toContain('<title>Second</title>')
+    expect(rendered.headTags).not.toContain('<title>First</title>')
+  })
+
+  it('does not load a promise-triggered script after StrictMode unmount', async () => {
+    const head = createHead()
+    let resolveTrigger!: () => void
+    const trigger = new Promise<void>((resolve) => {
+      resolveTrigger = resolve
+    })
+
+    function PageWithScript() {
+      useScript('//react-strict-script.js', {
+        trigger,
+        head,
+      })
+      return null
+    }
+
+    const { unmount } = render(
+      <StrictMode>
+        <UnheadProvider head={head}>
+          <PageWithScript />
+        </UnheadProvider>
+      </StrictMode>,
+    )
+
+    await act(async () => {
+      await wait()
+    })
+
+    const script = (head as any)._scripts['//react-strict-script.js']
+    expect(script.status).toBe('awaitingLoad')
+
+    await act(async () => {
+      unmount()
+      await wait()
+    })
+
+    resolveTrigger()
+    await act(async () => {
+      await wait()
+    })
+
+    expect(script.status).toBe('awaitingLoad')
+    expect(document.querySelector('script[src="//react-strict-script.js"]')).toBeNull()
+  })
+
+  it('keeps script callbacks registered through StrictMode effect replay', async () => {
+    const head = createHead()
+    let loaded = 0
+
+    function PageWithScript() {
+      const script = useScript('//react-strict-callback.js', {
+        trigger: 'manual',
+        head,
+      })
+      script.onLoaded(() => {
+        loaded++
+      })
+      return null
+    }
+
+    render(
+      <StrictMode>
+        <UnheadProvider head={head}>
+          <PageWithScript />
+        </UnheadProvider>
+      </StrictMode>,
+    )
+
+    await act(async () => {
+      await wait()
+    })
+
+    const script = (head as any)._scripts['//react-strict-callback.js']
+    expect(script._cbs.loaded).toHaveLength(1)
+
+    script.load()
+    await act(async () => {
+      await renderDOMHead(head)
+      await wait()
+    })
+
+    document
+      .querySelector('script[src="//react-strict-callback.js"]')
+      ?.dispatchEvent(new Event('load'))
+
+    await act(async () => {
+      await wait()
+    })
+
+    expect(loaded).toBe(1)
+  })
+
+  it('keeps post-commit script callbacks registered across rerenders', async () => {
+    const head = createHead()
+    let loaded = 0
+
+    function PageWithScript({ label }: { label: string }) {
+      const script = useScript('//react-effect-callback.js', {
+        trigger: 'manual',
+        head,
+      })
+      React.useEffect(() => {
+        return script.onLoaded(() => {
+          loaded++
+        })
+      }, [script])
+      return <div>{label}</div>
+    }
+
+    const renderApp = (label: string) => (
+      <UnheadProvider head={head}>
+        <PageWithScript label={label} />
+      </UnheadProvider>
+    )
+
+    const { rerender } = render(renderApp('first'))
+
+    await act(async () => {
+      await wait()
+    })
+
+    const script = (head as any)._scripts['//react-effect-callback.js']
+    expect(script._cbs.loaded).toHaveLength(1)
+
+    rerender(renderApp('second'))
+    await act(async () => {
+      await wait()
+    })
+
+    expect(script._cbs.loaded).toHaveLength(1)
+
+    script.load()
+    await act(async () => {
+      await renderDOMHead(head)
+      await wait()
+    })
+
+    document
+      .querySelector('script[src="//react-effect-callback.js"]')
+      ?.dispatchEvent(new Event('load'))
+
+    await act(async () => {
+      await wait()
+    })
+
+    expect(loaded).toBe(1)
   })
 })

--- a/packages/react/test/useScript.test.tsx
+++ b/packages/react/test/useScript.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { useScript } from '../src'
+import { createHead, renderDOMHead, UnheadProvider } from '../src/client'
+
+function wait(ms = 10) {
+  return new Promise<void>(resolve => setTimeout(resolve, ms))
+}
+
+function getScript(head: any, src: string) {
+  return head._scripts[src]
+}
+
+async function flushLoad(head: any, src: string, event: 'load' | 'error' = 'load') {
+  await act(async () => {
+    await renderDOMHead(head)
+    await wait()
+  })
+  document.querySelector(`script[src="${src}"]`)?.dispatchEvent(new Event(event))
+  await act(async () => {
+    await wait()
+  })
+}
+
+describe('react useScript', () => {
+  it('loads a manual script and fires onLoaded exactly once', async () => {
+    const head = createHead()
+    let loaded = 0
+
+    function Page() {
+      const script = useScript('//react-happy.js', { trigger: 'manual', head })
+      script.onLoaded(() => {
+        loaded++
+      })
+      return null
+    }
+
+    render(
+      <UnheadProvider head={head}>
+        <Page />
+      </UnheadProvider>,
+    )
+    await act(async () => {
+      await wait()
+    })
+
+    const script = getScript(head, '//react-happy.js')
+    expect(script.status).toBe('awaitingLoad')
+
+    script.load()
+    await flushLoad(head, '//react-happy.js')
+
+    expect(loaded).toBe(1)
+    expect(script.status).toBe('loaded')
+  })
+
+  it('fires onError when the script fails to load', async () => {
+    const head = createHead()
+    let errored = 0
+
+    function Page() {
+      const script = useScript('//react-error.js', { trigger: 'manual', head })
+      script.onError(() => {
+        errored++
+      })
+      return null
+    }
+
+    render(
+      <UnheadProvider head={head}>
+        <Page />
+      </UnheadProvider>,
+    )
+    await act(async () => {
+      await wait()
+    })
+
+    const script = getScript(head, '//react-error.js')
+    script.load()
+    await flushLoad(head, '//react-error.js', 'error')
+
+    expect(errored).toBe(1)
+    expect(script.status).toBe('error')
+  })
+
+  it('loads when a promise trigger resolves while mounted', async () => {
+    const head = createHead()
+    let resolveTrigger!: () => void
+    const trigger = new Promise<void>((resolve) => {
+      resolveTrigger = resolve
+    })
+
+    function Page() {
+      useScript('//react-promise.js', { trigger, head })
+      return null
+    }
+
+    render(
+      <UnheadProvider head={head}>
+        <Page />
+      </UnheadProvider>,
+    )
+    await act(async () => {
+      await wait()
+    })
+
+    const script = getScript(head, '//react-promise.js')
+    expect(script.status).toBe('awaitingLoad')
+
+    resolveTrigger()
+    await act(async () => {
+      await renderDOMHead(head)
+      await wait()
+    })
+
+    expect(script.status).not.toBe('awaitingLoad')
+    expect(document.querySelector('script[src="//react-promise.js"]')).not.toBeNull()
+  })
+
+  it('disposes the correct onLoaded callback when handles are removed out of order', async () => {
+    const head = createHead()
+    const calls: string[] = []
+    let offFirst!: () => void
+    let offSecond!: () => void
+
+    function Page() {
+      const script = useScript('//react-order.js', { trigger: 'manual', head })
+      React.useEffect(() => {
+        offFirst = script.onLoaded(() => {
+          calls.push('first')
+        }) as unknown as () => void
+        offSecond = script.onLoaded(() => {
+          calls.push('second')
+        }) as unknown as () => void
+        // intentionally no cleanup: the test disposes the handles manually
+      }, [script])
+      return null
+    }
+
+    render(
+      <UnheadProvider head={head}>
+        <Page />
+      </UnheadProvider>,
+    )
+    await act(async () => {
+      await wait()
+    })
+
+    // dispose out of order: index-based cleanup would leave `second` registered
+    offFirst()
+    offSecond()
+
+    const script = getScript(head, '//react-order.js')
+    script.load()
+    await flushLoad(head, '//react-order.js')
+
+    expect(calls).toEqual([])
+  })
+
+  it('passes the use() API to onLoaded after the script loads', async () => {
+    const head = createHead()
+    let initCalls = 0
+    const api = {
+      init() {
+        initCalls++
+      },
+    }
+
+    function Page() {
+      const script = useScript<typeof api>('//react-use.js', {
+        trigger: 'manual',
+        head,
+        use: () => api,
+      })
+      script.onLoaded((vm) => {
+        vm.init()
+      })
+      return null
+    }
+
+    render(
+      <UnheadProvider head={head}>
+        <Page />
+      </UnheadProvider>,
+    )
+    await act(async () => {
+      await wait()
+    })
+
+    const script = getScript(head, '//react-use.js')
+    script.load()
+    await flushLoad(head, '//react-use.js')
+
+    expect(initCalls).toBe(1)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Split from #788. Follows up #558.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Under React 18 StrictMode the composables could dispose the live entry, load a promise-triggered script after unmount, or drop script callbacks across the effect replay. `UnheadProvider` now holds the created head in a `useRef` so it survives the double invoke, `Head` creates its entry inside an effect while still pushing during server render, and `useScript` reconciles callbacks per render so dispose and patch target the same entry on re-invoke.

Adds StrictMode and unmount coverage to `packages/react/test/unmount-cleanup.test.tsx` (10/10 passing).