### PR TITLE
test(bench): DOM renderer re-render hot-path bench

### DIFF
--- a/bench/dom-rerender.bench.ts
+++ b/bench/dom-rerender.bench.ts
@@ -1,0 +1,42 @@
+import { JSDOM } from 'jsdom'
+import { bench, describe } from 'vitest'
+import { createHead, renderDOMHead } from '../packages/unhead/src/client'
+
+// Re-render hot path: one head, ~12 tags incl htmlAttrs/bodyAttrs (with classes)
+// + a bodyAttrs window event handler, forced dirty re-render each iteration.
+function setup() {
+  const dom = new JSDOM('<!DOCTYPE html><html><head></head><body><div><h1>hello</h1></div></body></html>')
+  const document = dom.window.document
+  const head = createHead({ document })
+  head.push({
+    htmlAttrs: { lang: 'en', class: 'theme-dark layout-wide' },
+    bodyAttrs: { class: 'page-home is-ready', onresize: () => {} },
+    title: 'Page title',
+    meta: [
+      { charset: 'utf-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { name: 'description', content: 'A description of the page' },
+      { property: 'og:title', content: 'Page title' },
+      { property: 'og:description', content: 'A description of the page' },
+      { property: 'og:image', content: 'https://example.com/og.png' },
+    ],
+    link: [
+      { rel: 'canonical', href: 'https://example.com/' },
+      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+    ],
+    script: [
+      { src: 'https://example.com/app.js', defer: true },
+    ],
+  })
+  // initial render so subsequent renders hit the re-render (reuse) path
+  renderDOMHead(head, { document })
+  return { head, document }
+}
+
+describe('renderDOMHead re-render', () => {
+  const { head, document } = setup()
+  bench('forced dirty re-render (12 tags)', () => {
+    head.dirty = true
+    renderDOMHead(head, { document })
+  })
+})


### PR DESCRIPTION
Adds a microbench for the client DOM renderer re-render path that #787 touched, so the wall-clock cost of the renderer is tracked rather than measured ad-hoc.

### What it measures
One head, ~12 tags (incl. `htmlAttrs`/`bodyAttrs` with classes + a `bodyAttrs` window event handler), forced dirty re-render each iteration (jsdom).

```
npx vitest bench --run --config bench/vitest.config.ts bench/dom-rerender.bench.ts
```

### Context
Follow-up to #787. I also prototyped two renderer optimizations against this bench and discarded both as non-wins:

- **try/catch hoist** — neutral (within run-to-run noise); modern V8 optimizes the wrapped body fine.
- **generation-counter cleanup** (single `Map<key,[fn,gen]>` replacing the `_s`/`_p` two-object swap + per-key `delete`) — CPU-neutral-to-slightly-worse and **+24 B gz**; the full per-render map scan + Map/tuple overhead offsets the saved object churn.

Both confirm the ~1.2x re-render cost vs pre-#787 is the irreducible correctness work (content tracking, event identity, reentrancy guards), not the allocation/bookkeeping those changes target. Landing only the bench.