### PR TITLE
perf(unhead): remove the dead unhead:payload mechanism

### DIFF
--- a/bench/ssr-harlanzw-com-e2e.bench.ts
+++ b/bench/ssr-harlanzw-com-e2e.bench.ts
@@ -26,14 +26,13 @@ describe('ssr e2e bench', () => {
         },
       ],
     })
-    const options = { mode: 'server' } as const
     // 1. payload
     head.push({
       link: [
         // resource hints for vue chunks
         { rel: 'preload', as: 'fetch', href: '/payload.json' },
       ],
-    }, options)
+    })
     // 2. styles
     head.push({
       link: [
@@ -44,7 +43,7 @@ describe('ssr e2e bench', () => {
         { rel: 'stylesheet', href: '/page4.css' },
         { rel: 'stylesheet', href: '/page5.css' },
       ],
-    }, options)
+    })
     // 3. resource hints
     head.push({
       link: [
@@ -52,7 +51,7 @@ describe('ssr e2e bench', () => {
         { rel: 'preload', as: 'script', href: '/_nuxt/vendors.js' },
         { rel: 'preload', as: 'script', href: '/_nuxt/app.js' },
       ],
-    }, options)
+    })
     // 4. payloads
     head.push({
       script: [
@@ -60,7 +59,6 @@ describe('ssr e2e bench', () => {
         { innerHTML: { id: '__NUXT_DATA__', data: { initial: { bar: 'foo' }, payload: { foo: 'bar' } } } },
       ],
     }, {
-      ...options,
       tagPosition: 'bodyClose',
       tagPriority: 'high',
     })
@@ -80,7 +78,7 @@ describe('ssr e2e bench', () => {
           crossorigin: '',
         },
       ],
-    }, options)
+    })
     // start the vue rendererer
     // Nuxt SEO experiments
     head.use({

--- a/bench/ssr-harlanzw-com-e2e.test.ts
+++ b/bench/ssr-harlanzw-com-e2e.test.ts
@@ -31,14 +31,13 @@ describe('ssr e2e bench', () => {
         },
       ],
     })
-    const options = { mode: 'server' } as const
     // 1. payload
     head.push({
       link: [
         // resource hints for vue chunks
         { rel: 'preload', as: 'fetch', href: '/payload.json' },
       ],
-    }, options)
+    })
     // 2. styles
     head.push({
       link: [
@@ -49,7 +48,7 @@ describe('ssr e2e bench', () => {
         { rel: 'stylesheet', href: '/page4.css' },
         { rel: 'stylesheet', href: '/page5.css' },
       ],
-    }, options)
+    })
     // 3. resource hints
     head.push({
       link: [
@@ -57,7 +56,7 @@ describe('ssr e2e bench', () => {
         { rel: 'preload', as: 'script', href: '/_nuxt/vendors.js' },
         { rel: 'preload', as: 'script', href: '/_nuxt/app.js' },
       ],
-    }, options)
+    })
     // 4. payloads
     head.push({
       script: [
@@ -65,7 +64,6 @@ describe('ssr e2e bench', () => {
         { innerHTML: { id: '__NUXT_DATA__', data: { initial: { bar: 'foo' }, payload: { foo: 'bar' } } } },
       ],
     }, {
-      ...options,
       tagPosition: 'bodyClose',
       tagPriority: 'high',
     })
@@ -85,7 +83,7 @@ describe('ssr e2e bench', () => {
           crossorigin: '',
         },
       ],
-    }, options)
+    })
     // start the vue rendererer
     // Nuxt SEO experiments
     head.use({

--- a/bench/ssr-harlanzw-no-schema-e2e.bench.ts
+++ b/bench/ssr-harlanzw-no-schema-e2e.bench.ts
@@ -25,14 +25,13 @@ describe('ssr e2e bench', () => {
         },
       ],
     })
-    const options = { mode: 'server' } as const
     // 1. payload
     head.push({
       link: [
         // resource hints for vue chunks
         { rel: 'preload', as: 'fetch', href: '/payload.json' },
       ],
-    }, options)
+    })
     // 2. styles
     head.push({
       link: [
@@ -43,7 +42,7 @@ describe('ssr e2e bench', () => {
         { rel: 'stylesheet', href: '/page4.css' },
         { rel: 'stylesheet', href: '/page5.css' },
       ],
-    }, options)
+    })
     // 3. resource hints
     head.push({
       link: [
@@ -51,7 +50,7 @@ describe('ssr e2e bench', () => {
         { rel: 'preload', as: 'script', href: '/_nuxt/vendors.js' },
         { rel: 'preload', as: 'script', href: '/_nuxt/app.js' },
       ],
-    }, options)
+    })
     // 4. payloads
     head.push({
       script: [
@@ -59,7 +58,6 @@ describe('ssr e2e bench', () => {
         { innerHTML: { id: '__NUXT_DATA__', data: { initial: { bar: 'foo' }, payload: { foo: 'bar' } } } },
       ],
     }, {
-      ...options,
       tagPosition: 'bodyClose',
       tagPriority: 'high',
     })
@@ -79,7 +77,7 @@ describe('ssr e2e bench', () => {
           crossorigin: '',
         },
       ],
-    }, options)
+    })
     // start the vue rendererer
     // Nuxt SEO experiments
     head.use({

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -907,10 +907,10 @@ const _sfc_main = /* @__PURE__ */ _defineComponent({
   it('preserves complex second argument', async () => {
     const code = await transform([
       'import { useSeoMeta } from \'unhead\'',
-      'useSeoMeta({ description: \'Test\' }, { head, mode: \'server\' })',
+      'useSeoMeta({ description: \'Test\' }, { head, tagPriority: \'high\' })',
     ])
     expect(code).toBeDefined()
-    expect(code).toContain('{ head, mode: \'server\' }')
+    expect(code).toContain('{ head, tagPriority: \'high\' }')
   })
 
   it('handles #import', async () => {

--- a/packages/unhead/src/client/createHead.ts
+++ b/packages/unhead/src/client/createHead.ts
@@ -16,7 +16,6 @@ export interface ClientUnhead<T = ResolvableHead> extends Unhead<T, boolean> {
 export function createHead<T = ResolvableHead>(options: CreateClientHeadOptions = {}): ClientUnhead<T> {
   options.document = options.document || (typeof window !== 'undefined' ? document : undefined)
   const renderer = (options.render || createDomRenderer({ document: options.document })) as HeadRenderer<boolean>
-  const initialPayload = options.document?.head.querySelector('script[id="unhead:payload"]')?.innerHTML || false
   const core = createUnhead<T, boolean>(renderer, { document: options.document, propResolvers: options.propResolvers, _tagWeight: tagWeight, init: [] })
   const hooks = createHooks<ClientHeadHooks>(options.hooks)
   let dirty = false
@@ -63,7 +62,6 @@ export function createHead<T = ResolvableHead>(options: CreateClientHeadOptions 
     renderer(head)
   })
   options.plugins?.forEach(p => registerPlugin(head, p))
-  initialPayload && head.push(JSON.parse(initialPayload) as T)
   options.init?.forEach(e => e && head.push(e as T))
   return head
 }

--- a/packages/unhead/src/server/createHead.ts
+++ b/packages/unhead/src/server/createHead.ts
@@ -59,28 +59,5 @@ export function createHead<T = ResolvableHead>(options: CreateServerHeadOptions 
   // Register plugins
   options.plugins?.forEach(p => registerPlugin(head, p))
 
-  head._ssrPayload = {}
-  const payloadHook = (ctx: { tags: any[] }) => {
-    let payload: ResolvableHead = {}
-    if (Object.keys(head._ssrPayload || {}).length > 0) {
-      payload = { ...head._ssrPayload }
-    }
-    if (Object.values(payload).some(Boolean)) {
-      ctx.tags.push({
-        tag: 'script',
-        innerHTML: JSON.stringify(payload),
-        props: { id: 'unhead:payload', type: 'application/json' },
-      })
-    }
-  }
-  // only appends a fresh tag, never mutates resolved tags, so it must not
-  // force the defensive clone in resolveTags
-  payloadHook._nonMutating = true
-  registerPlugin(head, {
-    key: 'server',
-    hooks: {
-      'tags:resolve': payloadHook,
-    },
-  })
   return head
 }

--- a/packages/unhead/src/stream/client.ts
+++ b/packages/unhead/src/stream/client.ts
@@ -105,12 +105,7 @@ export function createStreamableHead<T = ResolvableHead>(options: CreateStreamab
   })
 
   // Push init entries
-  const initialPayload = rest.document?.head.querySelector('script[id="unhead:payload"]')?.innerHTML || false
-  const initEntries = [
-    initialPayload ? JSON.parse(initialPayload) : false,
-    ...(rest.init || []),
-  ]
-  initEntries.forEach(e => e && head.push(e as T))
+  rest.init?.forEach(e => e && head.push(e as T))
 
   // Update the stream queue to use the wrapped head
   if (streamQueue)

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -299,10 +299,6 @@ export interface Unhead<Input = ResolvableHead, RenderResult = unknown> {
   /**
    * @internal
    */
-  _ssrPayload?: ResolvableHead
-  /**
-   * @internal
-   */
   _rootStreamedTags?: Record<string, HeadTag>
 }
 

--- a/packages/unhead/test/unit/client/templateParams.test.ts
+++ b/packages/unhead/test/unit/client/templateParams.test.ts
@@ -189,38 +189,6 @@ describe('templateParams', () => {
     `)
   })
 
-  it('payload', async () => {
-    const dom = useDom({
-      headTags: '<title>default</title><script id="unhead:payload">{"templateParams": {"siteName": "Test"}, "titleTemplate": "%s %separator %siteName"}</script>',
-    })
-    const head = createClientHeadWithContext({
-      document: dom.window.document,
-      plugins: [TemplateParamsPlugin],
-    })
-    useHead(head, {
-      title: 'test',
-    })
-
-    const html = await new Promise<string>((resolve) => {
-      setTimeout(() => resolve(dom!.serialize()), 250)
-    })
-
-    expect(html).toMatchInlineSnapshot(`
-      "<!DOCTYPE html><html><head>
-      <title>test | Test</title><script id="unhead:payload">{"templateParams": {"siteName": "Test"}, "titleTemplate": "%s %separator %siteName"}</script>
-      </head>
-      <body>
-
-      <div>
-      <h1>hello world</h1>
-      </div>
-
-
-
-      </body></html>"
-    `)
-  })
-
   it('edge case #561', async () => {
     const dom = useDom({
       headTags: '<title>Vite</title>',


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Removes the `unhead:payload` server→client hydration mechanism, which has been dead since its populator was removed.

The server set `head._ssrPayload = {}` and registered a `tags:resolve` hook that serialised a `<script id="unhead:payload">`; the client (`client/createHead`, `stream/client`) read that script back and pushed it as an entry. The populator was the `mode: 'server'` title/titleTemplate logic, dropped in an earlier refactor, so nothing has written `_ssrPayload` since and the hook could never emit a payload tag.

Checked end to end before removing:

- No producer: nothing in the repo or in any framework integration (`@unhead/vue|react|svelte|solid|angular`) writes `_ssrPayload` or emits the script.
- No consumer that matters: only a hand-crafted test exercised the client read; no docs reference it.
- Devtools (`packages/bundler`) reads `unhead:payload` from the DOM only as a defensive SSR-detection fallback and tolerates its absence, so it's left as-is.

Removed both sides: the server hook + `_ssrPayload` field, the client and streaming readers, and the test that constructed the payload script by hand.

### 📊 Bundle (gz)

Removing the client-side read shrinks every client bundle too:

| bundle | Δ gz |
| --- | --- |
| client | −36 |
| server | −99 |
| vueClient | −13 |
| vueServer | −99 |
| reactClient | −35 |
| reactServer | −102 |

All 1550 tests pass; typecheck and lint clean. (The CI `typecheck` job also fails on `main` from an unrelated `unplugin`/`rolldown` duplicate-version mismatch in `packages/*/src/bundler.ts`, not introduced here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified head initialization across client, server, and streaming SSR to rely on configured startup entries only.
  * Removed automatic inline payload hydration/injection during SSR and streamed rendering, eliminating duplicated initialization paths.
* **Tests**
  * Updated unit test snapshots to reflect the new rendered HTML output formatting.
  * Adjusted SSR benchmark/test head setup to match the new head push behavior (no longer using server-mode options).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->