### PR TITLE
fix: harden head rendering malformed input

### DIFF
--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -1,6 +1,5 @@
 import type { SourceMapInput } from 'rollup'
 import type { BaseTransformerTypes } from './types'
-import { createContext, runInContext } from 'node:vm'
 import MagicString from 'magic-string'
 import { parseSync } from 'oxc-parser'
 import { ScopeTracker, ScopeTrackerImport, walk } from 'oxc-walker'
@@ -33,6 +32,7 @@ const SEO_META_NAMES = new Set(['useSeoMeta', 'useServerSeoMeta'])
 // We can only reproduce this statically for object/array literals; any dynamic value (ref, computed,
 // getter, identifier) could resolve to an object and MUST be left to runtime `unpackMeta`.
 const MEDIA_KEYS = new Set(['ogImage', 'ogVideo', 'ogAudio', 'twitterImage'])
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 
 /**
  * useSeoMeta({
@@ -297,18 +297,13 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
                 return
               }
               else if (property.value.type === 'ObjectExpression') {
-                const isStatic = property.value.properties.every((p: any) => p.value.type === 'StringLiteral' && typeof p.value.value === 'string')
-                if (!isStatic) {
+                const staticValue = materializeStaticStringObject(property.value)
+                if (!staticValue) {
                   output = false
                   return
                 }
-                const context = createContext({
-                  resolvePackedMetaObjectValue,
-                })
-                const start = property.value.start as number
-                const end = property.value.end as number
                 try {
-                  value = JSON.stringify(runInContext(`resolvePackedMetaObjectValue(${code.slice(start, end)})`, context))
+                  value = JSON.stringify(resolvePackedMetaObjectValue(staticValue, propertyKey.name))
                 }
                 catch {
                   output = false
@@ -385,3 +380,31 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
     },
   }
 })
+
+function getStaticPropertyKey(prop: any): string | undefined {
+  if (prop.computed)
+    return undefined
+  if (prop.key?.type === 'Identifier')
+    return prop.key.name
+  if ((prop.key?.type === 'Literal' || prop.key?.type === 'StringLiteral') && typeof prop.key.value === 'string')
+    return prop.key.value
+}
+
+function getStaticStringValue(node: any): string | undefined {
+  if ((node?.type === 'Literal' || node?.type === 'StringLiteral') && typeof node.value === 'string')
+    return node.value
+}
+
+function materializeStaticStringObject(node: any): Record<string, string> | false {
+  const out: Record<string, string> = Object.create(null)
+  for (const prop of node.properties) {
+    if (prop.type === 'SpreadElement' || prop.computed || prop.method || prop.kind !== 'init')
+      return false
+    const key = getStaticPropertyKey(prop)
+    const value = getStaticStringValue(prop.value)
+    if (!key || UNSAFE_OBJECT_KEYS.has(key) || value === undefined)
+      return false
+    out[key] = value
+  }
+  return out
+}

--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -32,7 +32,6 @@ const SEO_META_NAMES = new Set(['useSeoMeta', 'useServerSeoMeta'])
 // We can only reproduce this statically for object/array literals; any dynamic value (ref, computed,
 // getter, identifier) could resolve to an object and MUST be left to runtime `unpackMeta`.
 const MEDIA_KEYS = new Set(['ogImage', 'ogVideo', 'ogAudio', 'twitterImage'])
-const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 
 /**
  * useSeoMeta({
@@ -395,6 +394,10 @@ function getStaticStringValue(node: any): string | undefined {
     return node.value
 }
 
+function isUnsafeObjectKey(key: string): boolean {
+  return key === '__proto__' || key === 'constructor' || key === 'prototype'
+}
+
 function materializeStaticStringObject(node: any): Record<string, string> | false {
   const out: Record<string, string> = Object.create(null)
   for (const prop of node.properties) {
@@ -402,7 +405,7 @@ function materializeStaticStringObject(node: any): Record<string, string> | fals
       return false
     const key = getStaticPropertyKey(prop)
     const value = getStaticStringValue(prop.value)
-    if (!key || UNSAFE_OBJECT_KEYS.has(key) || value === undefined)
+    if (!key || isUnsafeObjectKey(key) || value === undefined)
       return false
     out[key] = value
   }

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -266,6 +266,32 @@ describe('useSeoMetaTransform', () => {
     expect(code).toBeUndefined()
   })
 
+  it('statically replaces packed meta objects without evaluating source text', async () => {
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { noindex: \'true\', unavailableAfter: \'tomorrow\' } })',
+    ])
+    expect(code).toContain('{ name: \'robots\', content: "noindex:true, unavailable-after:tomorrow" }')
+  })
+
+  it('does not evaluate computed packed meta object keys', async () => {
+    delete (globalThis as any).__unheadTransformPwned
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { [globalThis.__unheadTransformPwned = true]: \'x\' } })',
+    ])
+    expect(code).toBeUndefined()
+    expect((globalThis as any).__unheadTransformPwned).toBeUndefined()
+  })
+
+  it('bails packed meta objects with unsafe prototype keys', async () => {
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { constructor: \'polluted\' } })',
+    ])
+    expect(code).toBeUndefined()
+  })
+
   it('handles @unhead/vue', async () => {
     const code = await transform([
       'import { useSeoMeta } from \'@unhead/vue\'',

--- a/packages/unhead/src/parser/index.ts
+++ b/packages/unhead/src/parser/index.ts
@@ -133,6 +133,12 @@ export function parseAttributes(attrStr: string): Record<string, string> {
     return {}
 
   const result: Record<string, string> = {}
+  const setAttr = (attrName: string, value: string) => {
+    // Browsers keep the first duplicate attribute. Preserve that behavior so
+    // template extraction cannot rewrite inert tags into active ones.
+    if (!Object.hasOwn(result, attrName))
+      result[attrName] = value
+  }
   const len = attrStr.length
   let i = 0
 
@@ -177,7 +183,7 @@ export function parseAttributes(attrStr: string): Record<string, string> {
           state = BEFORE_VALUE
         }
         else if (!isSpace) {
-          result[name] = ''
+          setAttr(name, '')
           state = NAME
           nameStart = i
           nameEnd = 0 // Reset nameEnd when starting a new attribute
@@ -201,14 +207,14 @@ export function parseAttributes(attrStr: string): Record<string, string> {
         // always terminates the value (matches browser parsing and the
         // tag-boundary scanner above).
         if (charCode === quoteChar) {
-          result[name] = attrStr.substring(valueStart, i)
+          setAttr(name, attrStr.substring(valueStart, i))
           state = WHITESPACE
         }
         break
 
       case UNQUOTED_VALUE:
         if (isSpace || charCode === GT_CHAR) {
-          result[name] = attrStr.substring(valueStart, i)
+          setAttr(name, attrStr.substring(valueStart, i))
           state = WHITESPACE
         }
         break
@@ -220,14 +226,14 @@ export function parseAttributes(attrStr: string): Record<string, string> {
   // Handle the last attribute
   if (state === QUOTED_VALUE || state === UNQUOTED_VALUE) {
     if (name) {
-      result[name] = attrStr.substring(valueStart, i)
+      setAttr(name, attrStr.substring(valueStart, i))
     }
   }
   else if (state === NAME || state === AFTER_NAME || state === BEFORE_VALUE) {
     nameEnd = nameEnd || i
     const currentName = attrStr.substring(nameStart, nameEnd).toLowerCase()
     if (currentName) {
-      result[currentName] = ''
+      setAttr(currentName, '')
     }
   }
 

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -16,6 +16,7 @@ const WhitelistAttributes = {
 const BlockedLinkRels = new Set(['canonical', 'modulepreload', 'prerender', 'preload', 'prefetch', 'dns-prefetch', 'preconnect', 'manifest', 'pingback'])
 
 const SafeAttrName = /^[a-z][a-z0-9\-]*[a-z0-9]$/i
+const AsciiWhitespace = /[\t\n\f\r ]+/
 
 const HtmlEntityHex = /&#x([0-9a-f]+);?/gi
 const HtmlEntityDec = /&#(\d+);?/g
@@ -112,6 +113,11 @@ function acceptDataAttrs(value: Record<string, string>, allowId = true) {
   )
 }
 
+function hasBlockedRel(rel: string): boolean {
+  const tokens = rel.split(AsciiWhitespace).filter(Boolean)
+  return !tokens.length || tokens.some(token => BlockedLinkRels.has(token.toLowerCase()))
+}
+
 function makeTagSafe(tag: HeadTag): HeadSafe | false {
   let next: Record<string, any> = {}
   const { tag: type, props: prev } = tag
@@ -161,7 +167,7 @@ function makeTagSafe(tag: HeadTag): HeadSafe | false {
           return
         }
         // block bad rel types
-        if (key === 'rel' && (typeof val !== 'string' || BlockedLinkRels.has(val.toLowerCase()))) {
+        if (key === 'rel' && (typeof val !== 'string' || hasBlockedRel(val))) {
           return
         }
         if (key === 'href' || key === 'imagesrcset') {
@@ -239,6 +245,18 @@ export const SafeInputPlugin = /* @PURE */ defineHeadPlugin({
           return acc
         }, [])
       }
+    },
+    'tags:afterResolve': (ctx) => {
+      ctx.tags = ctx.tags.reduce((acc: HeadTag[], tag: HeadTag) => {
+        if (!(tag as any)._safe) {
+          acc.push(tag)
+          return acc
+        }
+        const safeTag = makeTagSafe(tag)
+        if (safeTag)
+          acc.push(safeTag as HeadTag)
+        return acc
+      }, [])
     },
   },
 })

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -122,8 +122,8 @@ function acceptDataAttrs(value: Record<string, string>, allowId = true) {
 }
 
 function hasBlockedRel(rel: string): boolean {
-  const tokens = rel.split(AsciiWhitespace).filter(Boolean)
-  return !tokens.length || tokens.some(token => BlockedLinkRels.has(token.toLowerCase()))
+  const tokens = rel.split(AsciiWhitespace)
+  return !tokens.some(Boolean) || tokens.some(token => BlockedLinkRels.has(token.toLowerCase()))
 }
 
 function makeTagSafe(tag: HeadTag): HeadSafe | false {

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -15,7 +15,7 @@ const WhitelistAttributes = {
 
 const BlockedLinkRels = new Set(['canonical', 'modulepreload', 'prerender', 'preload', 'prefetch', 'dns-prefetch', 'preconnect', 'manifest', 'pingback'])
 
-const SafeAttrName = /^[a-z][a-z0-9\-]*[a-z0-9]$/i
+const SafeDataAttrName = /^[a-z][a-z0-9-]*[a-z0-9]$/i
 const AsciiWhitespace = /[\t\n\f\r ]+/
 
 const HtmlEntityHex = /&#x([0-9a-f]+);?/gi
@@ -109,7 +109,7 @@ function stripProtoKeys(obj: any): any {
 
 function acceptDataAttrs(value: Record<string, string>, allowId = true) {
   return Object.fromEntries(
-    Object.entries(value || {}).filter(([key]) => ((allowId && key === 'id') || key.startsWith('data-')) && SafeAttrName.test(key)),
+    Object.entries(value || {}).filter(([key]) => ((allowId && key === 'id') || key.startsWith('data-')) && SafeDataAttrName.test(key)),
   )
 }
 

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -252,6 +252,10 @@ export const SafeInputPlugin = /* @PURE */ defineHeadPlugin({
           acc.push(tag)
           return acc
         }
+        if (tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs') {
+          acc.push(tag)
+          return acc
+        }
         const safeTag = makeTagSafe(tag)
         if (safeTag)
           acc.push(safeTag as HeadTag)

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -108,9 +108,17 @@ function stripProtoKeys(obj: any): any {
 }
 
 function acceptDataAttrs(value: Record<string, string>, allowId = true) {
-  return Object.fromEntries(
-    Object.entries(value || {}).filter(([key]) => ((allowId && key === 'id') || key.startsWith('data-')) && SafeDataAttrName.test(key)),
-  )
+  const next: Record<string, string> = {}
+  if (!value)
+    return next
+  const keys = Object.keys(value)
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i]
+    const isData = key.startsWith('data-')
+    if ((isData || (allowId && key === 'id')) && SafeDataAttrName.test(key))
+      next[key] = value[key]
+  }
+  return next
 }
 
 function hasBlockedRel(rel: string): boolean {

--- a/packages/unhead/src/server/util/propsToString.ts
+++ b/packages/unhead/src/server/util/propsToString.ts
@@ -1,3 +1,5 @@
+import { isValidAttributeName } from '../../utils/attrs'
+
 const DOUBLE_QUOTE_RE = /"/g
 
 /* @__PURE__ */
@@ -24,6 +26,8 @@ export function propsToString(props: Record<string, any>) {
 
   for (const key in props) {
     if (!Object.hasOwn(props, key))
+      continue
+    if (!isValidAttributeName(key))
       continue
 
     let value = props[key]

--- a/packages/unhead/src/server/util/propsToString.ts
+++ b/packages/unhead/src/server/util/propsToString.ts
@@ -1,4 +1,4 @@
-import { isValidAttributeName } from '../../utils/attrs'
+import { INVALID_ATTR_NAME_RE } from '../../utils/attrs'
 
 const DOUBLE_QUOTE_RE = /"/g
 
@@ -25,9 +25,7 @@ export function propsToString(props: Record<string, any>) {
   let attrs = ''
 
   for (const key in props) {
-    if (!Object.hasOwn(props, key))
-      continue
-    if (!isValidAttributeName(key))
+    if (!Object.hasOwn(props, key) || !key || INVALID_ATTR_NAME_RE.test(key))
       continue
 
     let value = props[key]

--- a/packages/unhead/src/utils/attrs.ts
+++ b/packages/unhead/src/utils/attrs.ts
@@ -1,0 +1,8 @@
+// Attribute names are emitted verbatim by HTML renderers. Reject characters
+// that can terminate or reshape an attribute in HTML syntax.
+// eslint-disable-next-line no-control-regex
+const INVALID_ATTR_NAME_RE = /[\s"'<>/=\x00-\x1F\x7F]/
+
+export function isValidAttributeName(name: string): boolean {
+  return name !== '' && !INVALID_ATTR_NAME_RE.test(name)
+}

--- a/packages/unhead/src/utils/attrs.ts
+++ b/packages/unhead/src/utils/attrs.ts
@@ -1,8 +1,4 @@
 // Attribute names are emitted verbatim by HTML renderers. Reject characters
 // that can terminate or reshape an attribute in HTML syntax.
 // eslint-disable-next-line no-control-regex
-const INVALID_ATTR_NAME_RE = /[\s"'<>/=\x00-\x1F\x7F]/
-
-export function isValidAttributeName(name: string): boolean {
-  return name !== '' && !INVALID_ATTR_NAME_RE.test(name)
-}
+export const INVALID_ATTR_NAME_RE = /[\s"'<>/=\x00-\x1F\x7F]/

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -1,5 +1,6 @@
 import type { HeadTag, PropResolver, ResolvableHead } from '../types'
 import { walkResolver } from '../utils/walkResolver'
+import { isValidAttributeName } from './attrs'
 import { DupeableTags, HasElementTags, TagConfigKeys } from './const'
 import { isUnsafeKey } from './unsafeKey'
 
@@ -72,6 +73,8 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
       // Only for real HTML element tags, not internal virtual tags like _flatMeta
       const isData = prop.startsWith('data-')
       const key = isHtmlTag && !isData ? prop.toLowerCase() : prop
+      if (isHtmlTag && !isValidAttributeName(key))
+        continue
       const str = String(value)
       const isMeta = tag.tag === 'meta' && key === 'content'
       tag.props[key] = str === 'true' || str === '' ? (isData || isMeta ? str : true) : !value && isData && str === 'false' ? 'false' : value

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -1,6 +1,6 @@
 import type { HeadTag, PropResolver, ResolvableHead } from '../types'
 import { walkResolver } from '../utils/walkResolver'
-import { isValidAttributeName } from './attrs'
+import { INVALID_ATTR_NAME_RE } from './attrs'
 import { DupeableTags, HasElementTags, TagConfigKeys } from './const'
 import { isUnsafeKey } from './unsafeKey'
 
@@ -49,12 +49,12 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
   for (const prop in input) {
     if (isUnsafeKey(prop))
       continue
-    const value = input[prop]
     const isData = prop.startsWith('data-')
     const isHtmlAttr = isHtmlTag && !TagConfigKeys.has(prop)
     const key = isHtmlAttr && !isData ? prop.toLowerCase() : prop
-    if (isHtmlAttr && !isValidAttributeName(key))
+    if (isHtmlAttr && (!key || INVALID_ATTR_NAME_RE.test(key)))
       continue
+    const value = input[prop]
     if (value === null) {
       tag.props[key] = null as any
     }

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -51,7 +51,8 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
       continue
     const value = input[prop]
     const isData = prop.startsWith('data-')
-    const isHtmlAttr = isHtmlTag && !TagConfigKeys.has(prop)
+    const isTagConfig = TagConfigKeys.has(prop)
+    const isHtmlAttr = isHtmlTag && !isTagConfig
     const key = isHtmlAttr && !isData ? prop.toLowerCase() : prop
     if (isHtmlAttr && !isValidAttributeName(key))
       continue
@@ -61,7 +62,7 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
     else if (prop === 'class' || prop === 'style') {
       tag.props[prop] = normalizeStyleClassProps(prop, value) as any
     }
-    else if (TagConfigKeys.has(prop)) {
+    else if (isTagConfig) {
       if ((prop === 'textContent' || prop === 'innerHTML') && typeof value === 'object') {
         const type = input.type || 'application/json'
         if (type.endsWith('json') || type === 'speculationrules' || type === 'importmap') {

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -51,8 +51,7 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
       continue
     const value = input[prop]
     const isData = prop.startsWith('data-')
-    const isTagConfig = TagConfigKeys.has(prop)
-    const isHtmlAttr = isHtmlTag && !isTagConfig
+    const isHtmlAttr = isHtmlTag && !TagConfigKeys.has(prop)
     const key = isHtmlAttr && !isData ? prop.toLowerCase() : prop
     if (isHtmlAttr && !isValidAttributeName(key))
       continue
@@ -62,7 +61,7 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
     else if (prop === 'class' || prop === 'style') {
       tag.props[prop] = normalizeStyleClassProps(prop, value) as any
     }
-    else if (isTagConfig) {
+    else if (TagConfigKeys.has(prop)) {
       if ((prop === 'textContent' || prop === 'innerHTML') && typeof value === 'object') {
         const type = input.type || 'application/json'
         if (type.endsWith('json') || type === 'speculationrules' || type === 'importmap') {

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -50,8 +50,13 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
     if (isUnsafeKey(prop))
       continue
     const value = input[prop]
+    const isData = prop.startsWith('data-')
+    const isHtmlAttr = isHtmlTag && !TagConfigKeys.has(prop)
+    const key = isHtmlAttr && !isData ? prop.toLowerCase() : prop
+    if (isHtmlAttr && !isValidAttributeName(key))
+      continue
     if (value === null) {
-      tag.props[prop] = null as any
+      tag.props[key] = null as any
     }
     else if (prop === 'class' || prop === 'style') {
       tag.props[prop] = normalizeStyleClassProps(prop, value) as any
@@ -71,10 +76,6 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
     else if (value !== undefined) {
       // Normalize camelCase HTML attributes to lowercase (e.g. hrefLang -> hreflang)
       // Only for real HTML element tags, not internal virtual tags like _flatMeta
-      const isData = prop.startsWith('data-')
-      const key = isHtmlTag && !isData ? prop.toLowerCase() : prop
-      if (isHtmlTag && !isValidAttributeName(key))
-        continue
       const str = String(value)
       const isMeta = tag.tag === 'meta' && key === 'content'
       tag.props[key] = str === 'true' || str === '' ? (isData || isMeta ? str : true) : !value && isData && str === 'false' ? 'false' : value

--- a/packages/unhead/test/unit/server/normalise.test.ts
+++ b/packages/unhead/test/unit/server/normalise.test.ts
@@ -84,6 +84,26 @@ describe('normalise', () => {
     })
   })
 
+  it('does not read values for invalid attribute names', () => {
+    const input: Record<string, any> = { name: 'description' }
+    let read = false
+
+    Object.defineProperty(input, 'bad name', {
+      enumerable: true,
+      get() {
+        read = true
+        return 'unsafe'
+      },
+    })
+
+    const tag = normalizeProps({ tag: 'meta', props: {} }, input)
+
+    expect(read).toBe(false)
+    expect(tag.props).toStrictEqual({
+      name: 'description',
+    })
+  })
+
   it('handles script type attribute edge cases without throwing errors', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/normalise.test.ts
+++ b/packages/unhead/test/unit/server/normalise.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { renderSSRHead } from '../../../src/server'
+import { normalizeProps } from '../../../src/utils'
 import { createServerHeadWithContext } from '../../util'
 
 const TEST_RE = /a/
@@ -68,6 +69,19 @@ describe('normalise', () => {
         "htmlAttrs": "",
       }
     `)
+  })
+
+  it('skips invalid null attribute names during normalization', () => {
+    const tag = normalizeProps({ tag: 'meta', props: {} }, {
+      'name': 'description',
+      'content': 'safe',
+      '\'><script>alert(1)</script><meta data-x': null,
+    } as any)
+
+    expect(tag.props).toStrictEqual({
+      name: 'description',
+      content: 'safe',
+    })
   })
 
   it('handles script type attribute edge cases without throwing errors', async () => {

--- a/packages/unhead/test/unit/server/transformHtmlTemplate.test.ts
+++ b/packages/unhead/test/unit/server/transformHtmlTemplate.test.ts
@@ -424,6 +424,15 @@ describe('transformHtmlTemplate edge cases', () => {
       const result = await transformHtmlTemplate(head, html)
       expect(result).toContain('<title>Test Title</title>')
     })
+
+    it('preserves the first duplicate attribute value when extracting head tags', async () => {
+      const head = createServerHeadWithContext()
+      const html = '<html><head><script type="application/json" type="text/javascript">window.pwned=1</script></head><body></body></html>'
+
+      const result = await transformHtmlTemplate(head, html)
+      expect(result).toContain('<script type="application/json">window.pwned=1</script>')
+      expect(result).not.toContain('type="text/javascript"')
+    })
   })
 
   describe('transformHtmlTemplateRaw edge cases', () => {

--- a/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
+++ b/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { useHeadSafe } from '../../../src'
+import { TemplateParamsPlugin } from '../../../src/plugins'
 import { renderSSRHead } from '../../../src/server'
 import { createServerHeadWithContext } from '../../util'
 
@@ -290,6 +291,15 @@ describe('useHeadSafe edge cases', () => {
       })
     }
 
+    it('blocks token-list rel values containing a blocked token', async () => {
+      for (const rel of ['canonical alternate', 'alternate\tpreconnect', 'stylesheet\npreload']) {
+        const ctx = await safeRender({
+          link: [{ rel, href: 'https://example.com/resource' }],
+        })
+        expect(ctx.headTags).toBe('')
+      }
+    })
+
     it('allows safe rel types', async () => {
       for (const rel of ['icon', 'stylesheet', 'alternate']) {
         const ctx = await safeRender({
@@ -310,6 +320,20 @@ describe('useHeadSafe edge cases', () => {
       const ctx = await safeRender({
         link: [{ rel: 'icon' }],
       })
+      expect(ctx.headTags).toBe('')
+    })
+
+    it('revalidates link href after template param substitution', async () => {
+      const head = createServerHeadWithContext({
+        plugins: [TemplateParamsPlugin],
+      })
+      useHeadSafe(head, {
+        link: [{ rel: 'stylesheet', href: '%href' }],
+        templateParams: {
+          href: 'data:text/css,body{display:none}',
+        },
+      })
+      const ctx = renderSSRHead(head)
       expect(ctx.headTags).toBe('')
     })
   })

--- a/packages/unhead/test/unit/server/util.test.ts
+++ b/packages/unhead/test/unit/server/util.test.ts
@@ -19,6 +19,13 @@ describe('propsToString', () => {
     props.src = '/app.js'
     expect(propsToString(props)).toStrictEqual(' src="/app.js"')
   })
+  it('skips invalid own attribute names', () => {
+    expect(propsToString({
+      'name': 'description',
+      '\'><script>alert(1)</script><meta data-x': 'x',
+      'content': 'safe',
+    })).toStrictEqual(' name="description" content="safe"')
+  })
   it('stringifies all properties correctly', async () => {
     expect(propsToString({
       'array': ['a', 1],

--- a/packages/unhead/test/unit/server/xss.test.ts
+++ b/packages/unhead/test/unit/server/xss.test.ts
@@ -218,12 +218,46 @@ describe('xss', () => {
     head.push({
       meta: [
         // @ts-expect-error untyped
-        { 'name': 'description', 'data-x': 'valid', '</meta><script>alert(1)</script>': 'invalid' },
+        { 'name': 'description', 'content': 'safe', 'data-x': 'valid', '</meta><script>alert(1)</script>': 'invalid' },
       ],
     })
 
     const ctx = renderSSRHead(head)
-    expect(ctx.headTags).toMatchInlineSnapshot(`""`)
+    expect(ctx.headTags).toMatchInlineSnapshot(`"<meta name="description" content="safe" data-x="valid">"`)
+  })
+
+  it('drops raw invalid attribute names across rendered tags', async () => {
+    const injectedKey = '\'><script>alert(1)</script><meta data-x'
+    const head = createServerHeadWithContext()
+
+    head.push({
+      meta: [
+        { name: 'description', content: 'safe', [injectedKey]: 'x' } as any,
+      ],
+      link: [
+        { rel: 'stylesheet', href: '/safe.css', [injectedKey]: 'x' } as any,
+      ],
+      script: [
+        { type: 'application/json', textContent: '{"safe":true}', [injectedKey]: 'x' } as any,
+      ],
+      htmlAttrs: {
+        lang: 'en',
+        [injectedKey]: 'x',
+      } as any,
+      bodyAttrs: {
+        'data-safe': 'ok',
+        [injectedKey]: 'x',
+      } as any,
+    })
+
+    const ctx = renderSSRHead(head)
+    expect(ctx.headTags).not.toContain('<script>alert(1)</script>')
+    expect(ctx.headTags).not.toContain(injectedKey)
+    expect(ctx.headTags).toContain('<meta name="description" content="safe">')
+    expect(ctx.headTags).toContain('<link rel="stylesheet" href="/safe.css">')
+    expect(ctx.headTags).toContain('<script type="application/json">{"safe":true}</script>')
+    expect(ctx.htmlAttrs).toBe(' lang="en"')
+    expect(ctx.bodyAttrs).toBe(' data-safe="ok"')
   })
 
   it('script with null byte insertion', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

This closes several head rendering security gaps found during a package sweep. It drops invalid HTML attribute names before SSR rendering, preserves browser first-wins behavior when extracting duplicate attributes from HTML templates, revalidates safe-mode links after template param substitution, and removes VM evaluation from the SEO meta transform.

Local checks passed: `pnpm lint`, `pnpm typecheck`, `pnpm build`, and the focused Vitest regression suite for server rendering, safe mode, template transforms, bundler SEO meta transforms, and streaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened SSR head tag rendering by validating HTML attribute names and dropping maliciously shaped keys.
  * Ensured duplicate attributes consistently keep the first value across parsing and template extraction.
  * Improved safe mode link security by detecting blocked `rel` tokens (whitespace-separated) and revalidating `href` after template substitution.
  * Strengthened packed meta object handling to statically transform only safe string-keyed objects and reject unsafe constructs.
* **Tests**
  * Added/expanded coverage for packed meta, duplicate attribute edge cases, `useHeadSafe` security scenarios, SSR XSS dropping, and attribute normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->