### PR TITLE
perf(schema-org): reduce entry normalization

### DIFF
--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -10,9 +10,18 @@ import { pathToFileURL } from 'node:url'
 
 // resolve built dist from the repo root (cwd) so this harness can run from anywhere
 // (e.g. /tmp during the base-branch measurement) without a relative path back to packages/
-const dist = name => import(pathToFileURL(`${process.cwd()}/packages/unhead/dist/${name}`).href)
+const packageDist = (pkg, name) => import(pathToFileURL(`${process.cwd()}/packages/${pkg}/dist/${name}`).href)
+const dist = name => packageDist('unhead', name)
+const schemaOrgDist = name => packageDist('schema-org', name)
 const { useHead, useSeoMeta } = await dist('index.mjs')
 const { createHead, renderSSRHead } = await dist('server.mjs')
+const {
+  defineOrganization,
+  defineProduct,
+  defineWebPage,
+  defineWebSite,
+  useSchemaOrg,
+} = await schemaOrgDist('index.mjs')
 
 function renderMediumSsrHead() {
   const head = createHead({ disableDefaults: true })
@@ -39,6 +48,92 @@ function renderMediumSsrHead() {
     twitterCard: 'summary_large_image',
   })
   return renderSSRHead(head, { omitLineBreaks: true })
+}
+
+function createCachedSchemaOrgRenderer() {
+  const head = createHead({ disableDefaults: true })
+  head.push({
+    htmlAttrs: { lang: 'en-AU' },
+    title: 'Widget Pro | Example Store',
+    titleTemplate: '%s %separator %siteName',
+    templateParams: {
+      separator: '|',
+      siteName: 'Example Store',
+      schemaOrg: {
+        host: 'https://example.com',
+        url: 'https://example.com/products/widget-pro',
+        inLanguage: 'en-AU',
+        path: '/products/widget-pro',
+      },
+    },
+    meta: [
+      {
+        name: 'description',
+        content: 'A product page with enough head state to exercise schema.org metadata collection.',
+      },
+      { property: 'og:image', content: 'https://example.com/products/widget-pro/og.png' },
+    ],
+    link: [{ rel: 'canonical', href: 'https://example.com/products/widget-pro' }],
+  })
+  for (let i = 0; i < 32; i++) {
+    useHead(head, {
+      meta: [
+        { name: `product-detail-${i}`, content: `Detail ${i}` },
+        { property: `product:attribute:${i}`, content: `Attribute ${i}` },
+      ],
+      link: [
+        { rel: 'preload', as: 'image', href: `/products/widget-pro/gallery-${i}.webp` },
+      ],
+    })
+  }
+  useSeoMeta(head, {
+    title: 'Widget Pro',
+    description: 'A product page with enough head state to exercise schema.org metadata collection.',
+    ogTitle: 'Widget Pro',
+    ogImage: 'https://example.com/products/widget-pro/og.png',
+    twitterCard: 'summary_large_image',
+  })
+  useSchemaOrg(head, [
+    defineWebSite({
+      name: 'Example Store',
+      inLanguage: 'en-AU',
+      description: 'Benchmark storefront',
+    }),
+    defineWebPage({
+      '@type': 'ItemPage',
+    }),
+    defineOrganization({
+      name: 'Example Store',
+      url: 'https://example.com',
+      logo: 'https://example.com/logo.png',
+    }),
+    defineProduct({
+      name: 'Widget Pro',
+      description: 'A benchmark product with a realistic schema.org graph.',
+      sku: 'WIDGET-PRO-001',
+      brand: { '@type': 'Brand', name: 'WidgetCorp' },
+      image: [
+        'https://example.com/products/widget-pro/1.jpg',
+        'https://example.com/products/widget-pro/2.jpg',
+        'https://example.com/products/widget-pro/3.jpg',
+      ],
+      offers: {
+        '@type': 'Offer',
+        price: 129.99,
+        priceCurrency: 'AUD',
+        availability: 'https://schema.org/InStock',
+        url: 'https://example.com/products/widget-pro',
+      },
+      aggregateRating: {
+        '@type': 'AggregateRating',
+        ratingValue: 4.8,
+        reviewCount: 256,
+      },
+    }),
+  ])
+
+  renderSSRHead(head, { omitLineBreaks: true })
+  return () => renderSSRHead(head, { omitLineBreaks: true })
 }
 
 function forceGC() {
@@ -152,12 +247,18 @@ async function csrBenches() {
 
 const times = measureTimes(renderMediumSsrHead)
 const alloc = measureAlloc(renderMediumSsrHead)
+const renderCachedSchemaOrgHead = createCachedSchemaOrgRenderer()
+const schemaOrgTimes = measureTimes(renderCachedSchemaOrgHead, { reps: 30, runs: 120 })
+const schemaOrgAlloc = measureAlloc(renderCachedSchemaOrgHead, { reps: 20, runs: 40 })
 
 const result = {
   benches: [
     { id: 'ssr-medium-cpu', name: 'SSR render (CPU)', kind: 'time', value: times.cpu.value, rme: times.cpu.rme },
     { id: 'ssr-medium-wall', name: 'SSR render (wall)', kind: 'time', value: times.wall.value, rme: times.wall.rme, informational: true },
     { id: 'ssr-medium-alloc', name: 'SSR allocated / render', kind: 'alloc', value: alloc.value },
+    { id: 'schema-org-cached-cpu', name: 'Schema.org cached render (CPU)', kind: 'time', value: schemaOrgTimes.cpu.value, rme: schemaOrgTimes.cpu.rme },
+    { id: 'schema-org-cached-wall', name: 'Schema.org cached render (wall)', kind: 'time', value: schemaOrgTimes.wall.value, rme: schemaOrgTimes.wall.rme, informational: true },
+    { id: 'schema-org-cached-alloc', name: 'Schema.org cached allocated / render', kind: 'alloc', value: schemaOrgAlloc.value },
     ...await csrBenches(),
   ],
 }

--- a/packages/schema-org/src/plugin.ts
+++ b/packages/schema-org/src/plugin.ts
@@ -1,3 +1,4 @@
+import type { HeadTag } from 'unhead/types'
 import type { SchemaOrgGraph } from './core/graph'
 import type { MetaInput, ResolvedMeta } from './types'
 import { defineHeadPlugin, TemplateParamsPlugin } from 'unhead/plugins'
@@ -30,6 +31,10 @@ function mergeObjects(target: any, source: any): any {
   return result
 }
 
+function isSchemaOrgTag(tag: HeadTag) {
+  return (tag.tag === 'script' && tag.props.type === 'application/ld+json' && tag.props.nodes) || tag.key === 'schema-org-graph'
+}
+
 export interface PluginSchemaOrgOptions {
   minify?: boolean
   trailingSlash?: boolean
@@ -41,72 +46,79 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
   let resolvedMeta = {} as ResolvedMeta
   return defineHeadPlugin((head) => {
     head.use(TemplateParamsPlugin)
+    function collectTag(tag: HeadTag) {
+      if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && tag.props.nodes) {
+        // this is a bit expensive, load in seperate chunk
+        const nodes = tag.props.nodes
+        for (const node of Array.isArray(nodes) ? nodes : [nodes]) {
+          // malformed input - skip null/undefined but allow empty objects
+          if (typeof node !== 'object' || node === null) {
+            continue
+          }
+
+          const newNode = {
+            ...node,
+            _dedupeStrategy: tag.tagDuplicateStrategy,
+          }
+          // Push node (it already has _resolver if it came from a defineXXX function)
+          graph.push(newNode)
+        }
+        tag.tagPosition = tag.tagPosition || config.tagPosition === 'head' ? 'head' : 'bodyClose'
+      }
+      if (tag.tag === 'htmlAttrs' && tag.props.lang) {
+        resolvedMeta.inLanguage = tag.props.lang
+      }
+      else if (tag.tag === 'title') {
+        resolvedMeta.title = tag.textContent
+      }
+      else if (tag.tag === 'meta' && tag.props.name === 'description') {
+        resolvedMeta.description = tag.props.content
+      }
+      else if (tag.tag === 'link' && tag.props.rel === 'canonical') {
+        resolvedMeta.url = tag.props.href
+        // may be using template params that aren't resolved
+        if (resolvedMeta.url && !resolvedMeta.host) {
+          try {
+            resolvedMeta.host = new URL(resolvedMeta.url).origin
+          }
+          catch {
+            // Canonical URLs may contain unresolved template params; leave host unset.
+          }
+        }
+      }
+      else if (tag.tag === 'meta' && tag.props.property === 'og:image') {
+        resolvedMeta.image = tag.props.content
+      }
+      // use template params
+      else if (tag.tag === 'templateParams' && tag.props.schemaOrg) {
+        resolvedMeta = {
+          ...resolvedMeta,
+          ...(tag.props.schemaOrg as unknown as Record<string, any>),
+        }
+      }
+    }
     return {
       key: 'schema-org',
       hooks: {
         'entries:resolve': (ctx) => {
           graph = graph || createSchemaOrgGraph()
           // Reset graph nodes each cycle so disposed entries don't leave stale nodes.
-          // Force all entries to re-normalize so their nodes are re-pushed to the graph.
           graph.nodes = []
           graph.nodeIndex = new Map()
           for (const entry of ctx.entries) {
-            delete entry._tags
+            if (entry._tags) {
+              if (entry._tags.some(isSchemaOrgTag)) {
+                delete entry._tags
+                continue
+              }
+              for (const tag of entry._tags)
+                collectTag(tag)
+            }
           }
         },
         'entries:normalize': ({ tags }) => {
-          for (const tag of tags) {
-            if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && tag.props.nodes) {
-              // this is a bit expensive, load in seperate chunk
-              const nodes = tag.props.nodes
-              for (const node of Array.isArray(nodes) ? nodes : [nodes]) {
-                // malformed input - skip null/undefined but allow empty objects
-                if (typeof node !== 'object' || node === null) {
-                  continue
-                }
-
-                const newNode = {
-                  ...node,
-                  _dedupeStrategy: tag.tagDuplicateStrategy,
-                }
-                // Push node (it already has _resolver if it came from a defineXXX function)
-                graph.push(newNode)
-              }
-              tag.tagPosition = tag.tagPosition || config.tagPosition === 'head' ? 'head' : 'bodyClose'
-            }
-            if (tag.tag === 'htmlAttrs' && tag.props.lang) {
-              resolvedMeta.inLanguage = tag.props.lang
-            }
-            else if (tag.tag === 'title') {
-              resolvedMeta.title = tag.textContent
-            }
-            else if (tag.tag === 'meta' && tag.props.name === 'description') {
-              resolvedMeta.description = tag.props.content
-            }
-            else if (tag.tag === 'link' && tag.props.rel === 'canonical') {
-              resolvedMeta.url = tag.props.href
-              // may be using template params that aren't resolved
-              if (resolvedMeta.url && !resolvedMeta.host) {
-                try {
-                  resolvedMeta.host = new URL(resolvedMeta.url).origin
-                }
-                catch {
-                  // Canonical URLs may contain unresolved template params; leave host unset.
-                }
-              }
-            }
-            else if (tag.tag === 'meta' && tag.props.property === 'og:image') {
-              resolvedMeta.image = tag.props.content
-            }
-            // use template params
-            else if (tag.tag === 'templateParams' && tag.props.schemaOrg) {
-              resolvedMeta = {
-                ...resolvedMeta,
-                ...(tag.props.schemaOrg as Record<string, any>),
-              }
-              delete tag.props.schemaOrg
-            }
-          }
+          for (const tag of tags)
+            collectTag(tag)
         },
         'tags:resolve': async (ctx) => {
           // find the schema.org node, should be a single instance
@@ -137,12 +149,12 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
         },
         'tags:afterResolve': (ctx) => {
           let firstNodeIdx: number | undefined
-          const toRemove = new Set<number>()
+          let toRemove: Set<number> | undefined
           for (let i = 0; i < ctx.tags.length; i++) {
             const tag = ctx.tags[i]
             if (!tag?.props)
               continue
-            if ((tag.props.type === 'application/ld+json' && tag.props.nodes) || tag.key === 'schema-org-graph') {
+            if (isSchemaOrgTag(tag)) {
               delete tag.props.nodes
               if (typeof firstNodeIdx === 'undefined') {
                 firstNodeIdx = i
@@ -151,11 +163,12 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
               // merge props on to first node and delete
               ctx.tags[firstNodeIdx].props = mergeObjects(ctx.tags[firstNodeIdx].props, tag.props)
               delete ctx.tags[firstNodeIdx].props.nodes
-              toRemove.add(i)
+              ;(toRemove ||= new Set()).add(i)
             }
           }
           // there may be multiple script nodes within the same entry
-          ctx.tags = ctx.tags.filter((_: unknown, i: number) => !toRemove.has(i))
+          if (toRemove)
+            ctx.tags = ctx.tags.filter((_: unknown, i: number) => !toRemove.has(i))
         },
       },
     }

--- a/packages/schema-org/src/plugin.ts
+++ b/packages/schema-org/src/plugin.ts
@@ -63,7 +63,7 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
           // Push node (it already has _resolver if it came from a defineXXX function)
           graph.push(newNode)
         }
-        tag.tagPosition = tag.tagPosition || config.tagPosition === 'head' ? 'head' : 'bodyClose'
+        tag.tagPosition = tag.tagPosition || (config.tagPosition === 'head' ? 'head' : 'bodyClose')
       }
       if (tag.tag === 'htmlAttrs' && tag.props.lang) {
         resolvedMeta.inLanguage = tag.props.lang
@@ -105,6 +105,7 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
           // Reset graph nodes each cycle so disposed entries don't leave stale nodes.
           graph.nodes = []
           graph.nodeIndex = new Map()
+          resolvedMeta = {} as ResolvedMeta
           for (const entry of ctx.entries) {
             if (entry._tags) {
               if (entry._tags.some(isSchemaOrgTag)) {

--- a/packages/unhead/src/server/sort.ts
+++ b/packages/unhead/src/server/sort.ts
@@ -22,7 +22,7 @@ export function capoTagWeight(tag: HeadTag): number {
     weight = LINK_WEIGHTS[tag.props.rel as keyof typeof LINK_WEIGHTS]
   }
   else if (tag.tag === 'script') {
-    const type = String(tag.props.type)
+    const type = typeof tag.props.type === 'string' ? tag.props.type : ''
     const json = type.endsWith('json')
     if (type === 'importmap')
       // parse-time directive, not a loadable resource: placed between


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Schema.org no longer forces every cached head entry to normalize again during `entries:resolve`. Cached tags are reused unless the entry owns schema.org nodes, and script sorting avoids coercing missing `type` values into strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Schema.org metadata so structured data is collected more reliably and duplicated entries are avoided.
  * Refined script tag sorting behavior to better preserve correct ordering for different script types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->