### PR TITLE
chore(build): remove Rollup side-effect warnings

### DIFF
--- a/packages/unhead/build.config.ts
+++ b/packages/unhead/build.config.ts
@@ -7,10 +7,20 @@ import { build as viteBuild } from 'vite'
 
 const COMMENT_RE = /\/\*[\s\S]*?\*\/|\/\/.*/g
 const WHITESPACE_RE = /\s+/g
+const IIFE_GLOBAL_NAME = '__unhead_iife__'
+const IIFE_INIT_CALL = `${IIFE_GLOBAL_NAME}.init();`
 const IIFE_TYPES = 'export declare const streamingIifeCode: string;\nexport declare const streamingIifeSize: number;\n'
 
 function minifyIifeCode(code: string) {
   return code.replace(COMMENT_RE, '').replace(WHITESPACE_RE, ' ').trim()
+}
+
+function makeExecutableIifeCode(code: string) {
+  return `${code}${code.endsWith(';') ? '' : ';'}${IIFE_INIT_CALL}`
+}
+
+function isFirstSideEffectWarning(warning: { message?: string }) {
+  return warning.message?.startsWith('First side effect in ') === true
 }
 
 function writeIifeArtifacts(rootDir: string, code: string) {
@@ -30,7 +40,7 @@ async function buildIifeFromDist(rootDir: string) {
     plugins: [nodeResolve()],
   })
   try {
-    const { output } = await bundle.generate({ format: 'iife', name: '__unhead_iife__' })
+    const { output } = await bundle.generate({ format: 'iife', name: IIFE_GLOBAL_NAME })
     const chunk = output.find(item => item.type === 'chunk')
     if (!chunk)
       throw new Error('[unhead] Failed to build streaming IIFE.')
@@ -48,7 +58,7 @@ async function buildIifeFromSource(rootDir: string) {
       lib: {
         entry: resolve(rootDir, 'src/stream/iife.ts'),
         formats: ['iife'],
-        name: '__unhead_iife__',
+        name: IIFE_GLOBAL_NAME,
       },
       minify: false,
       write: false,
@@ -74,11 +84,19 @@ export default defineBuildConfig({
   hooks: {
     'rollup:options': (_, options) => {
       options.experimentalLogSideEffects = true
+      const onwarn = options.onwarn
+      options.onwarn = (warning, warn) => {
+        if (isFirstSideEffectWarning(warning))
+          throw new Error(warning.message)
+        if (onwarn)
+          return onwarn(warning, warn)
+        warn(warning)
+      }
     },
     'build:done': async function (ctx) {
-      const code = minifyIifeCode(ctx.options.stub
+      const code = makeExecutableIifeCode(minifyIifeCode(ctx.options.stub
         ? await buildIifeFromSource(ctx.options.rootDir)
-        : await buildIifeFromDist(ctx.options.rootDir))
+        : await buildIifeFromDist(ctx.options.rootDir)))
 
       writeIifeArtifacts(ctx.options.rootDir, code)
       console.log(`Built streaming IIFE: ${code.length} bytes`)

--- a/packages/unhead/src/plugins/aliasSorting.ts
+++ b/packages/unhead/src/plugins/aliasSorting.ts
@@ -6,7 +6,7 @@ const sortTags = (a: HeadTag, b: HeadTag) => a._w === b._w ? a._p - b._p : a._w 
 
 const formatKey = (k: string) => !k.includes(':key') ? k.split(':').join(':key:') : k
 
-export const AliasSortingPlugin = defineHeadPlugin({
+export const AliasSortingPlugin = /* @__PURE__ */ defineHeadPlugin({
   key: 'aliasSorting',
   hooks: {
     'tags:resolve': (ctx) => {

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -4,16 +4,16 @@ import { isUnsafeKey } from '../utils/unsafeKey'
 import { defineHeadPlugin } from './defineHeadPlugin'
 
 const WhitelistAttributes = {
-  htmlAttrs: new Set(['class', 'style', 'lang', 'dir']),
-  bodyAttrs: new Set(['class', 'style']),
-  meta: new Set(['name', 'property', 'charset', 'content', 'media']),
-  noscript: new Set([] as string[]),
-  style: new Set(['media', 'nonce', 'title', 'blocking']),
-  script: new Set(['type', 'textContent', 'nonce', 'blocking']),
-  link: new Set(['color', 'crossorigin', 'fetchpriority', 'href', 'hreflang', 'imagesrcset', 'imagesizes', 'integrity', 'media', 'referrerpolicy', 'rel', 'sizes', 'type']),
+  htmlAttrs: /* @__PURE__ */ new Set(['class', 'style', 'lang', 'dir']),
+  bodyAttrs: /* @__PURE__ */ new Set(['class', 'style']),
+  meta: /* @__PURE__ */ new Set(['name', 'property', 'charset', 'content', 'media']),
+  noscript: /* @__PURE__ */ new Set([] as string[]),
+  style: /* @__PURE__ */ new Set(['media', 'nonce', 'title', 'blocking']),
+  script: /* @__PURE__ */ new Set(['type', 'textContent', 'nonce', 'blocking']),
+  link: /* @__PURE__ */ new Set(['color', 'crossorigin', 'fetchpriority', 'href', 'hreflang', 'imagesrcset', 'imagesizes', 'integrity', 'media', 'referrerpolicy', 'rel', 'sizes', 'type']),
 } as const
 
-const BlockedLinkRels = new Set(['canonical', 'modulepreload', 'prerender', 'preload', 'prefetch', 'dns-prefetch', 'preconnect', 'manifest', 'pingback'])
+const BlockedLinkRels = /* @__PURE__ */ new Set(['canonical', 'modulepreload', 'prerender', 'preload', 'prefetch', 'dns-prefetch', 'preconnect', 'manifest', 'pingback'])
 
 const SafeDataAttrName = /^[a-z][a-z0-9-]*[a-z0-9]$/i
 const AsciiWhitespace = /[\t\n\f\r ]+/
@@ -241,7 +241,7 @@ function makeTagSafe(tag: HeadTag): HeadSafe | false {
   return tag
 }
 
-export const SafeInputPlugin = /* @PURE */ defineHeadPlugin({
+export const SafeInputPlugin = /* @__PURE__ */ defineHeadPlugin({
   key: 'safe',
   hooks: {
     'entries:normalize': (ctx) => {

--- a/packages/unhead/src/stream/iife.ts
+++ b/packages/unhead/src/stream/iife.ts
@@ -74,6 +74,4 @@ function init(options: { streamKey?: string } = {}) {
   return head
 }
 
-init()
-
 export { init }

--- a/packages/unhead/src/stream/unplugin.ts
+++ b/packages/unhead/src/stream/unplugin.ts
@@ -317,4 +317,4 @@ export function buildStreamingPluginOptions(options: StreamingPluginOptions, met
  * `@unhead/{vue,react,svelte,solid-js}/bundler`) rather than importing this
  * directly.
  */
-export const createStreamingPlugin = createUnplugin<StreamingPluginOptions>(buildStreamingPluginOptions)
+export const createStreamingPlugin = /* @__PURE__ */ createUnplugin<StreamingPluginOptions>(buildStreamingPluginOptions)

--- a/packages/unhead/test/unit/plugins/tree-shaking.test.ts
+++ b/packages/unhead/test/unit/plugins/tree-shaking.test.ts
@@ -1,4 +1,3 @@
-import type { OutputChunk, RollupOutput } from 'rollup'
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
@@ -19,10 +18,36 @@ const unusedPluginMarkers = [
   'entries:resolve',
 ]
 
-function getOutputCode(output: RollupOutput | RollupOutput[]) {
+interface GeneratedChunk {
+  code: string
+  type: 'chunk'
+}
+
+interface GeneratedOutput {
+  output: unknown[]
+}
+
+function isGeneratedOutput(value: unknown): value is GeneratedOutput {
+  return typeof value === 'object'
+    && value !== null
+    && 'output' in value
+    && Array.isArray(value.output)
+}
+
+function isGeneratedChunk(value: unknown): value is GeneratedChunk {
+  return typeof value === 'object'
+    && value !== null
+    && 'type' in value
+    && value.type === 'chunk'
+    && 'code' in value
+    && typeof value.code === 'string'
+}
+
+function getOutputCode(output: unknown) {
   return (Array.isArray(output) ? output : [output])
+    .filter(isGeneratedOutput)
     .flatMap(result => result.output)
-    .filter((item): item is OutputChunk => item.type === 'chunk')
+    .filter(isGeneratedChunk)
     .map(chunk => chunk.code)
     .join('\n')
 }
@@ -56,7 +81,7 @@ async function bundlePluginConsumer(importName: string) {
           },
         },
       },
-    }) as RollupOutput | RollupOutput[]
+    })
 
     return getOutputCode(output)
   }

--- a/packages/unhead/test/unit/plugins/tree-shaking.test.ts
+++ b/packages/unhead/test/unit/plugins/tree-shaking.test.ts
@@ -1,0 +1,150 @@
+import type { OutputChunk, RollupOutput } from 'rollup'
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { rollup } from 'rollup'
+import ts from 'typescript'
+import { build as viteBuild } from 'vite'
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+const unusedPluginMarkers = [
+  'aliasSorting',
+  'vbscript:',
+  'missing-template-params-plugin',
+  'canonicalHost',
+  'infer-seo-meta',
+  'application/ld+json',
+  'entries:resolve',
+]
+
+function getOutputCode(output: RollupOutput | RollupOutput[]) {
+  return (Array.isArray(output) ? output : [output])
+    .flatMap(result => result.output)
+    .filter((item): item is OutputChunk => item.type === 'chunk')
+    .map(chunk => chunk.code)
+    .join('\n')
+}
+
+async function bundlePluginConsumer(importName: string) {
+  const tempDir = mkdtempSync(join(tmpdir(), 'unhead-plugin-tree-shaking-'))
+  try {
+    const entry = resolve(tempDir, 'entry.ts')
+    writeFileSync(
+      entry,
+      `import { ${importName} } from 'unhead/plugins'\nglobalThis.__unheadPlugin = ${importName}\n`,
+    )
+
+    const output = await viteBuild({
+      configFile: false,
+      logLevel: 'silent',
+      root: tempDir,
+      resolve: {
+        alias: {
+          'unhead/plugins': resolve(packageRoot, 'src/plugins/index.ts'),
+        },
+      },
+      build: {
+        minify: false,
+        write: false,
+        rollupOptions: {
+          input: entry,
+          treeshake: true,
+          output: {
+            format: 'es',
+          },
+        },
+      },
+    }) as RollupOutput | RollupOutput[]
+
+    return getOutputCode(output)
+  }
+  finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+function isFile(path: string) {
+  return existsSync(path) && statSync(path).isFile()
+}
+
+function resolveTs(id: string, importer?: string) {
+  const base = importer && id.startsWith('.')
+    ? resolve(dirname(importer), id)
+    : isAbsolute(id) ? id : null
+
+  if (!base)
+    return null
+
+  for (const candidate of [base, `${base}.ts`, `${base}.mts`, resolve(base, 'index.ts')]) {
+    if (isFile(candidate))
+      return candidate
+  }
+
+  return null
+}
+
+function tsSourcePlugin() {
+  return {
+    name: 'unhead-test-ts-source',
+    resolveId(id: string, importer?: string) {
+      const resolved = resolveTs(id, importer)
+      if (resolved)
+        return resolved
+      return id.startsWith('.') || isAbsolute(id) ? null : { id, external: true }
+    },
+    load(id: string) {
+      if (!id.endsWith('.ts') && !id.endsWith('.mts'))
+        return null
+
+      return ts.transpileModule(readFileSync(id, 'utf8'), {
+        compilerOptions: {
+          module: ts.ModuleKind.ESNext,
+          target: ts.ScriptTarget.ES2022,
+          sourceMap: false,
+        },
+      }).outputText
+    },
+  }
+}
+
+async function collectFirstSideEffectLogs(input: string) {
+  const logs: string[] = []
+  const bundle = await rollup({
+    input,
+    experimentalLogSideEffects: true,
+    onLog(_, log) {
+      if (log.message.includes('First side effect in '))
+        logs.push(log.message)
+    },
+    plugins: [
+      tsSourcePlugin(),
+    ],
+  })
+
+  try {
+    await bundle.generate({ format: 'es' })
+  }
+  finally {
+    await bundle.close()
+  }
+
+  return logs
+}
+
+describe('plugins tree shaking', () => {
+  it('removes unused plugin modules from a single plugins barrel import', async () => {
+    const code = await bundlePluginConsumer('defineHeadPlugin')
+
+    expect(code).toContain('defineHeadPlugin')
+    for (const marker of unusedPluginMarkers)
+      expect(code).not.toContain(marker)
+  })
+
+  it('does not report top-level side effects in the plugins barrel', async () => {
+    const logs = await collectFirstSideEffectLogs(resolve(packageRoot, 'src/plugins/index.ts'))
+
+    expect(logs).toEqual([])
+  })
+})

--- a/packages/vue/src/bundler.ts
+++ b/packages/vue/src/bundler.ts
@@ -20,7 +20,7 @@ export type UnheadVueOptions = UnheadFrameworkOptions<UnheadVueStreamingOptions>
  * addBuildPlugin(Unhead({ streaming: true }))
  * ```
  */
-export const Unhead = createFrameworkPlugin<UnheadVueStreamingOptions>({
+export const Unhead = /* @__PURE__ */ createFrameworkPlugin<UnheadVueStreamingOptions>({
   framework: '@unhead/vue',
   streamingPlugin: unheadVueStreamingPlugin,
 })

--- a/packages/vue/src/stream/plugin.ts
+++ b/packages/vue/src/stream/plugin.ts
@@ -12,7 +12,7 @@ export type UnheadVueStreamingOptions = Pick<StreamingPluginOptions, 'mode'>
  * This plugin exists to wire the client streaming bootstrap (virtual iife
  * module + `transformIndexHtml` head-prepend on vite).
  */
-export const unheadVueStreamingPlugin = createUnplugin<UnheadVueStreamingOptions | undefined>((options = {}) =>
+export const unheadVueStreamingPlugin = /* @__PURE__ */ createUnplugin<UnheadVueStreamingOptions | undefined>((options = {}) =>
   buildStreamingPluginOptions({
     framework: '@unhead/vue',
     mode: options.mode,


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Rollup was reporting `First side effect` diagnostics in `unhead` plugin exports, the streaming plugin factory, and the streaming IIFE source.

This marks the relevant factory calls and constants as pure, moves the streaming browser auto-init into the generated IIFE artifact, and makes future `unhead` side-effect diagnostics fail the package build. The Vue bundler plugin factories get the same pure annotations so the workspace build stays quiet.

Minimal imports from `unhead/plugins` already tree-shake correctly. This PR is build hygiene rather than a measured consumer bundle-size improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved streaming bundle output to ensure initialization runs reliably in browser builds.

* **Bug Fixes**
  * Made streaming IIFE initialization more consistent across generated artifacts.
  * Reduced potential unwanted side effects during plugin bundling and tree-shaking.

* **Tests**
  * Added unit coverage to verify the plugins barrel tree-shakes correctly and avoids top-level side-effect logs from unused modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->