### PR TITLE
fix(types): allow `media` on icon links

### DIFF
--- a/packages/unhead/src/types/schema/link.ts
+++ b/packages/unhead/src/types/schema/link.ts
@@ -75,6 +75,13 @@ export interface StylesheetLink extends LinkBase, LinkHttpEvents {
    */
   title?: string
   /**
+   * This attribute is used to define the type of the content linked to.
+   * It can be omitted; `text/css` is assumed.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-type
+   */
+  type?: 'text/css' | (string & Record<never, never>)
+  /**
    * Whether the stylesheet is disabled.
    */
   disabled?: boolean
@@ -263,12 +270,32 @@ export interface PrefetchLink extends LinkBase {
 // ============================================================================
 
 /**
+ * Icon links may be scoped to a media query, most commonly to serve
+ * separate light and dark variants.
+ */
+interface IconLinkBase extends LinkBase {
+  /**
+   * This attribute specifies the media that the linked resource applies to,
+   * for example `(prefers-color-scheme: dark)`.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-media
+   */
+  media?: string
+  /**
+   * This enumerated attribute indicates whether CORS must be used when fetching the resource.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
+   */
+  crossorigin?: '' | 'anonymous' | 'use-credentials'
+}
+
+/**
  * Favicon link.
  *
  * Prefer `rel: 'icon'` over `'shortcut icon'` — the `shortcut` keyword is non-standard
  * and was only used by older versions of Internet Explorer.
  */
-export interface FaviconLink extends LinkBase {
+export interface FaviconLink extends IconLinkBase {
   rel: 'icon' | 'shortcut icon'
   /**
    * This attribute specifies the URL of the linked resource.
@@ -293,7 +320,7 @@ export interface FaviconLink extends LinkBase {
 /**
  * Apple touch icon link
  */
-export interface AppleTouchIconLink extends LinkBase {
+export interface AppleTouchIconLink extends IconLinkBase {
   rel: 'apple-touch-icon'
   /**
    * This attribute specifies the URL of the linked resource.
@@ -320,7 +347,7 @@ export interface AppleTouchIconLink extends LinkBase {
  *
  * @see https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/pinnedTabs/pinnedTabs.html
  */
-export interface MaskIconLink extends LinkBase {
+export interface MaskIconLink extends IconLinkBase {
   rel: 'mask-icon'
   /**
    * This attribute specifies the URL of the linked resource.
@@ -356,6 +383,12 @@ export interface ManifestLink extends LinkBase {
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-href
    */
   href: string
+  /**
+   * This attribute is used to define the type of the content linked to.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-type
+   */
+  type?: 'application/manifest+json' | (string & Record<never, never>)
   /**
    * This enumerated attribute indicates whether CORS must be used when fetching the resource.
    *

--- a/packages/unhead/test/unit/types.test.ts
+++ b/packages/unhead/test/unit/types.test.ts
@@ -64,6 +64,29 @@ describe('types', () => {
       },
     })
   })
+  it('types link attributes valid on every `<link>`', () => {
+    // These are checked against the strict (non-resolvable) link union, which is
+    // what a Nuxt `app.head` config resolves to.
+    const head: SerializableHead = {
+      link: [
+        // Light / dark icons are selected with `media`
+        { rel: 'icon', href: '/light.ico', media: '(prefers-color-scheme: light)' },
+        { rel: 'shortcut icon', href: '/dark.ico', media: '(prefers-color-scheme: dark)' },
+        { rel: 'apple-touch-icon', href: '/dark.png', media: '(prefers-color-scheme: dark)' },
+        { rel: 'mask-icon', href: '/mask.svg', color: '#000', media: 'all' },
+        // Icons may be fetched cross-origin
+        { rel: 'icon', href: 'https://cdn.example.com/favicon.ico', crossorigin: 'anonymous' },
+        // Legacy but valid `type` hints
+        { rel: 'stylesheet', href: '/a.css', type: 'text/css' },
+        { rel: 'manifest', href: '/manifest.json', type: 'application/manifest+json' },
+      ],
+    }
+    void head
+
+    // @ts-expect-error media must be a string
+    const invalid: SerializableHead = { link: [{ rel: 'icon', href: '/f.ico', media: 123 }] }
+    void invalid
+  })
   it('types preload link enforces `as` via PreloadLink', () => {
     const head = createHead()
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #820

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`FaviconLink` had no `media`, so the standard light/dark favicon pattern was a type error:

```ts
link: [
  { rel: 'shortcut icon', href: '/light.ico', media: '(prefers-color-scheme: light)' },
  { rel: 'shortcut icon', href: '/dark.ico', media: '(prefers-color-scheme: dark)' },
]
```

`media` and `crossorigin` now live on a shared `IconLinkBase` that `FaviconLink`, `AppleTouchIconLink` and `MaskIconLink` extend. Both apply to every `<link>` per spec, and dark-mode variants of apple-touch-icon and mask-icon hit the same wall.

While in there I checked the other narrowed rels against the strict `SerializableHead` path and found two more valid attributes being rejected: `type` on `StylesheetLink` (`text/css`) and on `ManifestLink` (`application/manifest+json`). Both added.

Test coverage goes on the `SerializableHead` path rather than `defineLink`, since `defineLink` accepts excess properties and would not have caught the original bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded supported link metadata for stylesheets and manifests, including typed `type` values with flexible string support.
  * Improved icon link typing to better cover common attributes like `media` and `crossorigin`.

* **Tests**
  * Added type-check coverage for link attribute combinations, including validation that `media` must be a string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->