### PR TITLE
chore: add @deprecated markers for v4 removals

### DIFF
--- a/packages/unhead/src/legacy/index.ts
+++ b/packages/unhead/src/legacy/index.ts
@@ -12,6 +12,9 @@ import { createUnhead } from '../unhead'
  * v3 equivalents (`innerHTML`, `key`, `tagPosition`, `tagPriority`).
  *
  * Intended as a temporary migration aid. Remove once all call sites use the v3 API.
+ *
+ * @deprecated Will be removed in v4. Migrate tag props to their v3 equivalents
+ * (`innerHTML`, `key`, `tagPosition`, `tagPriority`) directly and drop this plugin.
  */
 export const DeprecationsPlugin = /* @__PURE__ */ defineHeadPlugin({
   key: 'deprecations',
@@ -48,15 +51,30 @@ export const DeprecationsPlugin = /* @__PURE__ */ defineHeadPlugin({
 /**
  * The full v2 migration plugin set applied by the legacy `createHead`/`createServerHead`.
  * Export so users with a custom `createHead` can opt into one-line v2 compatibility.
+ *
+ * @deprecated Will be removed in v4. Migrate call sites to the v3 API and construct
+ * `createHead`/`createServerHead` from `unhead/client`/`unhead/server` without this plugin set.
  */
 export const legacyPlugins: HeadPluginInput[] = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
 
+/**
+ * @deprecated Will be removed in v4. This global singleton exists only to support the legacy
+ * `getActiveHead()` API; use the `Unhead` instance returned by `createHead`/`createServerHead` directly instead.
+ */
 export const activeHead: { value: Unhead<any> | null } = { value: null }
 
+/**
+ * @deprecated Will be removed in v4. Store and use the `Unhead` instance returned by
+ * `createHead`/`createServerHead` directly instead of reading it from a global singleton.
+ */
 export function getActiveHead<T extends Record<string, any> = ResolvableHead>(): Unhead<T> | null {
   return activeHead.value
 }
 
+/**
+ * @deprecated Will be removed in v4. Use `createHead` from `unhead/client` instead; register
+ * `legacyPlugins` yourself if you still need v1/v2 tag prop compatibility.
+ */
 export function createHead<T extends Record<string, any> = ResolvableHead>(options: CreateClientHeadOptions = {}): Unhead<T> {
   return activeHead.value = _createClientHead<T>({
     ...options,
@@ -64,6 +82,10 @@ export function createHead<T extends Record<string, any> = ResolvableHead>(optio
   })
 }
 
+/**
+ * @deprecated Will be removed in v4. Use `createServerHead` from `unhead/server` instead; register
+ * `legacyPlugins` yourself if you still need v1/v2 tag prop compatibility.
+ */
 export function createServerHead<T extends Record<string, any> = ResolvableHead>(options: Omit<CreateServerHeadOptions, 'propResolvers'> = {}): Unhead<T> {
   return activeHead.value = _createServerHead<T>({
     ...options,
@@ -71,4 +93,7 @@ export function createServerHead<T extends Record<string, any> = ResolvableHead>
   })
 }
 
+/**
+ * @deprecated Will be removed in v4. Use `createHead` from `unhead` (or `createUnhead` from `unhead/unhead`) directly.
+ */
 export const createHeadCore = createUnhead

--- a/packages/unhead/src/legacy/index.ts
+++ b/packages/unhead/src/legacy/index.ts
@@ -94,6 +94,6 @@ export function createServerHead<T extends Record<string, any> = ResolvableHead>
 }
 
 /**
- * @deprecated Will be removed in v4. Use `createHead` from `unhead` (or `createUnhead` from `unhead/unhead`) directly.
+ * @deprecated Will be removed in v4. Use `createUnhead` from `unhead` directly.
  */
 export const createHeadCore = createUnhead

--- a/packages/vue/src/legacy.ts
+++ b/packages/vue/src/legacy.ts
@@ -6,11 +6,17 @@ import { createHead as _createClientHead } from './client'
 import { createHead as _createServerHead } from './server'
 
 export * from './client'
+/**
+ * @deprecated Will be removed in v4. Use `createHead` from `@unhead/vue/client` instead.
+ */
 export { createHead as createClientHead } from './client'
 
 /**
  * The full v2 migration plugin set applied by the legacy `createHead`/`createServerHead`.
  * Export so users with a custom `createHead` can opt into one-line v2 compatibility.
+ *
+ * @deprecated Will be removed in v4. Migrate call sites to the v3 API and construct
+ * `createHead`/`createServerHead` from `@unhead/vue/client`/`@unhead/vue/server` without this plugin set.
  */
 export const legacyPlugins: HeadPluginInput[] = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
 
@@ -18,6 +24,9 @@ export const legacyPlugins: HeadPluginInput[] = [DeprecationsPlugin, PromisesPlu
  * Creates a client `VueHeadClient` with the v2 migration plugin set pre-registered so that
  * tag props (`children`, `hid`, `vmid`, `body`), promise resolution, template params, and
  * alias sorting continue to work during the migration to v3.
+ *
+ * @deprecated Will be removed in v4. Use `createHead` from `@unhead/vue/client` instead; register
+ * `legacyPlugins` yourself if you still need v1/v2 tag prop compatibility.
  */
 /* @__NO_SIDE_EFFECTS__ */
 export function createHead(options: CreateClientHeadOptions = {}): VueHeadClient<UseHeadInput, boolean> {
@@ -29,6 +38,9 @@ export function createHead(options: CreateClientHeadOptions = {}): VueHeadClient
 
 /**
  * Creates a server `VueHeadClient` with the v2 migration plugin set pre-registered.
+ *
+ * @deprecated Will be removed in v4. Use `createHead` from `@unhead/vue/server` instead; register
+ * `legacyPlugins` yourself if you still need v1/v2 tag prop compatibility.
  */
 /* @__NO_SIDE_EFFECTS__ */
 export function createServerHead(options: Omit<CreateServerHeadOptions, 'propResolvers'> = {}): VueHeadClient<UseHeadInput, SSRHeadPayload> {


### PR DESCRIPTION
### Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### Description

JSDoc-only pass ahead of v4: the legacy modules had migration-aid prose but no `@deprecated` tag, so editors and tooling weren't surfacing the upcoming removal. Marked every export in `packages/unhead/src/legacy/index.ts` and `packages/vue/src/legacy.ts` with `@deprecated`, stating removal in v4 and what to use instead.

Also swept `useServerHead`/`useServerSeoMeta`-shaped aliases across react/solid-js/svelte/angular; none of those packages define server-specific aliases (only Vue does, and Vue's are already marked), so no changes needed there.

Symbols marked in `packages/unhead/src/legacy/index.ts` (`unhead/legacy`):
- `DeprecationsPlugin`
- `legacyPlugins`
- `activeHead`
- `getActiveHead`
- `createHead` (use `createHead` from `unhead/client`)
- `createServerHead` (use `createServerHead` from `unhead/server`)
- `createHeadCore` (use `createUnhead` from `unhead`)

Symbols marked in `packages/vue/src/legacy.ts` (`@unhead/vue/legacy`):
- `createClientHead` re-export (use `createHead` from `@unhead/vue/client`)
- `legacyPlugins`
- `createHead` (use `createHead` from `@unhead/vue/client`)
- `createServerHead` (use `createHead` from `@unhead/vue/server`)

Replacement subpaths verified against each package's `exports` map; `@unhead/vue/server` does export `createHead`, and `createUnhead` is exported from the `unhead` root (there is no `unhead/unhead` subpath).

No runtime or export changes; `git diff` is comments only, and `test/exports.test.ts` still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded deprecation notices for legacy/head helper compatibility entry points, including legacy plugin guidance.
  * Added clearer migration instructions from older compatibility surfaces to current v3 APIs and the `Unhead` instance returned by `createHead`/`createServerHead`.
  * Clarified expected removal timelines for legacy helpers in a future major release, with guidance on continuing to use legacy behavior where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->