### PR TITLE
chore(bench): add self-contained bundle-size baselines

### DIFF
--- a/bench/bundle/bundle-report.ts
+++ b/bench/bundle/bundle-report.ts
@@ -14,8 +14,10 @@ export interface BundleData {
   category: string
   size: number
   gzippedSize: number
+  brotliSize: number
   baseSize: number
   baseGzippedSize: number
+  baseBrotliSize: number
 }
 
 type Status = 'new' | 'grew' | 'shrank' | 'same'
@@ -89,15 +91,15 @@ export function renderBundleReport(data: BundleData[]): string {
 
   // full per-bundle breakdown, grouped by category, collapsed by default
   out.push('', `<details><summary>All bundles (${data.length})</summary>`, '')
-  out.push('| Bundle | Gzipped | Raw | |', '|---|---|---|---|')
+  out.push('| Bundle | Gzipped | Brotli | Raw | |', '|---|---|---|---|---|')
   let lastCat = ''
   for (const { item, status } of rows) {
     if (item.category !== lastCat) {
-      out.push(`| **${item.category}** | | | |`)
+      out.push(`| **${item.category}** | | | | |`)
       lastCat = item.category
     }
     const mark = status === 'new' ? '🆕' : status === 'grew' ? '🔴' : status === 'shrank' ? '🟢' : '✅'
-    out.push(`| ${item.name} | ${formatSize(item.gzippedSize)} | ${formatSize(item.size)} | ${mark} |`)
+    out.push(`| ${item.name} | ${formatSize(item.gzippedSize)} | ${formatSize(item.brotliSize)} | ${formatSize(item.size)} | ${mark} |`)
   }
   out.push('', '</details>')
 
@@ -106,6 +108,10 @@ export function renderBundleReport(data: BundleData[]): string {
 
 function gz(buf: Buffer): number {
   return zlib.gzipSync(buf).length
+}
+
+function br(buf: Buffer): number {
+  return zlib.brotliCompressSync(buf).length
 }
 
 function readBundle(dir: string, file: string): Buffer | null {
@@ -117,7 +123,7 @@ function readBundle(dir: string, file: string): Buffer | null {
 // locally, fall back to the committed last.json baseline.
 export function collectBundleData(): BundleData[] {
   const baseDist = process.env.BASE_DIST
-  const lastStats: Record<string, { size: number, gz: number }> | null = baseDist
+  const lastStats: Record<string, { size: number, gz: number, br?: number }> | null = baseDist
     ? null
     : JSON.parse(fs.readFileSync(path.resolve(__dirname, 'last.json'), 'utf8'))
 
@@ -131,24 +137,30 @@ export function collectBundleData(): BundleData[] {
     }
     let baseSize = 0
     let baseGzippedSize = 0
+    let baseBrotliSize = 0
     if (baseDist) {
       const base = readBundle(baseDist, spec.file)
       if (base) {
         baseSize = base.length
         baseGzippedSize = gz(base)
+        baseBrotliSize = br(base)
       }
     }
     else if (lastStats?.[spec.id]) {
       baseSize = lastStats[spec.id].size
       baseGzippedSize = lastStats[spec.id].gz
+      // legacy last.json entries predate brotli tracking; 0 just means "unknown", not "new"
+      baseBrotliSize = lastStats[spec.id].br ?? 0
     }
     data.push({
       name: spec.name,
       category: spec.category,
       size: current.length,
       gzippedSize: gz(current),
+      brotliSize: br(current),
       baseSize,
       baseGzippedSize,
+      baseBrotliSize,
     })
   }
   return data

--- a/bench/bundle/bundles.ts
+++ b/bench/bundle/bundles.ts
@@ -17,7 +17,9 @@ export interface BundleSpec {
 export const BUNDLES: BundleSpec[] = [
   { id: 'client', name: 'Client (Minimal)', category: 'Core', file: 'client/client/minimal.mjs', required: true },
   { id: 'clientFull', name: 'Client (Full)', category: 'Core', file: 'client-full/client/full.mjs' },
+  { id: 'clientSelfContained', name: 'Client (Self-Contained)', category: 'Core', file: 'client-sc/client/minimal.mjs' },
   { id: 'server', name: 'Server (Minimal)', category: 'Core', file: 'server/server/minimal.mjs', required: true },
+  { id: 'serverSelfContained', name: 'Server (Self-Contained)', category: 'Core', file: 'server-sc/server/minimal.mjs' },
   { id: 'vueClient', name: 'Vue Client (Minimal)', category: 'Vue', file: 'vue-client/vue-client/minimal.mjs', required: true },
   { id: 'vueClientFull', name: 'Vue Client (Full)', category: 'Vue', file: 'vue-client-full/vue-client/full.mjs' },
   { id: 'vueServer', name: 'Vue Server (Minimal)', category: 'Vue', file: 'vue-server/vue-server/minimal.mjs', required: true },

--- a/bench/bundle/client-sc-build.config.ts
+++ b/bench/bundle/client-sc-build.config.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import zlib from 'node:zlib'
+import { visualizer } from 'rollup-plugin-visualizer'
+import { defineBuildConfig } from 'unbuild'
+
+const packagesDir = path.resolve(__dirname, '../../packages')
+
+// Self-contained variant of client-build.config.ts: `hookable` is inlined instead of
+// externalized so the number reflects the true cost of shipping this bundle standalone,
+// not gameable by moving deps around.
+export default defineBuildConfig({
+  entries: [
+    'src/client/minimal',
+  ],
+  outDir: 'dist/client-sc',
+  failOnWarn: false,
+  rollup: {
+    inlineDependencies: true,
+    esbuild: {
+      treeShaking: true,
+      minify: true,
+    },
+    alias: {
+      entries: [
+        { find: 'unhead/client', replacement: path.join(packagesDir, 'unhead/dist/client.mjs') },
+        { find: 'unhead', replacement: path.join(packagesDir, 'unhead/dist/index.mjs') },
+      ],
+    },
+  },
+  declaration: false,
+  hooks: {
+    'rollup:options': (ctx, config) => {
+      config.plugins.push(visualizer({
+        emitFile: true,
+        filename: 'stats.html',
+      }))
+    },
+    'build:done': () => {
+      const file = path.resolve(__dirname, 'dist/client-sc/client/minimal.mjs')
+      const contents = fs.readFileSync(file)
+      const size = contents.length
+      const compressed = zlib.gzipSync(contents).length
+      console.log(`CLIENT (self-contained) Size: ${Math.round(size / 102.4) / 10} kB (gzipped: ${Math.round(compressed / 102.4) / 10} kB)`)
+    },
+  },
+})

--- a/bench/bundle/last.json
+++ b/bench/bundle/last.json
@@ -46,5 +46,15 @@
   "schemaOrgVueMeta": {
     "size": 845,
     "gz": 443
+  },
+  "clientSelfContained": {
+    "size": 13830,
+    "gz": 5584,
+    "br": 5067
+  },
+  "serverSelfContained": {
+    "size": 12255,
+    "gz": 4971,
+    "br": 4480
   }
 }

--- a/bench/bundle/server-sc-build.config.ts
+++ b/bench/bundle/server-sc-build.config.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import zlib from 'node:zlib'
+import { visualizer } from 'rollup-plugin-visualizer'
+import { defineBuildConfig } from 'unbuild'
+
+const packagesDir = path.resolve(__dirname, '../../packages')
+
+// Self-contained variant of server-build.config.ts: `hookable` is inlined instead of
+// externalized so the number reflects the true cost of shipping this bundle standalone,
+// not gameable by moving deps around.
+export default defineBuildConfig({
+  entries: [
+    'src/server/minimal',
+  ],
+  outDir: 'dist/server-sc',
+  failOnWarn: false,
+  rollup: {
+    inlineDependencies: true,
+    esbuild: {
+      treeShaking: true,
+      minify: true,
+    },
+    alias: {
+      entries: [
+        { find: 'unhead/server', replacement: path.join(packagesDir, 'unhead/dist/server.mjs') },
+        { find: 'unhead', replacement: path.join(packagesDir, 'unhead/dist/index.mjs') },
+      ],
+    },
+  },
+  declaration: false,
+  hooks: {
+    'rollup:options': (ctx, config) => {
+      config.plugins.push(visualizer({
+        emitFile: true,
+        filename: 'stats.html',
+      }))
+    },
+    'build:done': () => {
+      const file = path.resolve(__dirname, 'dist/server-sc/server/minimal.mjs')
+      const contents = fs.readFileSync(file)
+      const size = contents.length
+      const compressed = zlib.gzipSync(contents).length
+      console.log(`SERVER (self-contained) Size: ${Math.round(size / 102.4) / 10} kB (gzipped: ${Math.round(compressed / 102.4) / 10} kB)`)
+    },
+  },
+})

--- a/bench/bundle/update.ts
+++ b/bench/bundle/update.ts
@@ -6,24 +6,43 @@ import { BUNDLES } from './bundles'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const distDir = path.resolve(__dirname, 'dist')
+const lastJsonPath = path.resolve(__dirname, 'last.json')
 
-const newStats: Record<string, { size: number, gz: number }> = {}
+interface Stats {
+  size: number
+  gz: number
+  br?: number
+}
+
+// Merge, don't overwrite: only bundles that were actually rebuilt this run (their dist
+// file exists) get fresh numbers. Anything else keeps its previously committed value
+// untouched, so a partial build (e.g. only the self-contained fixtures) can't perturb
+// baselines it never regenerated.
+const oldStats: Record<string, Stats> = fs.existsSync(lastJsonPath)
+  ? JSON.parse(fs.readFileSync(lastJsonPath, 'utf8'))
+  : {}
+
+const newStats: Record<string, Stats> = { ...oldStats }
 for (const spec of BUNDLES) {
   const p = path.resolve(distDir, spec.file)
   if (!fs.existsSync(p)) {
-    if (spec.required)
+    if (spec.required && !oldStats[spec.id])
       throw new Error(`Missing required bundle: ${spec.file}`)
     continue
   }
   const buf = fs.readFileSync(p)
-  newStats[spec.id] = { size: buf.length, gz: zlib.gzipSync(buf).length }
+  newStats[spec.id] = {
+    size: buf.length,
+    gz: zlib.gzipSync(buf).length,
+    br: zlib.brotliCompressSync(buf).length,
+  }
 }
 
 // eslint-disable-next-line no-console
 console.table(newStats)
 
 fs.writeFileSync(
-  path.resolve(__dirname, 'last.json'),
+  lastJsonPath,
   `${JSON.stringify(newStats, null, 2)}\n`,
   'utf8',
 )

--- a/bench/bundle/update.ts
+++ b/bench/bundle/update.ts
@@ -17,17 +17,24 @@ interface Stats {
 // Merge, don't overwrite: only bundles that were actually rebuilt this run (their dist
 // file exists) get fresh numbers. Anything else keeps its previously committed value
 // untouched, so a partial build (e.g. only the self-contained fixtures) can't perturb
-// baselines it never regenerated.
+// baselines it never regenerated. Carried-forward entries are warned about loudly below
+// so a broken/skipped build can't silently ship stale numbers.
 const oldStats: Record<string, Stats> = fs.existsSync(lastJsonPath)
   ? JSON.parse(fs.readFileSync(lastJsonPath, 'utf8'))
   : {}
 
 const newStats: Record<string, Stats> = { ...oldStats }
+const stale: string[] = []
 for (const spec of BUNDLES) {
   const p = path.resolve(distDir, spec.file)
   if (!fs.existsSync(p)) {
+    // no fresh build AND no committed history: nothing to carry forward, fail loudly
     if (spec.required && !oldStats[spec.id])
       throw new Error(`Missing required bundle: ${spec.file}`)
+    if (oldStats[spec.id]) {
+      stale.push(spec.id)
+      console.warn(`[bundle-stats] STALE: "${spec.id}" was not built this run (missing dist/${spec.file}); carrying forward previous numbers from last.json`)
+    }
     continue
   }
   const buf = fs.readFileSync(p)
@@ -39,7 +46,12 @@ for (const spec of BUNDLES) {
 }
 
 // eslint-disable-next-line no-console
-console.table(newStats)
+console.table(Object.fromEntries(
+  Object.entries(newStats).map(([id, stats]) => [stale.includes(id) ? `${id} (stale)` : id, stats]),
+))
+
+if (stale.length)
+  console.warn(`[bundle-stats] ${stale.length} bundle(s) carried forward without a fresh build: ${stale.join(', ')}`)
 
 fs.writeFileSync(
   lastJsonPath,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "bundle-size:sync": "pnpm run build && pnpm run test:bundle-size && pnpm run test:vue-bundle-size && pnpm run test:react-bundle-size && pnpm run test:schema-org-bundle-size && bun bench/bundle/analyze.ts && bun bench/bundle/update.ts",
-    "test:bundle-size": "unbuild bench/bundle --config bench/bundle/client-build.config.ts && unbuild bench/bundle --config bench/bundle/client-full-build.config.ts && unbuild bench/bundle --config bench/bundle/server-build.config.ts",
+    "test:bundle-size": "unbuild bench/bundle --config bench/bundle/client-build.config.ts && unbuild bench/bundle --config bench/bundle/client-full-build.config.ts && unbuild bench/bundle --config bench/bundle/client-sc-build.config.ts && unbuild bench/bundle --config bench/bundle/server-build.config.ts && unbuild bench/bundle --config bench/bundle/server-sc-build.config.ts",
     "test:vue-bundle-size": "unbuild bench/bundle --config bench/bundle/vue-client-build.config.ts && unbuild bench/bundle --config bench/bundle/vue-client-full-build.config.ts && unbuild bench/bundle --config bench/bundle/vue-server-build.config.ts",
     "test:react-bundle-size": "unbuild bench/bundle --config bench/bundle/react-client-build.config.ts && unbuild bench/bundle --config bench/bundle/react-client-full-build.config.ts && unbuild bench/bundle --config bench/bundle/react-server-build.config.ts",
     "test:schema-org-bundle-size": "unbuild bench/bundle --config bench/bundle/schema-org-build.config.ts",


### PR DESCRIPTION
## Summary

Every bundle fixture in `bench/bundle/*.config.ts` externalizes `hookable`, including the "full" variants — so inlining/removing a dependency in a future refactor could move the real bundle size without the tracked numbers catching it.

- Adds `client-sc-build.config.ts` / `server-sc-build.config.ts`: copies of the minimal client/server unbuild configs with `externals: ['hookable']` removed, so `hookable` is inlined into the bundle.
- Wires the new fixtures (`clientSelfContained`, `serverSelfContained`) into `bundles.ts` and the `test:bundle-size` script chain.
- Adds brotli (`br`) size tracking alongside raw/gzip in `update.ts` and `bundle-report.ts` (used by both `analyze.ts` and `report.ts`), additive only — existing `last.json` entries keep their `{size, gz}` shape, new/regenerated ones get `{size, gz, br}`.
- `update.ts` now **merges** into `last.json` instead of overwriting it wholesale, so a partial build (e.g. only the two new self-contained fixtures) can't perturb baselines it didn't rebuild. Required-bundle validation only fires when there's neither a fresh dist file nor a prior committed value.

## New baseline numbers

| Bundle | Raw | Gzip | Brotli | vs externalized equivalent (gzip) |
|---|---|---|---|---|
| Client (Self-Contained) | 13,830 B | 5,584 B | 5,067 B | Client (Minimal, externalized hookable): 5,263 B → +321 B |
| Server (Self-Contained) | 12,255 B | 4,971 B | 4,480 B | Server (Minimal, externalized hookable): 4,658 B → +313 B |

Self-contained bundles are larger than their externalized equivalents, as expected (they carry `hookable`'s ~1 kB source instead of assuming it's a shared/deduped external).

## Verification

- `git diff bench/bundle/last.json` (pre-commit) showed **only additions** — `clientSelfContained` / `serverSelfContained` keys — no changes to any existing values.
- Ran the two new unbuild configs directly and via the full `test:bundle-size` chain; numbers are reproducible.
- Ran a full rebuild of all existing fixtures locally (without re-running `update.ts`) to confirm `bundle-report.ts`'s new Brotli column renders correctly and `last.json` stays untouched for pre-existing entries.
- `pnpm lint` clean, no unrelated diffs.

## Deviations from spec

- Used `bun` directly (available in this environment) for `update.ts`/`analyze.ts`/`report.ts` — no fallback needed.
- `bundle-report.ts` (shared by `analyze.ts` and `report.ts`) also gained a `brotliSize`/`baseBrotliSize` pair on `BundleData` and a new "Brotli" column in the collapsed "All bundles" table, so brotli numbers are visible in the PR comment, not just persisted to `last.json`. This is additive and doesn't change the gzip-driven grew/shrank/new status logic.

## Test plan

- [x] `pnpm lint`
- [x] Built `client-sc-build.config.ts` and `server-sc-build.config.ts` directly, confirmed hookable is inlined (visualizer/unbuild output shows `hookable/dist/index.mjs` bundled in)
- [x] `bun bench/bundle/update.ts` merges new keys only, verified via `git diff bench/bundle/last.json`
- [x] `bun bench/bundle/analyze.ts` / `report.ts` render the new fixtures with a Brotli column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-contained client and server bundle builds.
  * Bundle reports now include raw, gzip, and Brotli size metrics.
  * Added bundle-size tracking for the new self-contained outputs.

* **Improvements**
  * Bundle baselines now support partial rebuilds while preserving existing results.
  * Bundle-size checks now cover the additional self-contained variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->