### PR TITLE
perf(bundler): broaden static useSeoMeta lowering

### DIFF
--- a/packages/bundler/src/unplugin/createTransformPipeline.ts
+++ b/packages/bundler/src/unplugin/createTransformPipeline.ts
@@ -7,6 +7,7 @@ import MagicString from 'magic-string'
 import { parseSync } from 'oxc-parser'
 import { ScopeTracker, ScopeTrackerImport, walk } from 'oxc-walker'
 import {
+  MetaTagsArrayable,
   resolveMetaKeyType,
   resolveMetaKeyValue,
   resolvePackedMetaObjectValue,
@@ -479,6 +480,126 @@ export function createTransformPipeline(config: TransformPipelineConfig): Unplug
         // arg, spread properties). The original import must be preserved alongside the useHead rewrite.
         const untransformedCallees = new Set<string>()
 
+        // Lower one flat meta prop (`description: ...`, `robots: {...}`) into
+        // `{ name/property, content }` line(s). Returns `false` when the value
+        // needs runtime handling (dynamic media value, undecodable nested object).
+        //
+        // Runtime `unpackMeta` renders in two groups: structural expansions
+        // (media objects/arrays, array values) are collected into `extras` and
+        // rendered BEFORE the scalar/packed `primitives`, regardless of source
+        // order. Each lowered prop is therefore tagged with its group so the
+        // caller can reproduce `[...extras, ...primitives]`.
+        function lowerMetaProperty(property: any): { group: 'extras' | 'primitives', lines: string[] } | false {
+          const propertyKey = property.key
+          let key: string = resolveMetaKeyType(propertyKey.name)
+          const keyValue = resolveMetaKeyValue(propertyKey.name)
+          let valueKey = 'content'
+          if (keyValue === 'charset') {
+            valueKey = 'charset'
+            key = 'charset'
+          }
+          // `http-equiv` is not a valid identifier and must be emitted quoted
+          if (key === 'http-equiv')
+            key = '\'http-equiv\''
+          let value = code.substring(property.value.start as number, property.value.end as number)
+
+          if (MEDIA_KEYS.has(propertyKey.name)) {
+            // Expand an object literal `{ url, width, ... }` into `og:image`, `og:image:width`, ...
+            // matching runtime `unpackMeta`. Leaf values may be dynamic; only the structure must
+            // be statically known. Returns false when a prop key can't be resolved statically.
+            // Runtime emits `url` (then `secureUrl` for object values) before the other props.
+            const expandObject = (objNode: any, secureUrlFirst: boolean): string | false => {
+              const urlTags: string[] = []
+              const secureUrlTags: string[] = []
+              const otherTags: string[] = []
+              for (const p of objNode.properties) {
+                // Only plain `key: value` pairs can be reproduced statically. Spreads, getters,
+                // setters, methods, and computed/non-identifier keys bail to runtime.
+                if (p.type === 'SpreadElement' || p.computed || p.method || p.kind !== 'init' || p.key?.type !== 'Identifier')
+                  return false
+                // Match runtime `unpackMeta`: `url` -> bare property, `secureUrl` -> `:secure_url`.
+                const name = p.key.name
+                const suffix = name === 'url' ? '' : `:${name === 'secureUrl' ? 'secure_url' : name}`
+                const tag = `    { ${key}: '${keyValue}${suffix}', ${valueKey}: ${code.substring(p.value.start, p.value.end)} },`
+                if (name === 'url')
+                  urlTags.push(tag)
+                else if (name === 'secureUrl' && secureUrlFirst)
+                  secureUrlTags.push(tag)
+                else
+                  otherTags.push(tag)
+              }
+              return [...urlTags, ...secureUrlTags, ...otherTags].join('\n')
+            }
+            if (property.value.type === 'ObjectExpression') {
+              const expanded = expandObject(property.value, true)
+              if (expanded === false)
+                return false
+              return { group: 'extras', lines: [expanded] }
+            }
+            if (property.value.type === 'ArrayExpression') {
+              if (!property.value.elements.length)
+                return { group: 'extras', lines: [] }
+              const parts: string[] = []
+              for (const element of property.value.elements) {
+                if (!element || element.type !== 'ObjectExpression')
+                  return false
+                // The runtime array branch hoists only `url` per element.
+                const expanded = expandObject(element, false)
+                if (expanded === false)
+                  return false
+                parts.push(expanded)
+              }
+              return { group: 'extras', lines: [parts.join('\n')] }
+            }
+            // Primitive literals (string/number/boolean) and template literals always resolve to a
+            // scalar -> a single safe tag. Anything else (identifier, ref(), computed(), getter,
+            // or a non-primitive literal like a regexp) could resolve to an object/array, so bail
+            // to runtime `unpackMeta`.
+            const v = property.value
+            const primitive = typeof v.value === 'string' || typeof v.value === 'number' || typeof v.value === 'boolean'
+            const isScalar = v.type === 'TemplateLiteral'
+              || ((v.type === 'Literal' || v.type === 'StringLiteral' || v.type === 'NumericLiteral') && primitive)
+            if (!isScalar)
+              return false
+          }
+
+          if (property.value.type === 'ArrayExpression') {
+            const elements = property.value.elements
+            if (!elements.length)
+              return { group: 'extras', lines: [] }
+
+            const metaTags: string[] = []
+            for (const element of elements) {
+              if (!element || element.type === 'SpreadElement')
+                return false
+              if (element.type !== 'ObjectExpression') {
+                metaTags.push(`    { ${key}: '${keyValue}', ${valueKey}: ${code.substring(element.start, element.end)} },`)
+                continue
+              }
+              const propTags: string[] = []
+              for (const p of element.properties) {
+                if (p.type === 'SpreadElement' || p.computed || p.key?.type !== 'Identifier')
+                  return false
+                const propKey = p.key.name
+                const propValue = code.substring(p.value.start, p.value.end)
+                propTags.push(`    { ${key}: '${keyValue}:${propKey}', ${valueKey}: ${propValue} },`)
+              }
+              metaTags.push(propTags.join('\n'))
+            }
+
+            return { group: 'extras', lines: [metaTags.join('\n')] }
+          }
+          else if (property.value.type === 'ObjectExpression') {
+            const packed = lowerPackedMetaObject(property.value, propertyKey.name)
+            if (packed === false)
+              return false
+            value = packed
+          }
+          if (valueKey === 'charset')
+            return { group: 'primitives', lines: [`    { ${key}: ${value} },`] }
+          return { group: 'primitives', lines: [`    { ${key}: '${keyValue}', ${valueKey}: ${value} },`] }
+        }
+
         function seoMetaEnter(node: any, parent: any): void {
           // Track value references to seoMeta identifiers (e.g., console.log(useSeoMeta))
           // Skip: call callees (handled below), import specifiers (definitions, not references)
@@ -527,7 +648,7 @@ export function createTransformPipeline(config: TransformPipelineConfig): Unplug
             return
           }
 
-          let output: string[] | false = []
+          const output: string[] = []
           const title = properties.find((property: any) => property.key?.name === 'title')
           const titleTemplate = properties.find((property: any) => property.key?.name === 'titleTemplate')
           const meta = properties.filter((property: any) => property.key?.name !== 'title' && property.key?.name !== 'titleTemplate')
@@ -551,135 +672,58 @@ export function createTransformPipeline(config: TransformPipelineConfig): Unplug
             output.push('useServerHead({')
           }
 
-          if (meta.length)
-            output.push('  meta: [')
-
-          meta.forEach((property: any) => {
-            if (property.type === 'SpreadElement') {
-              output = false
-              return
+          // Lower meta props in source order. A structural failure (spread,
+          // computed/non-identifier key) bails the whole call; a value-level
+          // failure (dynamic media value, undecodable nested object) may
+          // instead split the unsupported tail into a residual runtime call
+          // when that is provably render-identical (see `canEmitResidual`).
+          // Runtime `unpackMeta` renders structural expansions before scalar/
+          // packed props (`[...extras, ...meta]`); group lines accordingly.
+          const extraLines: string[] = []
+          const primitiveLines: string[] = []
+          let bail = false
+          let failedAt = -1
+          for (let i = 0; i < meta.length; i++) {
+            const property = meta[i]
+            if (property.type === 'SpreadElement' || property.key.type !== 'Identifier' || !property.value) {
+              bail = true
+              break
             }
-            if (property.key.type !== 'Identifier' || !property.value) {
-              output = false
-              return
+            const lowered = lowerMetaProperty(property)
+            if (lowered === false) {
+              failedAt = i
+              break
             }
-            if (output === false)
-              return
-            const propertyKey = property.key
-            let key: string = resolveMetaKeyType(propertyKey.name)
-            const keyValue = resolveMetaKeyValue(propertyKey.name)
-            let valueKey = 'content'
-            if (keyValue === 'charset') {
-              valueKey = 'charset'
-              key = 'charset'
-            }
-            let value = code.substring(property.value.start as number, property.value.end as number)
+            (lowered.group === 'extras' ? extraLines : primitiveLines).push(...lowered.lines)
+          }
+          const metaLines = [...extraLines, ...primitiveLines]
 
-            if (MEDIA_KEYS.has(propertyKey.name)) {
-              // Expand an object literal `{ url, width, ... }` into `og:image`, `og:image:width`, ...
-              // matching runtime `unpackMeta`. Leaf values may be dynamic; only the structure must
-              // be statically known. Returns false when a prop key can't be resolved statically.
-              const expandObject = (objNode: any): string | false => {
-                const tags: string[] = []
-                for (const p of objNode.properties) {
-                  // Only plain `key: value` pairs can be reproduced statically. Spreads, getters,
-                  // setters, methods, and computed/non-identifier keys bail to runtime.
-                  if (p.type === 'SpreadElement' || p.computed || p.method || p.kind !== 'init' || p.key?.type !== 'Identifier')
-                    return false
-                  // Match runtime `unpackMeta`: `url` -> bare property, `secureUrl` -> `:secure_url`.
-                  const name = p.key.name
-                  const suffix = name === 'url' ? '' : `:${name === 'secureUrl' ? 'secure_url' : name}`
-                  tags.push(`    { ${key}: '${keyValue}${suffix}', ${valueKey}: ${code.substring(p.value.start, p.value.end)} },`)
-                }
-                return tags.join('\n')
-              }
-              if (property.value.type === 'ObjectExpression') {
-                const expanded = expandObject(property.value)
-                if (expanded === false) {
-                  output = false
-                  return
-                }
-                output.push(expanded)
-                return
-              }
-              if (property.value.type === 'ArrayExpression') {
-                if (!property.value.elements.length)
-                  return
-                const parts: string[] = []
-                for (const element of property.value.elements) {
-                  if (!element || element.type !== 'ObjectExpression') {
-                    output = false
-                    return
-                  }
-                  const expanded = expandObject(element)
-                  if (expanded === false) {
-                    output = false
-                    return
-                  }
-                  parts.push(expanded)
-                }
-                output.push(parts.join('\n'))
-                return
-              }
-              // Primitive literals (string/number/boolean) and template literals always resolve to a
-              // scalar -> a single safe tag. Anything else (identifier, ref(), computed(), getter,
-              // or a non-primitive literal like a regexp) could resolve to an object/array, so bail
-              // to runtime `unpackMeta`.
-              const v = property.value
-              const primitive = typeof v.value === 'string' || typeof v.value === 'number' || typeof v.value === 'boolean'
-              const isScalar = v.type === 'TemplateLiteral'
-                || ((v.type === 'Literal' || v.type === 'StringLiteral' || v.type === 'NumericLiteral') && primitive)
-              if (!isScalar) {
-                output = false
-                return
-              }
-            }
-
-            if (property.value.type === 'ArrayExpression') {
-              const elements = property.value.elements
-              if (!elements.length)
-                return
-
-              const metaTags = elements.map((element: any) => {
-                if (element.type !== 'ObjectExpression')
-                  return `    { ${key}: '${keyValue}', ${valueKey}: ${code.substring(element.start, element.end)} },`
-
-                return element.properties.map((p: any) => {
-                  const propKey = p.key.name
-                  const propValue = code.substring(p.value.start, p.value.end)
-                  return `    { ${key}: '${keyValue}:${propKey}', ${valueKey}: ${propValue} },`
-                }).join('\n')
-              })
-
-              output.push(metaTags.join('\n'))
-              return
-            }
-            else if (property.value.type === 'ObjectExpression') {
-              const staticValue = materializeStaticStringObject(property.value)
-              if (!staticValue) {
-                output = false
-                return
-              }
-              try {
-                value = JSON.stringify(resolvePackedMetaObjectValue(staticValue, propertyKey.name))
-              }
-              catch {
-                output = false
-                return
-              }
-            }
-            if (valueKey === 'charset')
-              output.push(`    { ${key}: ${value} },`)
+          let residualProps: any[] | null = null
+          if (!bail && failedAt !== -1) {
+            if (canEmitResidual(node, parent, originalName, title, titleTemplate, meta, failedAt))
+              residualProps = meta.slice(failedAt)
             else
-              output.push(`    { ${key}: '${keyValue}', ${valueKey}: ${value} },`)
-          })
-          if (output) {
-            if (meta.length)
+              bail = true
+          }
+
+          if (!bail) {
+            const loweredMetaCount = failedAt === -1 ? meta.length : failedAt
+            if (loweredMetaCount) {
+              output.push('  meta: [')
+              output.push(...metaLines)
               output.push('  ]')
+            }
             // Preserve the second argument (options like { head }) if present
             if (node.arguments.length >= 2) {
               const optionsArg = code.substring(node.arguments[1].start, node.arguments[1].end)
               output.push(`}, ${optionsArg})`)
+            }
+            else if (residualProps) {
+              // Per-prop fallback: keep the unsupported tail props on the
+              // original composable, adjacent to the lowered entry, so runtime
+              // `unpackMeta` handles them (same source order, disjoint names).
+              output.push('});')
+              output.push(`${code.substring(node.callee.start, node.callee.end)}({ ${residualProps.map((p: any) => code.substring(p.start, p.end)).join(', ')} })`)
             }
             else {
               output.push('})')
@@ -691,6 +735,9 @@ export function createTransformPipeline(config: TransformPipelineConfig): Unplug
               if (!importRewrites.has(importDecl))
                 importRewrites.set(importDecl, new Set())
               importRewrites.get(importDecl)!.add(originalName)
+              // The residual call still references the original composable.
+              if (residualProps)
+                untransformedCallees.add(originalName)
             }
           }
           else if (importDecl) {
@@ -867,25 +914,183 @@ function getStaticPropertyKey(prop: any): string | undefined {
     return prop.key.value
 }
 
-function getStaticStringValue(node: any): string | undefined {
-  if ((node?.type === 'Literal' || node?.type === 'StringLiteral') && typeof node.value === 'string')
-    return node.value
-}
-
 function isUnsafeObjectKey(key: string): boolean {
   return key === '__proto__' || key === 'constructor' || key === 'prototype'
 }
 
-function materializeStaticStringObject(node: any): Record<string, string> | false {
-  const out: Record<string, string> = Object.create(null)
-  for (const prop of node.properties) {
-    if (prop.type === 'SpreadElement' || prop.computed || prop.method || prop.kind !== 'init')
-      return false
-    const key = getStaticPropertyKey(prop)
-    const value = getStaticStringValue(prop.value)
-    if (!key || isUnsafeObjectKey(key) || value === undefined)
-      return false
-    out[key] = value
+const DECODE_BAIL = Symbol('unhead:decode-bail')
+
+type DecodedStaticValue = string | number | boolean | null | DecodedStaticValue[] | { [key: string]: DecodedStaticValue }
+
+const LITERAL_TYPES = new Set(['Literal', 'StringLiteral', 'NumericLiteral', 'BooleanLiteral', 'NullLiteral'])
+
+/**
+ * Safe recursive AST-value decoder. Turns a statically-analyzable expression
+ * into the JS value it evaluates to, without ever evaluating source text:
+ *
+ * - string/number/boolean/`null` literals
+ * - unary `-`/`+` on a numeric literal (`-1`, `+1.5`)
+ * - template literals with zero expressions
+ * - arrays of supported values (source order preserved)
+ * - plain object literals with static identifier/string keys (source order preserved)
+ *
+ * Everything else (spreads, computed keys, getters/setters/methods, unsafe
+ * prototype keys, identifiers, calls, member expressions, regexp/bigint
+ * literals, array holes) returns the `DECODE_BAIL` sentinel; it never throws.
+ */
+function decodeStaticValue(node: any): DecodedStaticValue | typeof DECODE_BAIL {
+  if (!node)
+    return DECODE_BAIL
+  if (LITERAL_TYPES.has(node.type)) {
+    // regexp literals carry a `regex` payload (their `value` may be a RegExp
+    // or null), bigint literals a `bigint` payload; neither is supported
+    if (node.regex !== undefined || node.bigint !== undefined)
+      return DECODE_BAIL
+    const value = node.value
+    if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean')
+      return value
+    return DECODE_BAIL
   }
-  return out
+  if (node.type === 'UnaryExpression') {
+    // only numeric negation/plus on a plain numeric literal (`-1`, `+1.5`)
+    const arg = node.argument
+    if ((node.operator !== '-' && node.operator !== '+')
+      || !arg
+      || !LITERAL_TYPES.has(arg.type)
+      || arg.regex !== undefined
+      || arg.bigint !== undefined
+      || typeof arg.value !== 'number') {
+      return DECODE_BAIL
+    }
+    return node.operator === '-' ? -arg.value : arg.value
+  }
+  if (node.type === 'TemplateLiteral') {
+    if (node.expressions.length > 0)
+      return DECODE_BAIL
+    const cooked = node.quasis[0]?.value?.cooked
+    return typeof cooked === 'string' ? cooked : DECODE_BAIL
+  }
+  if (node.type === 'ArrayExpression') {
+    const out: DecodedStaticValue[] = []
+    for (const element of node.elements) {
+      // reject holes (`[1, , 2]`) and spreads
+      if (!element || element.type === 'SpreadElement')
+        return DECODE_BAIL
+      const value = decodeStaticValue(element)
+      if (value === DECODE_BAIL)
+        return DECODE_BAIL
+      out.push(value)
+    }
+    return out
+  }
+  if (node.type === 'ObjectExpression') {
+    const out: Record<string, DecodedStaticValue> = Object.create(null)
+    for (const prop of node.properties) {
+      if (prop.type === 'SpreadElement' || prop.computed || prop.method || prop.kind !== 'init')
+        return DECODE_BAIL
+      const key = getStaticPropertyKey(prop)
+      if (!key || isUnsafeObjectKey(key))
+        return DECODE_BAIL
+      const value = decodeStaticValue(prop.value)
+      if (value === DECODE_BAIL)
+        return DECODE_BAIL
+      out[key] = value
+    }
+    return out
+  }
+  return DECODE_BAIL
+}
+
+/**
+ * Mirrors runtime `String(value)` for decoded values, used to replicate
+ * `sanitizeObject` (which drops entries whose value stringifies to 'false').
+ * Decoded objects are built with a null prototype so `String()` can't be
+ * called on them directly; at runtime a plain object stringifies to
+ * '[object Object]', arrays join with ',' and null elements become ''.
+ */
+function runtimeString(value: DecodedStaticValue): string {
+  if (Array.isArray(value))
+    return value.map(v => v === null ? '' : runtimeString(v)).join(',')
+  if (value !== null && typeof value === 'object')
+    return '[object Object]'
+  return String(value)
+}
+
+/**
+ * Lower a nested plain-object meta value (`robots: { maxSnippet: -1 }`) to the
+ * exact content string runtime `unpackMeta` would produce, or `false` when the
+ * value must be left to runtime.
+ */
+function lowerPackedMetaObject(node: any, key: string): string | false {
+  // Arrayable meta keys (themeColor, author, googleSiteVerification, ...)
+  // route through runtime `handleObjectEntry`, which expands the object into
+  // sibling tags rather than packing it into one content string.
+  if (MetaTagsArrayable.has(resolveMetaKeyValue(key) as any))
+    return false
+  const decoded = decodeStaticValue(node)
+  if (decoded === DECODE_BAIL)
+    return false
+  // Runtime `unpackMeta` passes object values through `sanitizeObject` before
+  // packing: top-level entries whose value stringifies to 'false' are dropped.
+  const sanitized: Record<string, DecodedStaticValue> = Object.create(null)
+  for (const k of Object.keys(decoded as Record<string, DecodedStaticValue>)) {
+    const v = (decoded as Record<string, DecodedStaticValue>)[k]
+    if (runtimeString(v) !== 'false')
+      sanitized[k] = v
+  }
+  try {
+    return JSON.stringify(resolvePackedMetaObjectValue(sanitized, key))
+  }
+  catch {
+    return false
+  }
+}
+
+/**
+ * Whether the unsupported tail of a `useSeoMeta` call may be split into a
+ * residual runtime call adjacent to the lowered `useHead` entry. Splitting
+ * creates a second head entry, so it is only allowed when rendering is
+ * provably identical to the original single entry:
+ *
+ * - the call result is unused (two statements are emitted in its place)
+ * - no options argument (it would have to be evaluated twice)
+ * - something is actually lowered, otherwise the call is left untouched;
+ *   `useServerSeoMeta` additionally requires at least one lowered meta prop
+ *   so an empty `useServerHead({})` entry is never emitted
+ * - `title`/`titleTemplate` are hoisted into the lowered entry regardless of
+ *   source position, so they must not appear after the failure point
+ * - residual props are plain `key: value` identifiers whose resolved meta
+ *   names are disjoint from the lowered props' names; a shared name would
+ *   dedupe across the two entries and could reorder rendered tags
+ * - runtime `unpackMeta` renders structural expansions (`extras`) before
+ *   scalar/packed props, per CALL. When meta props were lowered, a residual
+ *   prop that could produce extras at runtime (a dynamic media value, an
+ *   array, an arrayable-key object) would render before the lowered props in
+ *   the original but after them in the split output. So either nothing was
+ *   lowered into `meta` (`failedAt === 0`), or every residual prop must be
+ *   provably primitives-routed: a plain object literal on a non-media,
+ *   non-arrayable key
+ */
+function canEmitResidual(node: any, parent: any, originalName: string, title: any, titleTemplate: any, meta: any[], failedAt: number): boolean {
+  if (parent?.type !== 'ExpressionStatement' || node.arguments.length >= 2)
+    return false
+  if (failedAt === 0 && (originalName === 'useServerSeoMeta' || (!title && !titleTemplate)))
+    return false
+  const residual = meta.slice(failedAt)
+  const residualStart = residual[0].start
+  if ((title && title.start > residualStart) || (titleTemplate && titleTemplate.start > residualStart))
+    return false
+  for (const p of residual) {
+    if (p.type !== 'Property' || p.computed || p.key?.type !== 'Identifier' || !p.value)
+      return false
+    if (failedAt > 0 && (
+      p.value.type !== 'ObjectExpression'
+      || MEDIA_KEYS.has(p.key.name)
+      || MetaTagsArrayable.has(resolveMetaKeyValue(p.key.name) as any)
+    )) {
+      return false
+    }
+  }
+  const loweredNames = new Set(meta.slice(0, failedAt).map((p: any) => resolveMetaKeyValue(p.key.name)))
+  return residual.every((p: any) => !loweredNames.has(resolveMetaKeyValue(p.key.name)))
 }

--- a/packages/bundler/test/seoMetaRuntimeEquivalence.test.ts
+++ b/packages/bundler/test/seoMetaRuntimeEquivalence.test.ts
@@ -1,0 +1,418 @@
+import { useHead as coreUseHead, useSeoMeta as coreUseSeoMeta } from 'unhead'
+import { createHead } from 'unhead/server'
+import { describe, expect, it } from 'vitest'
+import { UseSeoMetaTransform } from '../src/unplugin/UseSeoMetaTransform'
+
+/**
+ * Runtime-vs-compiled equivalence suite.
+ *
+ * Every fixture is rendered twice through the real unhead server runtime:
+ * once from the ORIGINAL `useSeoMeta()` call and once from the TRANSFORMED
+ * output of the seoMeta lowering. The rendered head tags must be identical,
+ * proving the static lowering (including packed nested objects, sanitize
+ * semantics and residual per-prop fallbacks) matches runtime `unpackMeta`.
+ *
+ * The same corpus doubles as an eligibility report: a minimum fully-lowered
+ * count is asserted so a future bundle-size "win" can't come from silently
+ * narrowing the supported input space.
+ */
+
+async function transform(code: string | string[], id = 'some-id.js'): Promise<string | undefined> {
+  const plugin = UseSeoMetaTransform.vite({}) as any
+  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
+  const res = await handler.call({}, Array.isArray(code) ? code.join('\n') : code, id)
+  return res?.code
+}
+
+const IMPORT_LINE_RE = /^import\s.*$/gm
+const SEO_META_CALL_RE = /\buse(?:Server)?SeoMeta\s*\(/
+
+/** Evaluates the module body against the real unhead runtime and renders it. */
+function render(code: string): string {
+  const head = createHead({ disableDefaults: true })
+  const body = code.replace(IMPORT_LINE_RE, '')
+  const bindings: Record<string, (input: any, options?: any) => any> = {
+    useHead: (input, options) => coreUseHead(head, input, options),
+    useServerHead: (input, options) => coreUseHead(head, input, options),
+    useSeoMeta: (input, options) => coreUseSeoMeta(head, input, options),
+    useServerSeoMeta: (input, options) => coreUseSeoMeta(head, input, options),
+  }
+  // eslint-disable-next-line no-new-func
+  new Function(...Object.keys(bindings), body)(...Object.values(bindings))
+  return head.render().headTags
+}
+
+type Eligibility = 'full' | 'partial' | 'bail'
+
+interface Fixture {
+  name: string
+  expected: Eligibility
+  code: string[]
+}
+
+const corpus: Fixture[] = [
+  // -- flat -------------------------------------------------------------
+  {
+    name: 'flat strings',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ title: \'T\', description: \'D\' })',
+    ],
+  },
+  {
+    name: 'flat og and twitter keys',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ ogTitle: \'T\', ogDescription: \'D\', ogSiteName: \'Site\', twitterCard: \'summary_large_image\' })',
+    ],
+  },
+  {
+    name: 'charset',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ charset: \'utf-8\' })',
+    ],
+  },
+  {
+    name: 'title and titleTemplate',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ title: \'T\', titleTemplate: \'%s | Site\', description: \'D\' })',
+    ],
+  },
+  {
+    name: 'template literal values',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ title: `Hello`, description: `World` })',
+    ],
+  },
+  {
+    name: 'flat http-equiv key',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ contentType: \'text/html; charset=utf-8\' })',
+    ],
+  },
+  {
+    name: 'dynamic scalar value inlined',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const desc = \'dynamic description\'',
+      'useSeoMeta({ title: \'T\', description: desc })',
+    ],
+  },
+  // -- nested / packed objects ------------------------------------------
+  {
+    name: 'robots booleans',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { noindex: true, nofollow: true } })',
+    ],
+  },
+  {
+    name: 'robots numbers and negative numbers',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { maxSnippet: -1, maxImagePreview: \'large\', maxVideoPreview: 0 } })',
+    ],
+  },
+  {
+    name: 'robots false flags dropped like runtime',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { noindex: false, nofollow: true, maxSnippet: -1 } })',
+    ],
+  },
+  {
+    name: 'robots unary plus',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { maxSnippet: +20 } })',
+    ],
+  },
+  {
+    name: 'robots template literal value',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { unavailableAfter: `2026-01-01` } })',
+    ],
+  },
+  {
+    name: 'robots null value',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { maxSnippet: null, noindex: true } })',
+    ],
+  },
+  {
+    name: 'nested arrays and nested objects',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { all: [\'a\', \'b\'], nested: { level: 2 } } })',
+    ],
+  },
+  {
+    name: 'refresh with numeric seconds',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ refresh: { seconds: 3, url: \'https://example.com\' } })',
+    ],
+  },
+  {
+    name: 'appleItunesApp with numeric app id',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ appleItunesApp: { appId: 123456789, appArgument: \'https://example.com\' } })',
+    ],
+  },
+  {
+    name: 'contentSecurityPolicy',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ contentSecurityPolicy: { defaultSrc: "\'self\'", upgradeInsecureRequests: true } })',
+    ],
+  },
+  // -- media -------------------------------------------------------------
+  {
+    name: 'media object static',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ ogImage: { url: \'/og.png\', width: 800, height: 600 } })',
+    ],
+  },
+  {
+    name: 'media array static',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ twitterImage: [{ url: \'/t.png\', alt: \'hi\' }] })',
+    ],
+  },
+  {
+    name: 'media secureUrl mapping',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ ogImage: { url: \'/og.png\', secureUrl: \'/s.png\' } })',
+    ],
+  },
+  // -- mixed -------------------------------------------------------------
+  {
+    name: 'mixed flat, robots and media',
+    expected: 'full',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ title: \'T\', description: \'D\', robots: { noindex: true, maxSnippet: -1 }, ogImage: { url: \'/og.png\', width: 800 } })',
+    ],
+  },
+  {
+    name: 'useServerSeoMeta static',
+    expected: 'full',
+    code: [
+      'import { useServerSeoMeta } from \'unhead\'',
+      'useServerSeoMeta({ title: \'T\', description: \'D\', robots: { noindex: true } })',
+    ],
+  },
+  // -- partial: residual per-prop fallback --------------------------------
+  {
+    name: 'residual dynamic media tail (issue #769 shape)',
+    expected: 'partial',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = \'/og.png\'',
+      'useSeoMeta({ title: \'T\', ogImage: og })',
+    ],
+  },
+  {
+    name: 'residual dynamic media tail resolving to an object',
+    expected: 'partial',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = { url: \'/og.png\', width: 800 }',
+      'useSeoMeta({ title: \'T\', ogImage: og })',
+    ],
+  },
+  {
+    name: 'residual dynamic nested tail',
+    expected: 'partial',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const flag = true',
+      'useSeoMeta({ description: \'D\', robots: { noindex: flag } })',
+    ],
+  },
+  {
+    name: 'residual multi-prop tail keeps source order',
+    expected: 'partial',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = \'/og.png\'',
+      'const d = \'tail description\'',
+      'useSeoMeta({ title: \'T\', ogImage: og, description: d })',
+    ],
+  },
+  // -- bail: whole call left to runtime -----------------------------------
+  {
+    name: 'bail dynamic first argument',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const meta = { description: \'D\' }',
+      'useSeoMeta(meta)',
+    ],
+  },
+  {
+    name: 'bail spread properties',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const extra = { description: \'D\' }',
+      'useSeoMeta({ title: \'T\', ...extra })',
+    ],
+  },
+  {
+    name: 'bail lowered primitives before a dynamic media tail',
+    // og could resolve to an object at runtime; unpackMeta would render it
+    // BEFORE description in the original call but a residual entry renders
+    // after, so the whole call must stay at runtime.
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = { url: \'/og.png\' }',
+      'useSeoMeta({ description: \'D\', ogImage: og })',
+    ],
+  },
+  {
+    name: 'bail overlapping dedupe names across split',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = \'/b.png\'',
+      'useSeoMeta({ ogImageUrl: \'/a.png\', ogImage: og })',
+    ],
+  },
+  {
+    name: 'bail duplicate key across split boundary',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const flag = true',
+      'useSeoMeta({ description: \'a\', robots: { noindex: flag }, description: \'b\' })',
+    ],
+  },
+  {
+    name: 'bail title after unsupported prop',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const flag = true',
+      'useSeoMeta({ description: \'D\', robots: { noindex: flag }, title: \'T\' })',
+    ],
+  },
+  {
+    name: 'bail options argument with unsupported prop',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = \'/og.png\'',
+      'useSeoMeta({ title: \'T\', ogImage: og }, { tagPriority: 10 })',
+    ],
+  },
+  {
+    name: 'bail computed nested key',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { [\'no\' + \'index\']: true } })',
+    ],
+  },
+  {
+    name: 'bail unsafe prototype nested key',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { constructor: \'polluted\' } })',
+    ],
+  },
+  {
+    name: 'bail regexp nested value',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { pattern: /x/i } })',
+    ],
+  },
+  {
+    name: 'bail bigint nested value',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { maxSnippet: 1n } })',
+    ],
+  },
+  {
+    name: 'bail arrayable meta key object (themeColor)',
+    expected: 'bail',
+    code: [
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ themeColor: { color: \'#fff\', media: \'(prefers-color-scheme: dark)\' } })',
+    ],
+  },
+]
+
+function classify(transformed: string | undefined): Eligibility {
+  if (transformed === undefined)
+    return 'bail'
+  return SEO_META_CALL_RE.test(transformed.replace(IMPORT_LINE_RE, '')) ? 'partial' : 'full'
+}
+
+describe('seoMeta runtime equivalence', () => {
+  for (const fixture of corpus) {
+    it(`${fixture.name} [${fixture.expected}]`, async () => {
+      const code = fixture.code.join('\n')
+      const transformed = await transform(code)
+      expect(classify(transformed)).toBe(fixture.expected)
+      // rendered output must be byte-identical between the original call and
+      // the transformed output (trivially so for whole-call bails)
+      expect(render(transformed ?? code)).toBe(render(code))
+    })
+  }
+
+  it('eligibility summary holds a minimum fully-lowered floor', async () => {
+    const counts: Record<Eligibility, number> = { full: 0, partial: 0, bail: 0 }
+    const rows: string[] = []
+    for (const fixture of corpus) {
+      const result = classify(await transform(fixture.code.join('\n')))
+      counts[result]++
+      rows.push(`  ${result.padEnd(8)}${fixture.name}`)
+    }
+    // eslint-disable-next-line no-console
+    console.log([
+      `[seoMeta lowering eligibility] ${counts.full} fully lowered, ${counts.partial} partially lowered (residual), ${counts.bail} runtime-only of ${corpus.length} fixtures`,
+      ...rows,
+    ].join('\n'))
+    // Floors, not exact counts: a future bundle-size "win" must not come from
+    // silently narrowing the statically-supported input space.
+    expect(counts.full).toBeGreaterThanOrEqual(22)
+    expect(counts.full + counts.partial).toBeGreaterThanOrEqual(25)
+  })
+})

--- a/packages/bundler/test/transformPipeline.test.ts
+++ b/packages/bundler/test/transformPipeline.test.ts
@@ -80,6 +80,21 @@ const fixtures: Record<string, string> = {
     'import { useSeoMeta } from \'unhead\'',
     'useSeoMeta({ ogImage: { url: \'/og.png\', width: 800 }, twitterImage: [{ url: \'/t.png\', alt: \'hi\' }] })',
   ].join('\n'),
+  'seoMeta packed robots object': [
+    'import { useSeoMeta } from \'unhead\'',
+    'useSeoMeta({ title: \'Hello\', robots: { noindex: false, nofollow: true, maxSnippet: -1 } })',
+  ].join('\n'),
+  'seoMeta residual split': [
+    'import { useSeoMeta } from \'unhead\'',
+    'const flag = true',
+    'useSeoMeta({ title: \'Hello\', description: \'World\', robots: { noindex: flag } })',
+  ].join('\n'),
+  'seoMeta server residual split': [
+    'import { useServerSeoMeta } from \'unhead\'',
+    'const flag = true',
+    'useServerSeoMeta({ title: \'Hello\', description: \'World\', robots: { noindex: flag } })',
+    'console.log(\'kept\')',
+  ].join('\n'),
   'seoMeta server variant': [
     'import { useServerSeoMeta } from \'unhead\'',
     'const keep = useServerSeoMeta',

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -258,12 +258,165 @@ describe('useSeoMetaTransform', () => {
     `)
   })
 
-  it('fails gracefully with nested objects', async () => {
+  it('statically packs nested objects with booleans', async () => {
     const code = await transform([
       'import { useSeoMeta } from \'unhead\'',
       'useSeoMeta({ title: \'Hello\', robots: { noindex: true, nofollow: true } })',
     ])
-    expect(code).toBeUndefined()
+    expect(code).toMatchInlineSnapshot(`
+      "import { useHead } from 'unhead'
+      useHead({
+        title: 'Hello',
+        meta: [
+          { name: 'robots', content: "noindex, nofollow" },
+        ]
+      })"
+    `)
+  })
+
+  it('statically packs nested objects with numbers and negative numbers', async () => {
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { maxSnippet: -1, maxImagePreview: \'large\', maxVideoPreview: 0 } })',
+    ])
+    expect(code).toMatchInlineSnapshot(`
+      "import { useHead } from 'unhead'
+      useHead({
+        meta: [
+          { name: 'robots', content: "max-snippet:-1, max-image-preview:large, max-video-preview:0" },
+        ]
+      })"
+    `)
+  })
+
+  it('drops false nested values like runtime sanitizeObject', async () => {
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { noindex: false, nofollow: true, maxSnippet: -1 } })',
+    ])
+    expect(code).toContain('{ name: \'robots\', content: "nofollow, max-snippet:-1" }')
+  })
+
+  it('bails nested objects with identifiers, calls and member expressions', async () => {
+    for (const value of ['flag', 'getFlag()', 'config.noindex']) {
+      expect(await transform([
+        'import { useSeoMeta } from \'unhead\'',
+        `useSeoMeta({ robots: { noindex: ${value} } })`,
+      ])).toBeUndefined()
+    }
+  })
+
+  it('bails nested objects with bigint and regexp values', async () => {
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { maxSnippet: 1n } })',
+    ])).toBeUndefined()
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { pattern: /x/ } })',
+    ])).toBeUndefined()
+  })
+
+  it('bails non-numeric unary values', async () => {
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { noindex: !0 } })',
+    ])).toBeUndefined()
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ robots: { maxSnippet: -\'1\' } })',
+    ])).toBeUndefined()
+  })
+
+  it('bails arrayable meta keys with object values (runtime handleObjectEntry)', async () => {
+    // themeColor objects expand into sibling tags at runtime, not a packed string
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'useSeoMeta({ themeColor: { color: \'#fff\', media: \'dark\' } })',
+    ])).toBeUndefined()
+  })
+
+  it('splits an unsupported tail prop into a residual runtime call', async () => {
+    // robots stays a plain object at runtime (primitives-routed), so it can
+    // trail the lowered entry without reordering rendered tags.
+    const code = await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'const flag = true',
+      'useSeoMeta({ title: \'Hello\', description: \'World\', robots: { noindex: flag } })',
+    ])
+    expect(code).toMatchInlineSnapshot(`
+      "import { useHead, useSeoMeta } from 'unhead'
+      const flag = true
+      useHead({
+        title: 'Hello',
+        meta: [
+          { name: 'description', content: 'World' },
+        ]
+      });
+      useSeoMeta({ robots: { noindex: flag } })"
+    `)
+  })
+
+  it('does not split a dynamic media tail after lowered meta props', async () => {
+    // og could resolve to an object at runtime; unpackMeta renders media
+    // expansions before scalar props, so splitting would reorder tags.
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = \'/og.png\'',
+      'useSeoMeta({ title: \'Hello\', description: \'World\', ogImage: og })',
+    ])).toBeUndefined()
+  })
+
+  it('residual split keeps the aliased callee and its import', async () => {
+    const code = await transform([
+      'import { useSeoMeta as usm } from \'unhead\'',
+      'const og = \'/og.png\'',
+      'usm({ title: \'Hello\', ogImage: og })',
+    ])
+    expect(code).toMatchInlineSnapshot(`
+      "import { useHead, useSeoMeta as usm } from 'unhead'
+      const og = '/og.png'
+      useHead({
+        title: 'Hello',
+      });
+      usm({ ogImage: og })"
+    `)
+  })
+
+  it('does not split when the residual name overlaps a lowered name', async () => {
+    // ogImageUrl and ogImage both resolve to og:image; a cross-entry dedupe
+    // could reorder rendered tags, so the whole call must stay at runtime.
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = \'/og.png\'',
+      'useSeoMeta({ ogImageUrl: \'/a.png\', ogImage: og })',
+    ])).toBeUndefined()
+  })
+
+  it('does not split when title appears after the unsupported prop', async () => {
+    // title is hoisted into the lowered entry regardless of source position;
+    // splitting would move it before the residual props and change last-wins order.
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'const flag = true',
+      'useSeoMeta({ description: \'D\', robots: { noindex: flag }, title: \'T\' })',
+    ])).toBeUndefined()
+  })
+
+  it('does not split when an options argument is present', async () => {
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = \'/og.png\'',
+      'useSeoMeta({ title: \'T\', ogImage: og }, { tagPriority: 10 })',
+    ])).toBeUndefined()
+  })
+
+  it('does not split when the call result is used', async () => {
+    expect(await transform([
+      'import { useSeoMeta } from \'unhead\'',
+      'const og = \'/og.png\'',
+      'const entry = useSeoMeta({ title: \'T\', ogImage: og })',
+    ])).toBeUndefined()
   })
 
   it('statically replaces packed meta objects without evaluating source text', async () => {


### PR DESCRIPTION
Stacks on #831 (`feat/unified-transform-pipeline`).

## What

Broadens the static `useSeoMeta`/`useServerSeoMeta` lowering in the unified transform pipeline and closes the runtime-parity gaps it exposed.

### Safe recursive AST-value decoder

`materializeStaticStringObject`'s string-only value decoder is replaced with `decodeStaticValue`, supporting exactly:

- string/number/boolean/`null` literals
- unary `-`/`+` on numeric literals (`-1`, `+1.5`)
- template literals with zero expressions
- arrays of supported values (source order preserved)
- plain object literals with static identifier/string keys (source order preserved), built with `Object.create(null)`
- nested combinations of the above

Always rejected via a sentinel (never throws): spreads, computed keys, getters/setters/methods (`kind !== 'init'`), `__proto__`/`constructor`/`prototype` keys, identifiers/calls/member expressions, regexp/bigint literals, array holes, anything else. `robots: { maxSnippet: -1, maxImagePreview: 'large', noindex: false }` now lowers instead of forfeiting the whole call.

### Runtime parity fixes (verified against `unpackMeta`)

The equivalence suite (below) exposed places where the *existing* lowering diverged from runtime rendering; these are fixed so compiled output is byte-identical to what runtime produces:

- **`sanitizeObject` semantics**: runtime drops top-level packed-object entries whose value stringifies to `'false'` before packing; the transform now replicates this (`noindex: false` disappears, matching runtime).
- **`[...extras, ...meta]` ordering**: runtime renders structural expansions (media objects/arrays, array values) *before* scalar/packed props regardless of source order. Lowered meta lines are now grouped the same way (previously `{ description, ogImage: {…} }` compiled to source order but rendered media-first at runtime).
- **`url`/`secureUrl`-first** inside static media object expansions (runtime hoists them); array elements hoist only `url`, matching the runtime array branch.
- **Arrayable meta keys** (`themeColor`, `author`, `googleSiteVerification`) with object values now bail to runtime: `unpackMeta` routes them through `handleObjectEntry` (sibling tags), not `resolvePackedMetaObjectValue` (packed string), so the old lowering produced wrong content for them.
- **`http-equiv` emission**: previously emitted `{ http-equiv: … }`, which is invalid JS (any `contentType`/`refresh`/`contentSecurityPolicy` lowering produced unparseable output). Now quoted.

### Per-prop residual fallback (done, tightly guarded)

On a value-level failure (dynamic media value, undecodable nested object), the unsupported tail is now kept on the original composable adjacent to the lowered call:

```js
useSeoMeta({ title: 'T', description: 'D', robots: { noindex: flag } })
// ->
useHead({ title: 'T', meta: [ { name: 'description', content: 'D' } ] });
useSeoMeta({ robots: { noindex: flag } })
```

This creates a second head entry, so it is only emitted when provably render-identical:

- call is a statement (result unused) and has no options argument
- `title`/`titleTemplate` never appear after the failure point (they are hoisted regardless of position; last-wins order would change)
- residual props are plain identifier-keyed `key: value` pairs whose resolved meta names are disjoint from the lowered props' names (a shared name, e.g. `ogImageUrl` + `ogImage` -> `og:image`, would dedupe across entries and reorder tags -> whole-call bail, tested)
- residual props must be provably primitives-routed at runtime (plain object literal on a non-media, non-arrayable key), **unless nothing was lowered into `meta`** (`failedAt === 0`, the issue #769 `{ title, ogImage: ref }` shape). A dynamic media value after lowered scalar props stays a whole-call bail: at runtime it could resolve to an object and render *before* the lowered props (`extras` ordering), which a trailing residual entry cannot reproduce — covered by an explicit bail fixture.

MEDIA_KEYS dynamic-value bail rules are unchanged; the residual mechanism only relocates already-bailing props, it never lowers them.

### Tests

- **Runtime-vs-compiled equivalence corpus** (`seoMetaRuntimeEquivalence.test.ts`): 37 fixtures rendered through the real unhead server runtime twice — once from the original `useSeoMeta` call, once from the transformed output — asserting identical `headTags`, including overlapping-dedupe and ordering cases.
- **Eligibility floor**: the same corpus asserts ≥22 fully lowered and ≥26 full+partial, and prints a per-fixture summary, so a future size "win" can't come from silently narrowing supported input. Current: **22 full / 4 partial (residual) / 11 runtime-only**.
- Differential pipeline fixtures for packed robots and residual splits (client/server/unknown targets).
- 222 bundler tests pass; exports snapshot unchanged; lint clean.

### Bundle evidence

`bench/bundle` static-SEO fixtures rebuilt on base (`096f0de9`) and this branch — byte-identical, the saving holds exactly (the fixture is all flat keys, unaffected by the broadened decoder):

| build | raw | gzip |
|---|---|---|
| baseline (no plugin), base & branch | 19041 B | 7454 B |
| with plugin, base & branch | 14471 B | 5791 B |

Saving: **22.3% gzip** (unchanged). `last.json` untouched.

### Notes

- Runtime does **not** specially validate `__proto__`/`constructor`/`prototype` keys inside packed meta objects — they are only serialized into a content string via `Object.entries` (no object writes), and `normalizeProps` already skips unsafe keys on tag props, so there is no runtime pollution path. The transform rejects them at decode time so it never materializes such objects at build time; no runtime behavior was added.
- Pre-existing divergences left as-is (out of scope, noted for follow-up): dynamic values on packable keys (`robots: someRef`) still inline as `content` and would render `[object Object]` if they resolve to an object at runtime (same class of problem as #769 but for packed keys); the runtime array-branch `secureUrl` colon-casing quirk (`og:image:secure:url`) is not replicated.
- `pnpm typecheck` fails on base with a pre-existing error in `packages/bundler/test/fixtures/vite-build/entry.ts` (unrelated to this change).