### PR TITLE
chore: dedupe async-hook warning per instance

### DIFF
--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -275,6 +275,11 @@ export interface Unhead<Input = ResolvableHead, RenderResult = unknown> {
    * @internal
    */
   _entryCount: number
+  /**
+   * Dedupes the async-hook-listener warning per instance.
+   * @internal
+   */
+  _warnedAsyncHook?: boolean
   // client-specific (optional)
   /**
    * @internal

--- a/packages/unhead/src/utils/hooks.ts
+++ b/packages/unhead/src/utils/hooks.ts
@@ -10,8 +10,6 @@ export function createHooks<T extends CoreHeadHooks>(hooks?: Partial<T>): Hookab
   return instance
 }
 
-let warnedAsyncHook = false
-
 export function callHook(head: Unhead<any, any>, hook: string, ctx: any) {
   const hooks = (head.hooks as any)?._hooks?.[hook]
   if (!hooks?.length)
@@ -19,8 +17,8 @@ export function callHook(head: Unhead<any, any>, hook: string, ctx: any) {
   const res: any = head.hooks?.callHook(hook as any, ctx)
   // this is a synchronous pipeline: a listener returning a thenable is not
   // awaited — later listeners run out of order and the result is dropped
-  if (res?.then && !warnedAsyncHook) {
-    warnedAsyncHook = true
+  if (res?.then && !head._warnedAsyncHook) {
+    head._warnedAsyncHook = true
     console.warn(`[unhead] promise ignored: ${hook}`)
   }
   return res

--- a/packages/unhead/test/unit/hooks/async-listener-warn.test.ts
+++ b/packages/unhead/test/unit/hooks/async-listener-warn.test.ts
@@ -20,4 +20,25 @@ describe('async hook listeners on the sync pipeline', () => {
     expect(warn).toHaveBeenCalledTimes(1)
     warn.mockRestore()
   })
+
+  it('warns per head instance, not per process', () => {
+    // Dedupe state lives on the instance (CONTRIBUTING module-state policy):
+    // a fresh head (e.g. next SSR request) warns again.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const asyncHooks = {
+      'tags:resolve': async () => {
+        await Promise.resolve()
+      },
+    }
+    const first = createHead({ hooks: asyncHooks })
+    first.push({ title: 'first' })
+    renderSSRHead(first)
+
+    const second = createHead({ hooks: asyncHooks })
+    second.push({ title: 'second' })
+    renderSSRHead(second)
+
+    expect(warn).toHaveBeenCalledTimes(2)
+    warn.mockRestore()
+  })
 })


### PR DESCRIPTION
> Stacks on #828 (`perf/ssr-default-init-hoist`); the flag landed there via #833.

### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

#833 introduced a module-scope `let warnedAsyncHook = false` to dedupe the "promise ignored" warning for async listeners on the sync hook pipeline. That flag is import-inert (CI rule 1 passes) but violates the CONTRIBUTING module-state policy: its input originates from user hook behavior at request time, not module constants, and the policy's review test for that case says the state belongs on the head instance.

The flag now lives on the instance as `_warnedAsyncHook` (internal, optional). Practical effects: a fresh head (e.g. the next SSR request on a warm isolate) warns again instead of the whole process going silent after the first offender, and test files can no longer bleed the flag into each other. Regression test added covering the per-instance behavior; `test:import-inert` still passes all 48 entries.