### PR TITLE
feat(scripts): add consumer lifecycle scopes

### DIFF
--- a/docs/head/7.api/composables/4.use-script.md
+++ b/docs/head/7.api/composables/4.use-script.md
@@ -172,6 +172,48 @@ script.onError(() => {
 })
 ```
 
+### Consumer scopes
+
+The script element and resolved API are shared, but component callbacks,
+triggers, and resources should have a shorter lifecycle. A script scope owns
+those registrations without removing the shared script when it is disposed.
+Framework integrations create this scope for each component automatically.
+
+Use `onLoadedEffect()` when loading the API creates a resource. The effect gets
+an abort signal and may return cleanup synchronously or asynchronously:
+
+```ts
+const script = useScript('https://example.com/widget.js', {
+  use: () => window.Widget
+})
+
+script.onLoadedEffect(async (api, { signal }) => {
+  const widget = await api.create({ signal })
+
+  return () => widget.destroy()
+})
+```
+
+Vue, Svelte, Angular, and Solid dispose the scope with their component
+lifecycle. For a manually managed or React lifecycle, create and dispose a
+scope explicitly:
+
+```ts
+const script = useScript('https://example.com/widget.js')
+const scope = script.createScope()
+
+scope.onLoadedEffect(api => {
+  const widget = api.create()
+  return () => widget.destroy()
+})
+
+// Releases this consumer only. The shared script remains loaded.
+scope.dispose()
+```
+
+Calling `remove()` is intentionally different: it removes the shared script and
+disposes every scope attached to it.
+
 ## Resource Hints
 
 The `warmupStrategy` option automatically adds resource hints to optimize loading:
@@ -286,7 +328,11 @@ Returns a script controller object with these properties:
 - `status`: Current lifecycle state
 - `onLoaded`: Register callback for successful load
 - `onError`: Register callback for loading failure
+- `createScope`: Create a manually disposed consumer scope
 - `proxy`: Proxy to the script's API (if `use` option provided)
+
+Scoped return values also provide `signal`, `dispose()`, and
+`onLoadedEffect()` for consumer-owned resources.
 
 ## TypeScript
 

--- a/packages/angular/src/composables.ts
+++ b/packages/angular/src/composables.ts
@@ -1,6 +1,8 @@
-import type { ActiveHeadEntry, EventHandlerOptions, HeadEntryOptions, HeadSafe, Unhead, UseHeadInput, UseScriptInput, UseScriptOptions, UseScriptReturn, UseSeoMetaInput } from 'unhead/types'
+import type { UseScriptScopeReturn } from 'unhead/scripts'
+import type { ActiveHeadEntry, EventHandlerOptions, HeadEntryOptions, HeadSafe, Unhead, UseHeadInput, UseScriptInput, UseScriptOptions, UseSeoMetaInput } from 'unhead/types'
 import { DestroyRef, effect, inject } from '@angular/core'
-import { useHead as baseHead, useHeadSafe as baseHeadSafe, useSeoMeta as baseSeoMeta, useScript as baseUseScript } from 'unhead'
+import { useHead as baseHead, useHeadSafe as baseHeadSafe, useSeoMeta as baseSeoMeta } from 'unhead'
+import { useScriptScope as baseUseScriptScope } from 'unhead/scripts'
 import { UnheadInjectionToken } from './context'
 
 export function useUnhead() {
@@ -35,14 +37,13 @@ export function useSeoMeta(input: UseSeoMetaInput = {}, options: HeadEntryOption
   return withSideEffects<ActiveHeadEntry<UseSeoMetaInput>>(input, options, baseSeoMeta)
 }
 
-export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptReturn<T> {
+export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptScopeReturn<T> {
   const input = (typeof _input === 'string' ? { src: _input } : _input) as UseScriptInput
   const options = _options || {} as UseScriptOptions<T>
   const head = options?.head || useUnhead()
   options.head = head
 
   const mountCbs: (() => void)[] = []
-  const sideEffects: (() => void)[] = []
   let isMounted = false
 
   const destroyRef = inject(DestroyRef)
@@ -61,14 +62,16 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
       else {
         mountCbs.push(load)
       }
+      return () => {
+        const idx = mountCbs.indexOf(load)
+        if (idx !== -1)
+          mountCbs.splice(idx, 1)
+      }
     }
   }
 
   // @ts-expect-error untyped
-  const script = baseUseScript(head, input as BaseUseScriptInput, options)
-  // capture the controller at registration time so destroy aborts the controller
-  // that was active when this component registered, not a newer one
-  const triggerAbortController = script._triggerAbortController
+  const script = baseUseScriptScope(head, input as BaseUseScriptInput, options)
 
   // core's onLoaded/onError register by identity and return an identity-based
   // disposer; we defer registration to mount and tie the disposer to destroy
@@ -81,7 +84,6 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
       if (disposed)
         return
       off = register()
-      sideEffects.push(off)
     }
     if (isMounted)
       run()
@@ -94,19 +96,14 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
       const idx = mountCbs.indexOf(run)
       if (idx !== -1)
         mountCbs.splice(idx, 1)
-      if (off) {
-        const sideEffectIdx = sideEffects.indexOf(off)
-        if (sideEffectIdx !== -1)
-          sideEffects.splice(sideEffectIdx, 1)
-      }
       off?.()
     }
   }
 
   destroyRef.onDestroy(() => {
     isMounted = false
-    triggerAbortController?.abort()
-    sideEffects.forEach(i => i())
+    mountCbs.splice(0)
+    script.dispose()
   })
   script.onLoaded = (cb: (instance: T) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb(() => baseOnLoaded(cb, options))
   script.onError = (cb: (err?: Error) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb(() => baseOnError(cb, options))

--- a/packages/react/src/composables.ts
+++ b/packages/react/src/composables.ts
@@ -26,6 +26,43 @@ interface ScriptCallbackRecord {
   script: UseScriptReturn<any>
 }
 
+interface ScriptFacade {
+  onError: UseScriptReturn<any>['onError']
+  onLoaded: UseScriptReturn<any>['onLoaded']
+  script: UseScriptReturn<any>
+  value: UseScriptReturn<any>
+}
+
+/** Create a local callback facade while preserving the shared enumerable API. */
+function createScriptFacade(script: UseScriptReturn<any>): ScriptFacade {
+  const facade = {
+    onError: script.onError,
+    onLoaded: script.onLoaded,
+    script,
+  } as ScriptFacade
+  facade.value = new Proxy(script, {
+    get(target, key, receiver) {
+      if (key === 'onLoaded' || key === 'onError')
+        return facade[key]
+      return Reflect.get(target, key, receiver)
+    },
+    getOwnPropertyDescriptor(target, key) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(target, key)
+      if (descriptor && (key === 'onLoaded' || key === 'onError'))
+        return { ...descriptor, value: facade[key] }
+      return descriptor
+    },
+    set(target, key, value, receiver) {
+      if (key === 'onLoaded' || key === 'onError') {
+        facade[key] = value
+        return true
+      }
+      return Reflect.set(target, key, value, receiver)
+    },
+  })
+  return facade
+}
+
 export function useUnhead(): Unhead {
   // fallback to react context
   const instance = useContext<Unhead | null>(UnheadContext)
@@ -105,7 +142,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   } as UseScriptOptions<T>
 
   const callbackRecords = useRef<ScriptCallbackRecord[]>([])
-  const scriptFacade = useRef<{ script: UseScriptReturn<any>, value: UseScriptReturn<any> } | null>(null)
+  const scriptFacade = useRef<ScriptFacade | null>(null)
   const isMounted = useRef(false)
   const renderId = useRef(0)
   const committedRenderId = useRef(0)
@@ -113,14 +150,8 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
 
   // @ts-expect-error untyped
   const sharedScript = baseUseScript(head, input as BaseUseScriptInput, resolvedOptions)
-  if (!scriptFacade.current || scriptFacade.current.script !== sharedScript) {
-    scriptFacade.current = {
-      script: sharedScript,
-      // Callback methods below are render-scoped. Keep them off the shared
-      // registry instance so sibling consumers cannot overwrite each other.
-      value: Object.create(sharedScript),
-    }
-  }
+  if (!scriptFacade.current || scriptFacade.current.script !== sharedScript)
+    scriptFacade.current = createScriptFacade(sharedScript)
   const script = scriptFacade.current.value
 
   useEffect(() => {
@@ -212,7 +243,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     }
   }
   // if we have a scope we should make these callbacks reactive
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb('loaded', cb, options)
-  script.onError = (cb: (err?: Error) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb('error', cb, options)
+  scriptFacade.current.onLoaded = (cb: (instance: T) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb('loaded', cb, options)
+  scriptFacade.current.onError = (cb: (err?: Error) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb('error', cb, options)
   return script
 }

--- a/packages/react/src/composables.ts
+++ b/packages/react/src/composables.ts
@@ -1,5 +1,6 @@
 import type {
   ActiveHeadEntry,
+  EventHandlerOptions,
   HeadEntryOptions,
   HeadSafe,
   Unhead,
@@ -17,6 +18,8 @@ interface ScriptCallbackRecord {
   active: boolean
   handler: any
   key: 'loaded' | 'error'
+  off?: () => void
+  options?: EventHandlerOptions
   registered: boolean
   renderScoped: boolean
   renderId: number
@@ -156,25 +159,27 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   function registerScriptCallback(record: ScriptCallbackRecord) {
     if (!record.active || record.registered)
       return
-    const cbs = record.script._cbs[record.key]
-    if (!cbs) {
-      record.handler(record.script.instance)
-      return
+    const off = record.key === 'loaded'
+      ? record.script.onLoaded(record.handler, record.options)
+      : record.script.onError(record.handler, record.options)
+    if (record.active) {
+      record.off = off
+      record.registered = true
     }
-    cbs.push(record.handler)
-    record.registered = true
+    else {
+      off()
+    }
   }
 
   function unregisterScriptCallback(record: ScriptCallbackRecord) {
     if (!record.registered)
       return
-    const idx = record.script._cbs[record.key]?.indexOf(record.handler) ?? -1
-    if (idx !== -1)
-      record.script._cbs[record.key]?.splice(idx, 1)
+    record.off?.()
+    record.off = undefined
     record.registered = false
   }
 
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
+  const _registerCb = (key: 'loaded' | 'error', cb: any, options?: EventHandlerOptions) => {
     const renderScoped = !(isMounted.current && committedRenderId.current === currentRenderId)
     const record: ScriptCallbackRecord = {
       active: true,
@@ -182,14 +187,14 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         if (!record.active)
           return
         record.active = false
-        record.registered = false
         cb(...args)
       },
       key,
+      options,
       registered: false,
       renderScoped,
       renderId: currentRenderId,
-      script,
+      script: sharedScript,
     }
     callbackRecords.current.push(record)
     if (isMounted.current && committedRenderId.current === currentRenderId)
@@ -207,7 +212,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     }
   }
   // if we have a scope we should make these callbacks reactive
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  script.onLoaded = (cb: (instance: T) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb('loaded', cb, options)
+  script.onError = (cb: (err?: Error) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb('error', cb, options)
   return script
 }

--- a/packages/react/src/composables.ts
+++ b/packages/react/src/composables.ts
@@ -218,7 +218,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         if (!record.active)
           return
         record.active = false
-        cb(...args)
+        return cb(...args)
       },
       key,
       options,

--- a/packages/react/src/composables.ts
+++ b/packages/react/src/composables.ts
@@ -102,13 +102,23 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   } as UseScriptOptions<T>
 
   const callbackRecords = useRef<ScriptCallbackRecord[]>([])
+  const scriptFacade = useRef<{ script: UseScriptReturn<any>, value: UseScriptReturn<any> } | null>(null)
   const isMounted = useRef(false)
   const renderId = useRef(0)
   const committedRenderId = useRef(0)
   const currentRenderId = ++renderId.current
 
   // @ts-expect-error untyped
-  const script = baseUseScript(head, input as BaseUseScriptInput, resolvedOptions)
+  const sharedScript = baseUseScript(head, input as BaseUseScriptInput, resolvedOptions)
+  if (!scriptFacade.current || scriptFacade.current.script !== sharedScript) {
+    scriptFacade.current = {
+      script: sharedScript,
+      // Callback methods below are render-scoped. Keep them off the shared
+      // registry instance so sibling consumers cannot overwrite each other.
+      value: Object.create(sharedScript),
+    }
+  }
+  const script = scriptFacade.current.value
 
   useEffect(() => {
     isMounted.current = true

--- a/packages/react/test/useScript.test.tsx
+++ b/packages/react/test/useScript.test.tsx
@@ -253,4 +253,34 @@ describe('react useScript', () => {
     expect(spread.load).toBe(sharedScript.load)
     expect(spread.onLoaded).toBe(facade!.onLoaded)
   })
+
+  it('preserves an async callback result', async () => {
+    const head = createHead()
+    let called = false
+
+    function Page() {
+      const script = useScript('//react-async-callback.js', { trigger: 'manual', head })
+      script.onLoaded(async () => {
+        await Promise.resolve()
+        called = true
+      })
+      return null
+    }
+
+    render(
+      <UnheadProvider head={head}>
+        <Page />
+      </UnheadProvider>,
+    )
+    await act(async () => {
+      await wait()
+    })
+
+    const sharedScript = getScript(head, '//react-async-callback.js')
+    const result = sharedScript._cbs.loaded![0]({})
+
+    expect(result).toBeInstanceOf(Promise)
+    await result
+    expect(called).toBe(true)
+  })
 })

--- a/packages/react/test/useScript.test.tsx
+++ b/packages/react/test/useScript.test.tsx
@@ -226,4 +226,31 @@ describe('react useScript', () => {
 
     expect(calls).toEqual(['first'])
   })
+
+  it('keeps the shared script API enumerable on the local facade', async () => {
+    const head = createHead()
+    let facade: ReturnType<typeof useScript> | undefined
+
+    function Page() {
+      facade = useScript('//react-enumerable.js', { trigger: 'manual', head })
+      return null
+    }
+
+    render(
+      <UnheadProvider head={head}>
+        <Page />
+      </UnheadProvider>,
+    )
+    await act(async () => {
+      await wait()
+    })
+
+    const sharedScript = getScript(head, '//react-enumerable.js')
+    const spread = { ...facade! }
+
+    expect(facade).not.toBe(sharedScript)
+    expect(Object.keys(facade!)).toContain('load')
+    expect(spread.load).toBe(sharedScript.load)
+    expect(spread.onLoaded).toBe(facade!.onLoaded)
+  })
 })

--- a/packages/react/test/useScript.test.tsx
+++ b/packages/react/test/useScript.test.tsx
@@ -195,4 +195,35 @@ describe('react useScript', () => {
 
     expect(initCalls).toBe(1)
   })
+
+  it('forwards keyed callback options to the shared script', async () => {
+    const head = createHead()
+    const calls: string[] = []
+
+    function Page() {
+      const script = useScript('//react-keyed.js', { trigger: 'manual', head })
+      script.onLoaded(() => {
+        calls.push('first')
+      }, { key: 'shared' })
+      script.onLoaded(() => {
+        calls.push('second')
+      }, { key: 'shared' })
+      return null
+    }
+
+    render(
+      <UnheadProvider head={head}>
+        <Page />
+      </UnheadProvider>,
+    )
+    await act(async () => {
+      await wait()
+    })
+
+    const script = getScript(head, '//react-keyed.js')
+    script.load()
+    await flushLoad(head, '//react-keyed.js')
+
+    expect(calls).toEqual(['first'])
+  })
 })

--- a/packages/solid-js/src/composables.ts
+++ b/packages/solid-js/src/composables.ts
@@ -1,17 +1,19 @@
+import type { UseScriptScopeReturn } from 'unhead/scripts'
 import type {
   ActiveHeadEntry,
+  EventHandlerOptions,
   HeadEntryOptions,
   HeadSafe,
   Unhead,
   UseHeadInput,
   UseScriptInput,
   UseScriptOptions,
-  UseScriptReturn,
   UseSeoMetaInput,
 } from 'unhead/types'
 import { createEffect, createSignal, getOwner, onCleanup, onMount, runWithOwner, useContext } from 'solid-js'
 import { isServer } from 'solid-js/web'
-import { useHead as baseHead, useHeadSafe as baseHeadSafe, useSeoMeta as baseSeoMeta, useScript as baseUseScript } from 'unhead'
+import { useHead as baseHead, useHeadSafe as baseHeadSafe, useSeoMeta as baseSeoMeta } from 'unhead'
+import { useScriptScope as baseUseScriptScope } from 'unhead/scripts'
 import { UnheadContext } from './context'
 
 export function useUnhead(): Unhead {
@@ -59,7 +61,7 @@ export function useSeoMeta(input: UseSeoMetaInput = {}, options: HeadEntryOption
   return withSideEffects<ActiveHeadEntry<UseSeoMetaInput>>(input, options, baseSeoMeta)
 }
 
-export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptReturn<T> {
+export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptScopeReturn<T> {
   const input = (typeof _input === 'string' ? { src: _input } : _input) as UseScriptInput
   const options = _options || {} as UseScriptOptions<T>
   const head = options?.head || useUnhead()
@@ -81,33 +83,32 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
       else {
         mountCbs.push(load)
       }
+      return () => {
+        const idx = mountCbs.indexOf(load)
+        if (idx !== -1)
+          mountCbs.splice(idx, 1)
+      }
     }
   }
   // @ts-expect-error untyped
-  const script = baseUseScript(head, input as BaseUseScriptInput, options)
-  // capture the controller at registration time so cleanup aborts the controller
-  // that was active when this owner registered, not a newer one
-  const triggerAbortController = script._triggerAbortController
+  const script = baseUseScriptScope(head, input as BaseUseScriptInput, options)
   // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
-  const sideEffects: (() => void)[] = []
   onCleanup(() => {
     isMounted = false
-    triggerAbortController?.abort()
-    sideEffects.forEach(i => i())
+    mountCbs.splice(0)
+    script.dispose()
   })
   // core's onLoaded/onError register by identity and return an identity-based
   // disposer; we defer registration to mount and tie the disposer to cleanup
-  // core returns an identity-based disposer at runtime although the type says void
-  const baseOnLoaded = script.onLoaded as unknown as (cb: any) => (() => void) | undefined
-  const baseOnError = script.onError as unknown as (cb: any) => (() => void) | undefined
-  const _registerCb = (register: () => (() => void) | undefined) => {
+  const baseOnLoaded = script.onLoaded
+  const baseOnError = script.onError
+  const _registerCb = (register: () => () => void) => {
     let disposed = false
     let off: (() => void) | undefined
     const run = () => {
       if (disposed)
         return
-      off = register() ?? (() => {})
-      sideEffects.push(off)
+      off = register()
     }
     if (isMounted)
       run()
@@ -124,7 +125,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     }
   }
   // if we have a scope we should make these callbacks reactive
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb(() => baseOnLoaded(cb))
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb(() => baseOnError(cb))
+  script.onLoaded = (cb: (instance: T) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb(() => baseOnLoaded(cb, options))
+  script.onError = (cb: (err?: Error) => void | Promise<void>, options?: EventHandlerOptions) => _registerCb(() => baseOnError(cb, options))
   return script
 }

--- a/packages/svelte/src/composables.ts
+++ b/packages/svelte/src/composables.ts
@@ -1,17 +1,17 @@
+import type { UseScriptScopeReturn } from 'unhead/scripts'
 import type {
   ActiveHeadEntry,
-  EventHandlerOptions,
   HeadEntryOptions,
   HeadSafe,
   Unhead,
   UseHeadInput,
   UseScriptInput,
   UseScriptOptions,
-  UseScriptReturn,
   UseSeoMetaInput,
 } from 'unhead/types'
 import { getContext, onDestroy, onMount } from 'svelte'
-import { useHead as baseHead, useHeadSafe as baseHeadSafe, useSeoMeta as baseSeoMeta, useScript as baseUseScript } from 'unhead'
+import { useHead as baseHead, useHeadSafe as baseHeadSafe, useSeoMeta as baseSeoMeta } from 'unhead'
+import { useScriptScope as baseUseScriptScope } from 'unhead/scripts'
 import { UnheadContextKey } from './context'
 
 export function useUnhead(): Unhead {
@@ -45,7 +45,7 @@ export function useSeoMeta(input: UseSeoMetaInput = {}, options: HeadEntryOption
   return withSideEffects(baseSeoMeta(options.head || useUnhead(), input, options))
 }
 
-export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptReturn<T> {
+export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptScopeReturn<T> {
   const input = (typeof _input === 'string' ? { src: _input } : _input) as UseScriptInput
   const options = _options || {} as UseScriptOptions<T>
   const head = options?.head || useUnhead()
@@ -56,33 +56,8 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     options.trigger = onMount
   }
   // @ts-expect-error untyped
-  const script = baseUseScript(head, input as BaseUseScriptInput, options)
-  // capture the controller at registration time so unmount aborts the controller
-  // that was active when this component registered, not a newer one
-  const triggerAbortController = script._triggerAbortController
+  const script = baseUseScriptScope(head, input as BaseUseScriptInput, options)
   // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
-  const sideEffects: (() => void)[] = []
-  // core's onLoaded/onError register by identity and return an identity-based
-  // disposer; we only tie that disposer to the component lifecycle
-  const bind = (base: (cb: any, options?: EventHandlerOptions) => () => void) => (cb: any, options?: EventHandlerOptions) => {
-    const off = base(cb, options)
-    sideEffects.push(off)
-    return () => {
-      const idx = sideEffects.indexOf(off)
-      if (idx !== -1)
-        sideEffects.splice(idx, 1)
-      off()
-    }
-  }
-  const baseOnLoaded = script.onLoaded
-  const baseOnError = script.onError
-  // if we have a scope we should make these callbacks reactive
-  script.onLoaded = bind(baseOnLoaded)
-  script.onError = bind(baseOnError)
-  onDestroy(() => {
-    // stop any trigger promises
-    triggerAbortController?.abort()
-    sideEffects.forEach(i => i())
-  })
+  onDestroy(script.dispose)
   return script
 }

--- a/packages/unhead/src/composables.ts
+++ b/packages/unhead/src/composables.ts
@@ -49,4 +49,4 @@ export function useSeoMeta<T extends Unhead<any>>(unhead: T, input: UseSeoMetaIn
   return entry
 }
 
-export { useScript } from './scripts'
+export { useScript, useScriptScope } from './scripts'

--- a/packages/unhead/src/index.ts
+++ b/packages/unhead/src/index.ts
@@ -1,3 +1,3 @@
-export { useHead, useHeadSafe, useScript, useSeoMeta } from './composables'
+export { useHead, useHeadSafe, useScript, useScriptScope, useSeoMeta } from './composables'
 export { defineLink, defineScript } from './define'
 export { createUnhead } from './unhead'

--- a/packages/unhead/src/scripts/index.ts
+++ b/packages/unhead/src/scripts/index.ts
@@ -1,3 +1,3 @@
 export type * from './types'
-export { useScript } from './useScript'
+export { useScript, useScriptScope } from './useScript'
 export { createSpyProxy } from './utils'

--- a/packages/unhead/src/scripts/scope.ts
+++ b/packages/unhead/src/scripts/scope.ts
@@ -1,0 +1,180 @@
+import type {
+  ScriptInstance,
+  ScriptScope,
+  ScriptScopeCleanup,
+  ScriptScopeEffect,
+  ScriptScopeEffectOptions,
+  UseScriptOptions,
+} from './types'
+
+type BaseScriptApi = Record<symbol | string, any>
+type Disposer = () => void
+
+export function createScriptScope<T extends BaseScriptApi>(script: ScriptInstance<T>): ScriptScope<T> {
+  const controller = new AbortController()
+  const disposers = new Set<Disposer>()
+  let disposed = false
+
+  const track = (dispose: Disposer): Disposer => {
+    let active = true
+    const trackedDispose = () => {
+      if (!active)
+        return
+      active = false
+      disposers.delete(trackedDispose)
+      dispose()
+    }
+    if (disposed)
+      trackedDispose()
+    else
+      disposers.add(trackedDispose)
+    return trackedDispose
+  }
+
+  const dispose = () => {
+    if (disposed)
+      return
+    disposed = true
+    controller.abort()
+    const errors: unknown[] = []
+    for (const off of [...disposers].reverse()) {
+      try {
+        off()
+      }
+      catch (error) {
+        errors.push(error)
+      }
+    }
+    if (errors.length === 1)
+      throw errors[0]
+    if (errors.length > 1)
+      throw new AggregateError(errors, 'Failed to dispose script scope')
+  }
+
+  const onScriptAbort = () => {
+    controller.abort(script.signal.reason)
+    // Script errors abort the shared signal before queued onError callbacks are
+    // emitted. Give those callbacks one turn before releasing registrations.
+    queueMicrotask(() => queueMicrotask(dispose))
+  }
+  if (script.signal.aborted) {
+    onScriptAbort()
+  }
+  else {
+    script.signal.addEventListener('abort', onScriptAbort, { once: true })
+    track(() => script.signal.removeEventListener('abort', onScriptAbort))
+  }
+
+  const scope = Object.create(script) as ScriptScope<T>
+  Object.defineProperties(scope, {
+    script: { value: script, enumerable: true },
+    signal: { value: controller.signal, enumerable: true },
+    disposed: { get: () => disposed, enumerable: true },
+    dispose: { value: dispose, enumerable: true },
+    setupTriggerHandler: {
+      value: (trigger: UseScriptOptions['trigger']) => {
+        if (disposed)
+          return
+        try {
+          track(script._setupTriggerHandler(trigger, false))
+        }
+        catch (error) {
+          dispose()
+          throw error
+        }
+      },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    },
+    onLoaded: {
+      value: (fn: (instance: T) => void | Promise<void>, options?: ScriptScopeEffectOptions) => {
+        if (disposed)
+          return () => {}
+        return track(script.onLoaded(fn, options))
+      },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    },
+    onError: {
+      value: (fn: (err?: Error) => void | Promise<void>, options?: ScriptScopeEffectOptions) => {
+        if (disposed)
+          return () => {}
+        return track(script.onError(fn, options))
+      },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    },
+    onLoadedEffect: {
+      value: (fn: ScriptScopeEffect<T>, options?: ScriptScopeEffectOptions) => {
+        if (disposed || controller.signal.aborted)
+          return () => {}
+        const effectController = new AbortController()
+        let cleanup: ScriptScopeCleanup | undefined
+        let effectDisposed = false
+        const abortEffect = () => effectController.abort(controller.signal.reason)
+        controller.signal.addEventListener('abort', abortEffect, { once: true })
+
+        const handleError = (error: unknown) => {
+          if (options?.onError) {
+            options.onError(error)
+          }
+          else {
+            queueMicrotask(() => {
+              throw error
+            })
+          }
+        }
+        const runCleanup = () => {
+          const currentCleanup = cleanup
+          cleanup = undefined
+          if (!currentCleanup)
+            return
+          try {
+            Promise.resolve(currentCleanup()).catch(handleError)
+          }
+          catch (error) {
+            handleError(error)
+          }
+        }
+        const off = scope.onLoaded(async (instance) => {
+          try {
+            const result = await fn(instance, { signal: effectController.signal })
+            if (typeof result === 'function') {
+              if (effectDisposed) {
+                try {
+                  await result()
+                }
+                catch (error) {
+                  handleError(error)
+                }
+              }
+              else {
+                cleanup = result
+              }
+            }
+          }
+          catch (error) {
+            if (!effectController.signal.aborted)
+              handleError(error)
+          }
+        }, options)
+        return track(() => {
+          if (effectDisposed)
+            return
+          effectDisposed = true
+          controller.signal.removeEventListener('abort', abortEffect)
+          effectController.abort(controller.signal.reason)
+          off()
+          runCleanup()
+        })
+      },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    },
+  })
+  return scope
+}

--- a/packages/unhead/src/scripts/scope.ts
+++ b/packages/unhead/src/scripts/scope.ts
@@ -10,6 +10,20 @@ import type {
 type BaseScriptApi = Record<symbol | string, any>
 type Disposer = () => void
 
+/** Report cleanup failures without interrupting framework teardown. */
+function reportScopeError(error: unknown) {
+  const reportError = (globalThis as typeof globalThis & { reportError?: (error: unknown) => void }).reportError
+  if (reportError) {
+    reportError(error)
+  }
+  else {
+    queueMicrotask(() => {
+      throw error
+    })
+  }
+}
+
+/** Create an independently disposable consumer view of a shared script. */
 export function createScriptScope<T extends BaseScriptApi>(script: ScriptInstance<T>): ScriptScope<T> {
   const controller = new AbortController()
   const disposers = new Set<Disposer>()
@@ -46,9 +60,9 @@ export function createScriptScope<T extends BaseScriptApi>(script: ScriptInstanc
       }
     }
     if (errors.length === 1)
-      throw errors[0]
+      reportScopeError(errors[0])
     if (errors.length > 1)
-      throw new AggregateError(errors, 'Failed to dispose script scope')
+      reportScopeError(new AggregateError(errors, 'Failed to dispose script scope'))
   }
 
   const onScriptAbort = () => {
@@ -122,9 +136,7 @@ export function createScriptScope<T extends BaseScriptApi>(script: ScriptInstanc
             options.onError(error)
           }
           else {
-            queueMicrotask(() => {
-              throw error
-            })
+            reportScopeError(error)
           }
         }
         const runCleanup = () => {

--- a/packages/unhead/src/scripts/types.ts
+++ b/packages/unhead/src/scripts/types.ts
@@ -87,6 +87,39 @@ export interface UseScriptContextOptions {
 
 export type UseScriptTrigger = (load: () => void) => void | (() => void)
 
+export type ScriptScopeCleanup = () => void | PromiseLike<void>
+
+export interface ScriptScopeEffectContext {
+  /**
+   * Aborted when the effect is disposed, its scope is disposed, or the shared
+   * script fails or is removed.
+   */
+  signal: AbortSignal
+}
+
+export interface ScriptScopeEffectOptions extends EventHandlerOptions {
+  /**
+   * Handle errors thrown while setting up or cleaning up the effect.
+   */
+  onError?: (error: unknown) => void
+}
+
+export type ScriptScopeEffect<T extends BaseScriptApi> = (
+  instance: T,
+  context: ScriptScopeEffectContext,
+) => void | ScriptScopeCleanup | PromiseLike<void | ScriptScopeCleanup>
+
+/**
+ * A consumer-owned view of a shared script. Disposing it only releases the
+ * callbacks, triggers, and effects registered through this scope.
+ */
+export interface ScriptScope<T extends BaseScriptApi> extends ScriptInstance<T> {
+  readonly script: ScriptInstance<T>
+  readonly disposed: boolean
+  onLoadedEffect: (fn: ScriptScopeEffect<T>, options?: ScriptScopeEffectOptions) => () => void
+  dispose: () => void
+}
+
 export interface ScriptInstance<T extends BaseScriptApi> {
   proxy: AsVoidFunctions<T>
   instance?: T
@@ -101,6 +134,7 @@ export interface ScriptInstance<T extends BaseScriptApi> {
   warmup: (rel: WarmupStrategy) => ActiveHeadEntry<any>
   remove: () => boolean
   setupTriggerHandler: (trigger: UseScriptOptions['trigger']) => void
+  createScope: () => ScriptScope<T>
   // cbs
   onLoaded: (fn: (instance: T) => void | Promise<void>, options?: EventHandlerOptions) => () => void
   onError: (fn: (err?: Error) => void | Promise<void>, options?: EventHandlerOptions) => () => void
@@ -128,6 +162,10 @@ export interface ScriptInstance<T extends BaseScriptApi> {
    * @internal
    */
   _triggerPromises?: Promise<void>[]
+  /**
+   * @internal
+   */
+  _setupTriggerHandler: (trigger: UseScriptOptions['trigger'], removeOnError?: boolean) => () => void
   /**
    * @internal
    */
@@ -180,3 +218,5 @@ export interface UseScriptOptions<T extends BaseScriptApi = Record<string, any>>
 }
 
 export type UseScriptReturn<T extends Record<symbol | string, any>> = UseScriptContext<UseFunctionType<UseScriptOptions<T>, T>>
+
+export type UseScriptScopeReturn<T extends Record<symbol | string, any>> = ScriptScope<UseFunctionType<UseScriptOptions<T>, T>>

--- a/packages/unhead/src/scripts/types.ts
+++ b/packages/unhead/src/scripts/types.ts
@@ -118,6 +118,11 @@ export interface ScriptScope<T extends BaseScriptApi> extends ScriptInstance<T> 
   readonly disposed: boolean
   onLoadedEffect: (fn: ScriptScopeEffect<T>, options?: ScriptScopeEffectOptions) => () => void
   dispose: () => void
+  /**
+   * Remove the shared script for every consumer. Use `dispose()` to release
+   * only the registrations and resources owned by this scope.
+   */
+  remove: () => boolean
 }
 
 export interface ScriptInstance<T extends BaseScriptApi> {

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -367,14 +367,16 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
         let cleanup: void | (() => void)
         abortController.signal.addEventListener('abort', () => {
           script._triggerAbortControllers?.delete(abortController)
-          cleanup?.()
+          if (typeof cleanup === 'function')
+            cleanup()
           cleanup = undefined
         }, { once: true })
         try {
           cleanup = trigger(script.load)
           // A trigger may call load synchronously before returning its disposer.
           if (abortController.signal.aborted) {
-            cleanup?.()
+            if (typeof cleanup === 'function')
+              cleanup()
             cleanup = undefined
           }
         }

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -35,6 +35,7 @@ export function useScriptScope<T extends Record<symbol | string, any> = Record<s
   return _useScript(head, _input, _options, true) as UseScriptScopeReturn<T>
 }
 
+/** Resolve the shared script and optionally attach a consumer scope. */
 function _useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(head: Unhead<any>, _input: UseScriptInput, _options: UseScriptOptions<T> | undefined, scoped: boolean): UseScriptReturn<T> | UseScriptScopeReturn<T> {
   const input: UseScriptResolvedInput = typeof _input === 'string' ? { src: _input } : _input
   const options = _options || {}

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -11,10 +11,12 @@ import type {
   UseScriptOptions,
   UseScriptResolvedInput,
   UseScriptReturn,
+  UseScriptScopeReturn,
   WarmupStrategy,
 } from './types'
 import { callHook } from '../utils/hooks'
 import { createForwardingProxy, createNoopedRecordingProxy, replayProxyRecordings } from './proxy'
+import { createScriptScope } from './scope'
 import { createScriptWaitFor } from './waitFor'
 
 /**
@@ -23,6 +25,17 @@ import { createScriptWaitFor } from './waitFor'
  * @see https://unhead.unjs.io/usage/composables/use-script
  */
 export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(head: Unhead<any>, _input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptReturn<T> {
+  return _useScript(head, _input, _options, false) as UseScriptReturn<T>
+}
+
+/**
+ * Load a shared third-party script through a consumer-owned lifecycle scope.
+ */
+export function useScriptScope<T extends Record<symbol | string, any> = Record<symbol | string, any>>(head: Unhead<any>, _input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptScopeReturn<T> {
+  return _useScript(head, _input, _options, true) as UseScriptScopeReturn<T>
+}
+
+function _useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(head: Unhead<any>, _input: UseScriptInput, _options: UseScriptOptions<T> | undefined, scoped: boolean): UseScriptReturn<T> | UseScriptScopeReturn<T> {
   const input: UseScriptResolvedInput = typeof _input === 'string' ? { src: _input } : _input
   const options = _options || {}
   const id = input.key || input.src || (typeof input.innerHTML === 'string' ? input.innerHTML : '')
@@ -31,6 +44,11 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     ? scripts[id] as undefined | UseScriptContext<UseFunctionType<UseScriptOptions<T>, T>>
     : undefined
   if (prevScript) {
+    if (scoped) {
+      const scope = prevScript.createScope()
+      scope.setupTriggerHandler(options.trigger)
+      return scope
+    }
     prevScript.setupTriggerHandler(options.trigger)
     return prevScript
   }
@@ -278,17 +296,25 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     onError(cb: (err?: Error) => void | Promise<void>, options?: EventHandlerOptions) {
       return _registerCb('error', cb, options)
     },
+    createScope() {
+      return createScriptScope(script)
+    },
     setupTriggerHandler(trigger: UseScriptOptions['trigger']) {
+      script._setupTriggerHandler(trigger)
+    },
+    _setupTriggerHandler(trigger: UseScriptOptions['trigger'], removeOnError = true) {
+      const noop = () => {}
       if (script.status !== 'awaitingLoad') {
-        return
+        return noop
       }
       if (((typeof trigger === 'undefined' || trigger === 'client') && !head.ssr) || trigger === 'server') {
         script.load()
+        return noop
       }
       else if (trigger instanceof Promise) {
         // promise triggers only work client side
         if (head.ssr) {
-          return
+          return noop
         }
         // each trigger gets its own abort controller so that disposing one scope
         // does not cancel triggers from other scopes
@@ -326,11 +352,12 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
               script._triggerPromises?.splice(idx, 1)
           })
         script._triggerPromises.push(triggerPromise)
+        return () => abortController.abort()
       }
       else if (typeof trigger === 'function') {
         // function triggers only work client side
         if (head.ssr) {
-          return
+          return noop
         }
         const abortController = new AbortController()
         script._triggerAbortControllers = script._triggerAbortControllers || new Set()
@@ -351,10 +378,14 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
           }
         }
         catch (error) {
-          script.remove()
+          abortController.abort()
+          if (removeOnError)
+            script.remove()
           throw error
         }
+        return () => abortController.abort()
       }
+      return noop
     },
     _cbs,
   } as any as UseScriptContext<T>
@@ -375,7 +406,17 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     })
   const hookCtx = { script }
 
-  script.setupTriggerHandler(options.trigger)
+  const result = scoped ? script.createScope() : script
+  try {
+    result.setupTriggerHandler(options.trigger)
+  }
+  catch (error) {
+    // A new scoped script is not in the registry yet, so there is no shared
+    // lifecycle to preserve when its initial trigger registration fails.
+    if (scoped)
+      script.remove()
+    throw error
+  }
   if (options.use) {
     const { proxy, stack } = createNoopedRecordingProxy<T>(head.ssr ? {} as T : initialInstance || {} as T)
     script.proxy = proxy
@@ -393,5 +434,5 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     script.warmup(options.warmupStrategy)
   }
   scripts[id] = script
-  return script
+  return result
 }

--- a/packages/unhead/test/unit/scripts/events.test.ts
+++ b/packages/unhead/test/unit/scripts/events.test.ts
@@ -307,6 +307,19 @@ describe('useScript events', () => {
     expect(instance._triggerAbortControllers?.size).toBe(0)
   })
 
+  it('ignores non-callable function trigger cleanup values', () => {
+    const head = createHead()
+
+    expect(() => useScript(head, '/invalid-function-cleanup.js', {
+      trigger: ((load: () => void) => {
+        load()
+        return Promise.resolve()
+      }) as any,
+    })).not.toThrow()
+
+    expect(head._scripts?.['/invalid-function-cleanup.js']?.status).toBe('loading')
+  })
+
   it('removes partial lifecycle state when a function trigger throws', () => {
     const head = createHead()
     let signal!: AbortSignal

--- a/packages/unhead/test/unit/scripts/scope.test.ts
+++ b/packages/unhead/test/unit/scripts/scope.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest'
+// @vitest-environment jsdom
+import { createHead } from '../../../src/client'
+import { useScript, useScriptScope } from '../../../src/scripts'
+
+describe('script scope', () => {
+  it('keeps the shared script while owning callbacks and triggers per consumer', async () => {
+    const head = createHead()
+    const cleanupA = vi.fn()
+    const cleanupB = vi.fn()
+    const loadedA = vi.fn()
+    const loadedB = vi.fn()
+
+    const scopeA = useScriptScope(head, '/shared.js', {
+      trigger: () => cleanupA,
+    })
+    const scopeB = useScriptScope(head, '/shared.js', {
+      trigger: () => cleanupB,
+    })
+    scopeA.onLoaded(loadedA)
+    scopeB.onLoaded(loadedB)
+
+    expect(scopeA).not.toBe(scopeB)
+    expect(scopeA.script).toBe(scopeB.script)
+    expect(head._scripts?.['/shared.js']).toBe(scopeA.script)
+
+    scopeA.dispose()
+
+    expect(scopeA.signal.aborted).toBe(true)
+    expect(scopeB.signal.aborted).toBe(false)
+    expect(scopeA.script.signal.aborted).toBe(false)
+    expect(cleanupA).toHaveBeenCalledOnce()
+    expect(cleanupB).not.toHaveBeenCalled()
+
+    scopeB.load()
+    head.hooks.callHook('script:updated', { script: { id: scopeB.id, status: 'loaded' } as any })
+    await scopeB.script._loadPromise
+
+    expect(loadedA).not.toHaveBeenCalled()
+    expect(loadedB).toHaveBeenCalledOnce()
+    expect(cleanupB).toHaveBeenCalledOnce()
+  })
+
+  it('disposes all scopes when the shared script is removed', async () => {
+    const head = createHead()
+    const script = useScript(head, '/shared.js', { trigger: 'manual' })
+    const scopeA = script.createScope()
+    const scopeB = script.createScope()
+
+    script.remove()
+    await script._loadPromise
+    await Promise.resolve()
+
+    expect(scopeA.disposed).toBe(true)
+    expect(scopeB.disposed).toBe(true)
+    expect(scopeA.signal.aborted).toBe(true)
+    expect(scopeB.signal.aborted).toBe(true)
+  })
+
+  it('emits scoped errors before releasing an aborted script scope', async () => {
+    const head = createHead()
+    const scope = useScriptScope(head, '/failed.js', { trigger: 'manual' })
+    const onError = vi.fn()
+    scope.onError(onError)
+
+    scope.load()
+    const errorEvent = new Event('error')
+    const entry = (scope.script as any).input
+    entry.onerror?.(errorEvent)
+    await scope.script._loadPromise
+    await Promise.resolve()
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(scope.disposed).toBe(true)
+  })
+
+  it('runs effect cleanup once when its scope is disposed', async () => {
+    const head = createHead()
+    const script = useScript(head, '/effect.js', { trigger: 'manual' })
+    const scope = script.createScope()
+    const cleanup = vi.fn()
+    let effectSignal!: AbortSignal
+
+    scope.onLoadedEffect((_api, { signal }) => {
+      effectSignal = signal
+      return cleanup
+    })
+
+    script.load()
+    head.hooks.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    await script._loadPromise
+    await Promise.resolve()
+
+    scope.dispose()
+    scope.dispose()
+
+    expect(effectSignal.aborted).toBe(true)
+    expect(cleanup).toHaveBeenCalledOnce()
+  })
+
+  it('adopts late async effect cleanup after disposal', async () => {
+    const head = createHead()
+    const script = useScript(head, '/async-effect.js', { trigger: 'manual' })
+    const scope = script.createScope()
+    const cleanup = vi.fn()
+    const started = Promise.withResolvers<void>()
+    const setup = Promise.withResolvers<() => void>()
+
+    scope.onLoadedEffect(async (_api, { signal }) => {
+      started.resolve()
+      expect(signal.aborted).toBe(false)
+      return setup.promise
+    })
+
+    script.load()
+    head.hooks.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    await started.promise
+
+    scope.dispose()
+    setup.resolve(cleanup)
+    await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce())
+  })
+
+  it('treats abort rejection as expected effect cancellation', async () => {
+    const head = createHead()
+    const script = useScript(head, '/cancelled-effect.js', { trigger: 'manual' })
+    const scope = script.createScope()
+    const started = Promise.withResolvers<void>()
+    const onError = vi.fn()
+
+    scope.onLoadedEffect((_api, { signal }) => new Promise<void>((_resolve, reject) => {
+      started.resolve()
+      signal.addEventListener('abort', () => reject(new Error('cancelled')), { once: true })
+    }), { onError })
+
+    script.load()
+    head.hooks.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    await started.promise
+    scope.dispose()
+    await Promise.resolve()
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('does not replay callbacks registered after disposal', async () => {
+    const head = createHead()
+    const script = useScript(head, '/loaded.js', { trigger: 'manual' })
+    const scope = script.createScope()
+
+    script.load()
+    head.hooks.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    await script._loadPromise
+    scope.dispose()
+
+    const loaded = vi.fn()
+    const off = scope.onLoaded(loaded)
+
+    expect(off).toBeTypeOf('function')
+    expect(loaded).not.toHaveBeenCalled()
+  })
+
+  it('does not remove a shared script when one scope trigger throws', () => {
+    const head = createHead()
+    const script = useScript(head, '/shared-trigger.js', { trigger: 'manual' })
+
+    expect(() => useScriptScope(head, '/shared-trigger.js', {
+      trigger: () => {
+        throw new Error('scope trigger failed')
+      },
+    })).toThrow('scope trigger failed')
+
+    expect(head._scripts?.['/shared-trigger.js']).toBe(script)
+    expect(script.signal.aborted).toBe(false)
+    expect(script.status).toBe('awaitingLoad')
+    expect(script._triggerAbortControllers?.size).toBe(0)
+  })
+})

--- a/packages/unhead/test/unit/scripts/scope.test.ts
+++ b/packages/unhead/test/unit/scripts/scope.test.ts
@@ -98,6 +98,34 @@ describe('script scope', () => {
     expect(cleanup).toHaveBeenCalledOnce()
   })
 
+  it('reports disposer errors without throwing from teardown', () => {
+    const head = createHead()
+    const script = useScript(head, '/cleanup-error.js', { trigger: 'manual' })
+    const scope = script.createScope()
+    const error = new Error('cleanup failed')
+    const reportError = vi.fn()
+    const errorGlobal = globalThis as unknown as { reportError?: (error: unknown) => void }
+    const originalReportError = errorGlobal.reportError
+    const hadOwnReportError = Object.hasOwn(globalThis, 'reportError')
+    errorGlobal.reportError = reportError
+
+    try {
+      script._setupTriggerHandler = () => () => {
+        throw error
+      }
+      scope.setupTriggerHandler('manual')
+
+      expect(() => scope.dispose()).not.toThrow()
+      expect(reportError).toHaveBeenCalledWith(error)
+    }
+    finally {
+      if (hadOwnReportError)
+        errorGlobal.reportError = originalReportError
+      else
+        delete errorGlobal.reportError
+    }
+  })
+
   it('adopts late async effect cleanup after disposal', async () => {
     const head = createHead()
     const script = useScript(head, '/async-effect.js', { trigger: 'manual' })

--- a/packages/vue/src/scripts/useScript.ts
+++ b/packages/vue/src/scripts/useScript.ts
@@ -90,7 +90,11 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   return new Proxy(script, {
     get(_, key, a) {
       // we can't override status as it will break the unhead useScript API
-      return Reflect.get(_, key === 'status' ? '_statusRef' : key, a)
+      if (key === 'status') {
+        // @ts-expect-error internal shared status ref
+        return script.script._statusRef
+      }
+      return Reflect.get(_, key, a)
     },
   }) as any as UseScriptReturn<T>
 }

--- a/packages/vue/src/scripts/useScript.ts
+++ b/packages/vue/src/scripts/useScript.ts
@@ -1,19 +1,19 @@
-import type { UseScriptOptions as BaseUseScriptOptions, EventHandlerOptions, ScriptInstance, UseFunctionType, UseScriptStatus } from 'unhead/scripts'
+import type { UseScriptOptions as BaseUseScriptOptions, ScriptScope, UseFunctionType, UseScriptStatus } from 'unhead/scripts'
 import type {
   DataKeys,
   GenericScript,
   HeadEntryOptions,
   SchemaAugmentations,
 } from 'unhead/types'
-import type { ComponentInternalInstance, Ref, WatchHandle } from 'vue'
+import type { Ref, WatchHandle } from 'vue'
 import type { ResolvableProperties, VueHeadClient } from '../types'
-import { useScript as _useScript } from 'unhead/scripts'
+import { useScriptScope as _useScriptScope } from 'unhead/scripts'
 import { getCurrentInstance, isRef, onMounted, onScopeDispose, ref, watch } from 'vue'
 import { injectHead } from '../install'
 
 export type * from 'unhead/scripts'
 
-export interface VueScriptInstance<T extends Record<symbol | string, any>> extends Omit<ScriptInstance<T>, 'status'> {
+export interface VueScriptInstance<T extends Record<symbol | string, any>> extends Omit<ScriptScope<T>, 'status'> {
   status: Ref<UseScriptStatus>
 }
 
@@ -37,31 +37,6 @@ export interface UseScriptOptions<T extends Record<symbol | string, any> = Recor
 }
 
 export type UseScriptContext<T extends Record<symbol | string, any>> = VueScriptInstance<T>
-
-function registerVueScopeHandlers<T extends Record<symbol | string, any> = Record<symbol | string, any>>(script: UseScriptContext<UseFunctionType<UseScriptOptions<T>, T>>, scope?: ComponentInternalInstance | null) {
-  if (!scope) {
-    return
-  }
-  // core's onLoaded/onError already register the callback by identity and return
-  // an identity-based disposer; we only tie that disposer to the Vue scope so the
-  // callback is removed when the owning component unmounts
-  const bind = (base: (cb: any, options?: EventHandlerOptions) => () => void) => (cb: any, options?: EventHandlerOptions) => {
-    const off = base(cb, options)
-    onScopeDispose(off)
-    return off
-  }
-  const baseOnLoaded = script.onLoaded
-  const baseOnError = script.onError
-  // if we have a scope we should make these callbacks reactive
-  script.onLoaded = bind(baseOnLoaded)
-  script.onError = bind(baseOnError)
-  // capture the controller at registration time so this scope only aborts
-  // the controller it was associated with, not a newer one created by a later scope
-  const triggerAbortController = script._triggerAbortController
-  onScopeDispose(() => {
-    triggerAbortController?.abort()
-  })
-}
 
 export type UseScriptReturn<T extends Record<symbol | string, any>> = UseScriptContext<UseFunctionType<UseScriptOptions<T>, T>>
 
@@ -106,12 +81,12 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     }
   })
   // @ts-expect-error untyped
-  const script = _useScript(head, input as BaseUseScriptInput, options)
+  const script = _useScriptScope(head, input as BaseUseScriptInput, options)
   // @ts-expect-error untyped
-  script._statusRef = script._statusRef || ref<UseScriptStatus>(script.status)
+  script.script._statusRef = script.script._statusRef || ref<UseScriptStatus>(script.status)
   // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
-  // @ts-expect-error untyped
-  registerVueScopeHandlers(script, scope)
+  if (scope)
+    onScopeDispose(script.dispose)
   return new Proxy(script, {
     get(_, key, a) {
       // we can't override status as it will break the unhead useScript API


### PR DESCRIPTION
Stacked on #840. Review commits `ddceaaf3`, `a4cebaa5`, `83e23c63`, and `0e689d31`.

## Summary

- add `script.createScope()` and `useScriptScope()` while keeping the cached `ScriptInstance` global
- scope callback registrations, triggers, abort signals, and resource cleanup to each consumer
- add `onLoadedEffect()` with abort-aware async setup and automatic cleanup adoption
- migrate Vue, Svelte, Angular, and Solid away from mutating the shared script instance
- isolate React render-scoped callbacks on an enumerable local facade and forward keyed registrations through core

## Why

Framework adapters were rebuilding the same lifecycle ownership with callback wrappers, disposer arrays, private trigger-controller access, and shared method mutation. A consumer scope makes that ownership explicit without removing or reloading the shared script when a component unmounts.

`remove()` keeps its global meaning. `scope.dispose()` only releases work owned by that consumer.

## Validation

- `pnpm test` — 203 files passed, 1,637 tests passed, 8 skipped
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:bundle-size`
- `pnpm test:vue-bundle-size`
- `pnpm test:react-bundle-size`
- final targeted React and core suites — 33 tests passed
- edited documentation passes markdownlint and case-police

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added script scopes for consumer-specific lifecycle management while sharing the underlying script.
  * Added `createScope`, `dispose`, `remove`, and `onLoadedEffect` APIs.
  * Added public `useScriptScope` support across framework integrations.
  * Scoped callbacks, signals, triggers, and cleanup now operate independently.

* **Documentation**
  * Expanded API guidance on consumer scopes, resource cleanup, and shared script removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->