### PR TITLE
fix(schema-org): export missing node types

### DIFF
--- a/packages/schema-org/src/index.ts
+++ b/packages/schema-org/src/index.ts
@@ -2,6 +2,13 @@ export { createSchemaOrgGraph, defineSchemaOrgResolver, merge, resolveMeta, reso
 export type { ResolverOptions, SchemaOrgGraph } from './core'
 export { schemaAutoImports } from './imports'
 export * from './nodes'
+export type { DefinedRegion } from './nodes/DefinedRegion'
+export type { MerchantReturnPolicy, MerchantReturnPolicySimple } from './nodes/MerchantReturnPolicy'
+export type { MonetaryAmount, MonetaryAmountSimple, QuantitativeSimple, QuantitativeValue } from './nodes/MonetaryAmount'
+export type { OfferShippingDetails } from './nodes/OfferShippingDetails'
+export type { Place, PlaceSimple } from './nodes/Place'
+export type { ShippingDeliveryTime } from './nodes/ShippingDeliveryTime'
+export type { VirtualLocation, VirtualLocationSimple } from './nodes/VirtualLocation'
 export { UnheadSchemaOrg } from './plugin'
 export type { PluginSchemaOrgOptions } from './plugin'
 export {

--- a/packages/schema-org/test/public-types.test.ts
+++ b/packages/schema-org/test/public-types.test.ts
@@ -1,4 +1,19 @@
-import type { ResolverOptions } from '../src'
+import type {
+  DefinedRegion,
+  MerchantReturnPolicy,
+  MerchantReturnPolicySimple,
+  MonetaryAmount,
+  MonetaryAmountSimple,
+  OfferShippingDetails,
+  Place,
+  PlaceSimple,
+  QuantitativeSimple,
+  QuantitativeValue,
+  ResolverOptions,
+  ShippingDeliveryTime,
+  VirtualLocation,
+  VirtualLocationSimple,
+} from '../src'
 import { expectTypeOf, it } from 'vitest'
 
 it('exports schema resolver options from the package entry', () => {
@@ -6,4 +21,15 @@ it('exports schema resolver options from the package entry', () => {
   expectTypeOf<ResolverOptions>().toHaveProperty('root')
   expectTypeOf<ResolverOptions>().toHaveProperty('generateId')
   expectTypeOf<ResolverOptions>().toHaveProperty('afterResolve')
+})
+
+it('exports schema node types used by public helpers', () => {
+  expectTypeOf<DefinedRegion>().toHaveProperty('addressCountry')
+  expectTypeOf<MerchantReturnPolicy>().toEqualTypeOf<MerchantReturnPolicySimple>()
+  expectTypeOf<MonetaryAmount>().toEqualTypeOf<MonetaryAmountSimple>()
+  expectTypeOf<QuantitativeValue>().toEqualTypeOf<QuantitativeSimple>()
+  expectTypeOf<OfferShippingDetails>().toHaveProperty('shippingDestination')
+  expectTypeOf<Place>().toEqualTypeOf<PlaceSimple>()
+  expectTypeOf<ShippingDeliveryTime>().toHaveProperty('transitTime')
+  expectTypeOf<VirtualLocation>().toEqualTypeOf<VirtualLocationSimple>()
 })


### PR DESCRIPTION
### 🔗 Linked issue

Related to #822

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`definePlace()` and `defineVirtualLocation()` are public, and schema inputs already reference shipping and returns types, but those types could not be imported from `@unhead/schema-org`. This exports the existing location and commerce node types from the package entry and covers each export with public type tests. It only adds type exports; runtime code and existing consumer types are unchanged.