### PR TITLE
fix(react): export provider prop types

### DIFF
--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -15,7 +15,12 @@ export function createHead(options: CreateClientHeadOptions = {}): ClientUnhead 
   return head
 }
 
-export function UnheadProvider({ children, head }: { children: ReactNode, head?: Unhead<any, any> }) {
+export interface UnheadProviderProps {
+  children: ReactNode
+  head?: Unhead<any, any>
+}
+
+export function UnheadProvider({ children, head }: UnheadProviderProps) {
   const headRef = useRef<Unhead<any, any> | null>(null)
   if (!head && !headRef.current)
     headRef.current = createHead()

--- a/packages/react/src/server.ts
+++ b/packages/react/src/server.ts
@@ -5,7 +5,12 @@ import { UnheadContext } from './context'
 
 export { createHead, type PreparedTemplate, prepareTemplate, renderSSRHead, transformHtmlTemplate } from 'unhead/server'
 
-export function UnheadProvider({ children, value }: { children: ReactNode, value: Unhead }) {
+export interface UnheadProviderProps {
+  children: ReactNode
+  value: Unhead
+}
+
+export function UnheadProvider({ children, value }: UnheadProviderProps) {
   return createElement(UnheadContext.Provider, { value }, children)
 }
 

--- a/packages/react/src/stream/client.ts
+++ b/packages/react/src/stream/client.ts
@@ -3,7 +3,12 @@ import type { Unhead } from 'unhead/types'
 import { createElement } from 'react'
 import { UnheadContext } from '../context'
 
-export function UnheadProvider({ value, children }: { value: Unhead, children: ReactNode }): ReactNode {
+export interface UnheadProviderProps {
+  children: ReactNode
+  value: Unhead
+}
+
+export function UnheadProvider({ value, children }: UnheadProviderProps): ReactNode {
   return createElement(UnheadContext.Provider, { value }, children)
 }
 

--- a/packages/react/src/stream/server.ts
+++ b/packages/react/src/stream/server.ts
@@ -11,7 +11,12 @@ import {
 } from 'unhead/stream/server'
 import { UnheadContext } from '../context'
 
-export function UnheadProvider({ value, children }: { value: Unhead, children: ReactNode }): ReactNode {
+export interface UnheadProviderProps {
+  children: ReactNode
+  value: Unhead
+}
+
+export function UnheadProvider({ value, children }: UnheadProviderProps): ReactNode {
   return createElement(UnheadContext.Provider, { value }, children)
 }
 

--- a/packages/react/test/public-types.test.ts
+++ b/packages/react/test/public-types.test.ts
@@ -1,7 +1,18 @@
 import type { ComponentProps } from 'react'
 import type { Head, HeadProps } from '../src'
+import type { UnheadProvider as ClientUnheadProvider, UnheadProviderProps as ClientUnheadProviderProps } from '../src/client'
+import type { UnheadProvider as ServerUnheadProvider, UnheadProviderProps as ServerUnheadProviderProps } from '../src/server'
+import type { UnheadProvider as StreamClientUnheadProvider, UnheadProviderProps as StreamClientUnheadProviderProps } from '../src/stream/client'
+import type { UnheadProvider as StreamServerUnheadProvider, UnheadProviderProps as StreamServerUnheadProviderProps } from '../src/stream/server'
 import { expectTypeOf, it } from 'vitest'
 
 it('exports the Head component props', () => {
   expectTypeOf<ComponentProps<typeof Head>>().toEqualTypeOf<HeadProps>()
+})
+
+it('exports provider props from each React entry', () => {
+  expectTypeOf<ComponentProps<typeof ClientUnheadProvider>>().toEqualTypeOf<ClientUnheadProviderProps>()
+  expectTypeOf<ComponentProps<typeof ServerUnheadProvider>>().toEqualTypeOf<ServerUnheadProviderProps>()
+  expectTypeOf<ComponentProps<typeof StreamClientUnheadProvider>>().toEqualTypeOf<StreamClientUnheadProviderProps>()
+  expectTypeOf<ComponentProps<typeof StreamServerUnheadProvider>>().toEqualTypeOf<StreamServerUnheadProviderProps>()
 })


### PR DESCRIPTION
### 🔗 Linked issue

Related to #822

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`UnheadProvider` exposes anonymous prop objects from the React client, server, and streaming entry points, so wrappers cannot import a stable props type. This exports `UnheadProviderProps` from each entry while keeping the current prop shapes unchanged, with package-entry type tests covering all four.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved React provider type exports for clearer, reusable TypeScript integration.
* **Tests**
  * Added type-level validation across client, server, and streaming provider entry points.
  * Confirmed exported provider prop types match the components’ inferred props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->