### PR TITLE
fix(types): preserve define helper properties

### DIFF
--- a/packages/unhead/src/define.ts
+++ b/packages/unhead/src/define.ts
@@ -1,9 +1,11 @@
 import type { InferLink, InferScript, Link, Script } from './types'
 
 type IsUnion<T, U = T> = T extends U ? ([U] extends [T] ? false : true) : never
-type DefinedLink<T extends { rel: string }> = IsUnion<T['rel']> extends false
-  ? T extends Link ? T : Link & Omit<T, 'rel'>
-  : Link & Omit<T, 'rel'>
+type DefinedLink<T extends { rel: string }> = T extends { rel: infer U }
+  ? IsUnion<U> extends false
+    ? T extends Link ? T : Link & Omit<T, 'rel'>
+    : Link & Omit<T, 'rel'>
+  : never
 type DefinedScript<T extends object> = T extends { type: infer U }
   ? IsUnion<U> extends false
     ? T extends Script ? T : Script & Omit<T, 'type'>

--- a/packages/unhead/src/define.ts
+++ b/packages/unhead/src/define.ts
@@ -1,5 +1,15 @@
 import type { InferLink, InferScript, Link, Script } from './types'
 
+type IsUnion<T, U = T> = T extends U ? ([U] extends [T] ? false : true) : never
+type DefinedLink<T extends { rel: string }> = IsUnion<T['rel']> extends false
+  ? T extends Link ? T : Link & Omit<T, 'rel'>
+  : Link & Omit<T, 'rel'>
+type DefinedScript<T extends object> = T extends { type: infer U }
+  ? IsUnion<U> extends false
+    ? T extends Script ? T : Script & Omit<T, 'type'>
+    : Script & Omit<T, 'type'>
+  : T extends Script ? T : Script & Omit<T, 'type'>
+
 /**
  * Typed helper for declaring a `<link>` element inside {@link useHead}.
  *
@@ -25,8 +35,8 @@ import type { InferLink, InferScript, Link, Script } from './types'
  * })
  * ```
  */
-export function defineLink<const T extends { rel: string }>(link: T & InferLink<T>): Link {
-  return link as unknown as Link
+export function defineLink<const T extends { rel: string }>(link: T & InferLink<T>): DefinedLink<T> {
+  return link as unknown as DefinedLink<T>
 }
 
 /**
@@ -48,6 +58,6 @@ export function defineLink<const T extends { rel: string }>(link: T & InferLink<
  * })
  * ```
  */
-export function defineScript<const T extends object>(script: T & InferScript<T>): Script {
-  return script as unknown as Script
+export function defineScript<const T extends object>(script: T & InferScript<T>): DefinedScript<T> {
+  return script as unknown as DefinedScript<T>
 }

--- a/packages/unhead/test/unit/types.test.ts
+++ b/packages/unhead/test/unit/types.test.ts
@@ -21,6 +21,12 @@ describe('types', () => {
     expectTypeOf(preload.rel).toEqualTypeOf<'preload'>()
     expectTypeOf(preload.href).toEqualTypeOf<'/entry.js'>()
 
+    const linkUnion = defineLink(Math.random() > 0.5
+      ? { rel: 'preload', as: 'script', href: '/entry.js' }
+      : { rel: 'prefetch', href: '/next.js' })
+    if (linkUnion.rel === 'preload')
+      expectTypeOf(linkUnion.as).toEqualTypeOf<'script'>()
+
     const customLink = defineLink({
       'rel': 'openid2.provider',
       'href': 'https://example.com/openid',

--- a/packages/unhead/test/unit/types.test.ts
+++ b/packages/unhead/test/unit/types.test.ts
@@ -1,4 +1,4 @@
-import type { HeadEntry, HeadEntryOptions, PreloadLink, SerializableHead } from '../../src/types'
+import type { HeadEntry, HeadEntryOptions, Link, PreloadLink, Script, SerializableHead } from '../../src/types'
 import type { MetaKeyType, ResolveTagsOptions } from '../../src/utils'
 import { expectTypeOf } from 'vitest'
 import { useHead, useHeadSafe, useSeoMeta } from '../../src/composables'
@@ -11,6 +11,38 @@ describe('types', () => {
     expectTypeOf<ResolveTagsOptions>().toHaveProperty('tagWeight')
     expectTypeOf<NonNullable<HeadEntry<unknown>['options']>>()
       .toEqualTypeOf<Omit<HeadEntryOptions, 'head' | 'onRendered'>>()
+  })
+  it('preserves properties validated by define helpers', () => {
+    const preload = defineLink({
+      rel: 'preload',
+      as: 'script',
+      href: '/entry.js',
+    })
+    expectTypeOf(preload.rel).toEqualTypeOf<'preload'>()
+    expectTypeOf(preload.href).toEqualTypeOf<'/entry.js'>()
+
+    const customLink = defineLink({
+      'rel': 'openid2.provider',
+      'href': 'https://example.com/openid',
+      'data-provider': 'openid',
+    })
+    expectTypeOf(customLink['data-provider']).toEqualTypeOf<'openid'>()
+    customLink satisfies Link
+
+    const module = defineScript({
+      type: 'module',
+      src: '/entry.js',
+    })
+    expectTypeOf(module.type).toEqualTypeOf<'module'>()
+    expectTypeOf(module.src).toEqualTypeOf<'/entry.js'>()
+
+    const customScript = defineScript({
+      'type': 'text/plain',
+      'textContent': 'debug-token',
+      'data-purpose': 'debug',
+    })
+    expectTypeOf(customScript['data-purpose']).toEqualTypeOf<'debug'>()
+    customScript satisfies Script
   })
   it('types useHead', () => {
     const unhead = createHead()


### PR DESCRIPTION
### 🔗 Linked issue

Related to #822

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`defineLink()` and `defineScript()` validate precise inputs but currently return the broad `Link` and `Script` unions, erasing literal and custom properties. This preserves validated properties for single known variants and custom inputs while keeping union discriminants and existing `Link`/`Script` assignability unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type validation for link and script helpers.
  - Preserved stricter, context-specific property requirements while supporting custom values.
  - Enhanced type inference so returned configurations retain validated literal types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->