### PR TITLE
chore(ci): stabilize allocation benchmarks

### DIFF
--- a/bench/bundle/perf-report.test.ts
+++ b/bench/bundle/perf-report.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { renderPerfReport } from './perf-report'
+
+describe('renderPerfReport allocation noise gate', () => {
+  it('keeps allocation changes within the combined RME out of the verdict', () => {
+    const report = renderPerfReport(
+      {
+        benches: [
+          { id: 'alloc', name: 'Allocated / render', kind: 'alloc', value: 100_000, rme: 4 },
+        ],
+      },
+      {
+        benches: [
+          { id: 'alloc', name: 'Allocated / render', kind: 'alloc', value: 112_000, rme: 4 },
+        ],
+      },
+    )
+
+    expect(report).toContain('No significant change')
+    expect(report).toContain('~ noise')
+    expect(report).not.toContain('slower')
+  })
+
+  it('reports allocation changes that exceed the absolute and RME gates', () => {
+    const report = renderPerfReport(
+      {
+        benches: [
+          { id: 'alloc', name: 'Allocated / render', kind: 'alloc', value: 100_000, rme: 1 },
+        ],
+      },
+      {
+        benches: [
+          { id: 'alloc', name: 'Allocated / render', kind: 'alloc', value: 110_000, rme: 1 },
+        ],
+      },
+    )
+
+    expect(report).toContain('1 slower')
+    expect(report).toContain('+9.8 KiB (+10.0%)')
+  })
+})

--- a/bench/bundle/perf-report.ts
+++ b/bench/bundle/perf-report.ts
@@ -70,7 +70,8 @@ function classify(pr: PerfBench, base?: PerfBench): Row {
     significant = Math.abs(delta) > COUNT_FLOOR_UNITS && (base.value === 0 || Math.abs(deltaPct) > COUNT_FLOOR_PCT)
   }
   else {
-    significant = Math.abs(delta) > ALLOC_FLOOR_BYTES && (base.value === 0 || Math.abs(deltaPct) > ALLOC_FLOOR_PCT)
+    const threshold = Math.max(ALLOC_FLOOR_PCT, 2 * ((base.rme || 0) + (pr.rme || 0)))
+    significant = Math.abs(delta) > ALLOC_FLOOR_BYTES && (base.value === 0 || Math.abs(deltaPct) > threshold)
   }
   if (!significant)
     return { bench: pr, base, status: 'same', deltaPct }

--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -179,6 +179,10 @@ function sampledBytes(profile) {
   return bytes
 }
 
+// Fine-grained sampling catches small per-render deltas. Five short repetitions
+// keep the extra profiler work bounded in the bundle-size job.
+const ALLOCATION_SAMPLING_INTERVAL = 64
+
 // A heapUsed batch delta silently resets whenever V8 scavenges the young
 // generation. Profile total allocations instead, across several independent
 // samples so the report can gate on the profiler's measured variance.
@@ -190,8 +194,9 @@ async function measureAlloc(fn, { warmup = 50, reps = 5, runs = 200 } = {}) {
     const session = new Session()
     session.connect()
     try {
+      await session.post('HeapProfiler.enable')
       await session.post('HeapProfiler.startSampling', {
-        samplingInterval: 64,
+        samplingInterval: ALLOCATION_SAMPLING_INTERVAL,
         includeObjectsCollectedByMajorGC: true,
         includeObjectsCollectedByMinorGC: true,
       })
@@ -234,8 +239,9 @@ async function measureAllocAsync(fn, { warmup = 20, reps = 5, runs = 50 } = {}) 
     const session = new Session()
     session.connect()
     try {
+      await session.post('HeapProfiler.enable')
       await session.post('HeapProfiler.startSampling', {
-        samplingInterval: 64,
+        samplingInterval: ALLOCATION_SAMPLING_INTERVAL,
         includeObjectsCollectedByMajorGC: true,
         includeObjectsCollectedByMinorGC: true,
       })

--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -6,6 +6,7 @@
 //    that noisy timing hides; needs --expose-gc)
 // It imports built dist on purpose (measures shipped output), hence the .mjs +
 // eslint ignore. Output is a single JSON line; keep stdout clean.
+import { Session } from 'node:inspector/promises'
 import { pathToFileURL } from 'node:url'
 
 // resolve built dist from the repo root (cwd) so this harness can run from anywhere
@@ -167,21 +168,42 @@ function measureTimes(fn, { warmup = 50, reps = 40, runs = 250 } = {}) {
   return { wall: stats(wall), cpu: stats(cpu) }
 }
 
-// bytes allocated per render. The batch (`runs`) stays under new-space so no scavenge
-// fires mid-batch, making heapUsed delta == bytes allocated. Allocation is near
-// deterministic, so the median across reps has tiny variance — marginal wins (which
-// noisy wall-time hides) show up here.
-function measureAlloc(fn, { warmup = 50, reps = 25, runs = 60 } = {}) {
+function sampledBytes(profile) {
+  let bytes = 0
+  const visit = (node) => {
+    bytes += node.selfSize || 0
+    for (const child of node.children || [])
+      visit(child)
+  }
+  visit(profile.head)
+  return bytes
+}
+
+// A heapUsed batch delta silently resets whenever V8 scavenges the young
+// generation. Profile total allocations instead, across several independent
+// samples so the report can gate on the profiler's measured variance.
+async function measureAlloc(fn, { warmup = 50, reps = 5, runs = 200 } = {}) {
   for (let i = 0; i < warmup; i++) fn()
   const samples = []
-  for (let r = 0; r < reps; r++) {
+  for (let i = 0; i < reps; i++) {
     forceGC()
-    const before = process.memoryUsage().heapUsed
-    for (let i = 0; i < runs; i++) fn()
-    samples.push((process.memoryUsage().heapUsed - before) / runs)
+    const session = new Session()
+    session.connect()
+    try {
+      await session.post('HeapProfiler.startSampling', {
+        samplingInterval: 64,
+        includeObjectsCollectedByMajorGC: true,
+        includeObjectsCollectedByMinorGC: true,
+      })
+      for (let j = 0; j < runs; j++) fn()
+      const { profile } = await session.post('HeapProfiler.stopSampling')
+      samples.push(sampledBytes(profile) / runs)
+    }
+    finally {
+      session.disconnect()
+    }
   }
-  samples.sort((a, b) => a - b)
-  return { value: samples[samples.length >> 1] }
+  return stats(samples)
 }
 
 // async twins of measureTimes/measureAlloc for the streaming benches, which must be
@@ -204,17 +226,28 @@ async function measureTimesAsync(fn, { warmup = 20, reps = 25, runs = 40 } = {})
   return { wall: stats(wall), cpu: stats(cpu) }
 }
 
-async function measureAllocAsync(fn, { warmup = 20, reps = 15, runs = 25 } = {}) {
+async function measureAllocAsync(fn, { warmup = 20, reps = 5, runs = 50 } = {}) {
   for (let i = 0; i < warmup; i++) await fn()
   const samples = []
-  for (let r = 0; r < reps; r++) {
+  for (let i = 0; i < reps; i++) {
     forceGC()
-    const before = process.memoryUsage().heapUsed
-    for (let i = 0; i < runs; i++) await fn()
-    samples.push((process.memoryUsage().heapUsed - before) / runs)
+    const session = new Session()
+    session.connect()
+    try {
+      await session.post('HeapProfiler.startSampling', {
+        samplingInterval: 64,
+        includeObjectsCollectedByMajorGC: true,
+        includeObjectsCollectedByMinorGC: true,
+      })
+      for (let j = 0; j < runs; j++) await fn()
+      const { profile } = await session.post('HeapProfiler.stopSampling')
+      samples.push(sampledBytes(profile) / runs)
+    }
+    finally {
+      session.disconnect()
+    }
   }
-  samples.sort((a, b) => a - b)
-  return { value: samples[samples.length >> 1] }
+  return stats(samples)
 }
 
 // Streaming SSR: an end-to-end wrapStream drain (shell + 50 app chunks + closing
@@ -278,14 +311,14 @@ async function streamingBenches() {
   const wrapTimes = await measureTimesAsync(drainWrappedStream, { warmup: 50, reps: 30, runs: 100 })
   const wrapAlloc = await measureAllocAsync(drainWrappedStream)
   const chunkTimes = measureTimes(renderSuspenseChunk, { reps: 30, runs: 120 })
-  const chunkAlloc = measureAlloc(renderSuspenseChunk, { reps: 20, runs: 40 })
+  const chunkAlloc = await measureAlloc(renderSuspenseChunk)
 
   return [
     { id: 'stream-wrap-cpu', name: 'Streaming wrapStream drain (CPU)', kind: 'time', value: wrapTimes.cpu.value, rme: wrapTimes.cpu.rme },
     { id: 'stream-wrap-wall', name: 'Streaming wrapStream drain (wall)', kind: 'time', value: wrapTimes.wall.value, rme: wrapTimes.wall.rme, informational: true },
-    { id: 'stream-wrap-alloc', name: 'Streaming allocated / drain', kind: 'alloc', value: wrapAlloc.value, informational: true },
+    { id: 'stream-wrap-alloc', name: 'Streaming allocated / drain', kind: 'alloc', value: wrapAlloc.value, rme: wrapAlloc.rme, informational: true },
     { id: 'stream-chunk-cpu', name: 'Streaming suspense chunk (CPU)', kind: 'time', value: chunkTimes.cpu.value, rme: chunkTimes.cpu.rme },
-    { id: 'stream-chunk-alloc', name: 'Streaming allocated / suspense chunk', kind: 'alloc', value: chunkAlloc.value },
+    { id: 'stream-chunk-alloc', name: 'Streaming allocated / suspense chunk', kind: 'alloc', value: chunkAlloc.value, rme: chunkAlloc.rme },
   ]
 }
 
@@ -351,19 +384,19 @@ async function csrBenches() {
 }
 
 const times = measureTimes(renderMediumSsrHead)
-const alloc = measureAlloc(renderMediumSsrHead)
+const alloc = await measureAlloc(renderMediumSsrHead)
 const renderCachedSchemaOrgHead = createCachedSchemaOrgRenderer()
 const schemaOrgTimes = measureTimes(renderCachedSchemaOrgHead, { reps: 30, runs: 120 })
-const schemaOrgAlloc = measureAlloc(renderCachedSchemaOrgHead, { reps: 20, runs: 40 })
+const schemaOrgAlloc = await measureAlloc(renderCachedSchemaOrgHead)
 
 const result = {
   benches: [
     { id: 'ssr-medium-cpu', name: 'SSR render (CPU)', kind: 'time', value: times.cpu.value, rme: times.cpu.rme },
     { id: 'ssr-medium-wall', name: 'SSR render (wall)', kind: 'time', value: times.wall.value, rme: times.wall.rme, informational: true },
-    { id: 'ssr-medium-alloc', name: 'SSR allocated / render', kind: 'alloc', value: alloc.value },
+    { id: 'ssr-medium-alloc', name: 'SSR allocated / render', kind: 'alloc', value: alloc.value, rme: alloc.rme },
     { id: 'schema-org-cached-cpu', name: 'Schema.org cached render (CPU)', kind: 'time', value: schemaOrgTimes.cpu.value, rme: schemaOrgTimes.cpu.rme },
     { id: 'schema-org-cached-wall', name: 'Schema.org cached render (wall)', kind: 'time', value: schemaOrgTimes.wall.value, rme: schemaOrgTimes.wall.rme, informational: true },
-    { id: 'schema-org-cached-alloc', name: 'Schema.org cached allocated / render', kind: 'alloc', value: schemaOrgAlloc.value },
+    { id: 'schema-org-cached-alloc', name: 'Schema.org cached allocated / render', kind: 'alloc', value: schemaOrgAlloc.value, rme: schemaOrgAlloc.rme },
     ...await streamingBenches(),
     ...await csrBenches(),
   ],


### PR DESCRIPTION
### 🔗 Linked issue

Related to #822

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The bundle-size workflow measured allocations from `process.memoryUsage().heapUsed`, which can reset when V8 scavenges during a batch and produce misleading deltas. The harness now uses V8's sampling heap profiler for synchronous and streaming benchmarks, reports allocation RME, and applies the same variance gate used by timing metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance reports so small allocation changes caused by measurement noise are no longer incorrectly labeled as slower.
  * Allocation comparisons now account for expected measurement variability, producing more reliable results.

* **Performance**
  * Updated allocation tracking for synchronous, asynchronous, and streaming benchmarks to provide more consistent measurements.
  * Reports now include variability information for allocation metrics, making significant performance changes easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->