### PR TITLE
fix(unhead): dispatch tag:normalise hook

### DIFF
--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -24,7 +24,9 @@ function isEmptyProps(props: Record<string, any>): boolean {
 const TAG_MUTATING_HOOK_RE = /^tags:|:render/
 
 function syncEntryHookCache(head: Unhead<any>, hooks: Record<string, any>) {
-  const count = (hooks['entries:resolve']?.length || 0) + (hooks['entries:normalize']?.length || 0)
+  const count = (hooks['entries:resolve']?.length || 0)
+    + (hooks['entries:normalize']?.length || 0)
+    + (hooks['tag:normalise']?.length || 0)
   if (head._h !== count) {
     head._h = count
     for (const entry of head.entries.values())
@@ -185,7 +187,7 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
   // entries:resolve array is also part of that hook's contract: listeners
   // may mutate it (push/splice) to change which entries resolve.
   let entries: HeadEntry<any>[] | undefined
-  if (hooks['entries:resolve']?.length || hooks['entries:normalize']?.length) {
+  if (hooks['entries:resolve']?.length || hooks['entries:normalize']?.length || hooks['tag:normalise']?.length) {
     entries = [...head.entries.values()]
     if (hooks['entries:resolve']?.length)
       callHook(head, 'entries:resolve', { entries, ...ctx })
@@ -207,6 +209,7 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
         && weightFn === head.resolvedOptions._tagWeight
         && !hooks['entries:normalize']?.length
         && !hooks['entries:resolve']?.length
+        && !hooks['tag:normalise']?.length
         && (!e.options || isEmptyProps(e.options))) {
         tags = e._precomputedTags
       }
@@ -223,7 +226,12 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
           tags = normalizeCtx.tags
         }
         for (let i = 0; i < tags.length; i++) {
-          const t = tags[i]
+          let t = tags[i]
+          if (hooks['tag:normalise']?.length) {
+            const tagCtx = { tag: t, entry: e, resolvedOptions: head.resolvedOptions }
+            callHook(head, 'tag:normalise', tagCtx)
+            t = tags[i] = tagCtx.tag
+          }
           t._w = weightFn(t)
           t._p = (e._i << 10) + i
           t._d = dedupeKey(t)

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -25,8 +25,8 @@ const TAG_MUTATING_HOOK_RE = /^tags:|:render/
 
 function syncEntryHookCache(head: Unhead<any>, hooks: Record<string, any>) {
   const count = (hooks['entries:resolve']?.length || 0)
-    + (hooks['entries:normalize']?.length || 0)
-    + (hooks['tag:normalise']?.length || 0)
+    + ((hooks['entries:normalize']?.length || 0) << 10)
+    + ((hooks['tag:normalise']?.length || 0) << 20)
   if (head._h !== count) {
     head._h = count
     for (const entry of head.entries.values())

--- a/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
+++ b/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
@@ -29,9 +29,11 @@ describe('tag-mutating hooks', () => {
 
   it('invalidates cached tags when tag:normalise is registered', async () => {
     const head = createHead({ disableDefaults: true })
+    const removeNormalizeHook = head.hooks.hook('entries:normalize', () => {})
     head.push({ meta: [{ name: 'description', content: 'before-hook' }] })
     await head.render()
 
+    removeNormalizeHook()
     head.hooks.hook('tag:normalise', ({ tag }) => {
       tag.props.content = 'after-hook'
     })

--- a/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
+++ b/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
@@ -2,6 +2,62 @@ import { describe, expect, it } from 'vitest'
 import { createHead, renderSSRHead } from '../../../src/server'
 
 describe('tag-mutating hooks', () => {
+  it('runs tag:normalise before tag weighting and deduplication', async () => {
+    const calls: string[] = []
+    const head = createHead({
+      disableDefaults: true,
+      tagWeight: (tag) => {
+        calls.push(`weight:${tag.props.content}`)
+        return 100
+      },
+      hooks: {
+        'tag:normalise': ({ tag, entry, resolvedOptions }) => {
+          calls.push(`normalise:${tag.props.content}`)
+          expect(entry.input).toMatchObject({ meta: [{ name: 'description' }] })
+          expect(resolvedOptions._tagWeight).toBeTypeOf('function')
+          tag.props.content = 'after-hook'
+        },
+      },
+    })
+    head.push({ meta: [{ name: 'description', content: 'before-hook' }] })
+
+    const result = await head.render()
+
+    expect(calls).toEqual(['normalise:before-hook', 'weight:after-hook'])
+    expect(result.headTags).toContain('content="after-hook"')
+  })
+
+  it('invalidates cached tags when tag:normalise is registered', async () => {
+    const head = createHead({ disableDefaults: true })
+    head.push({ meta: [{ name: 'description', content: 'before-hook' }] })
+    await head.render()
+
+    head.hooks.hook('tag:normalise', ({ tag }) => {
+      tag.props.content = 'after-hook'
+    })
+
+    const result = await head.render()
+    expect(result.headTags).toContain('content="after-hook"')
+  })
+
+  it('normalises precomputed default tags', async () => {
+    const seen: string[] = []
+    const head = createHead({
+      hooks: {
+        'tag:normalise': ({ tag }) => {
+          seen.push(tag.tag)
+          if (tag.tag === 'htmlAttrs')
+            tag.props.lang = 'fr'
+        },
+      },
+    })
+
+    const result = await head.render()
+
+    expect(seen).toEqual(['htmlAttrs', 'meta', 'meta'])
+    expect(result.htmlAttrs).toContain('lang="fr"')
+  })
+
   it('hook mutations do not leak into the entry cache across renders', async () => {
     let render = 0
     const head = createHead({


### PR DESCRIPTION
### 🔗 Linked issue

Related to #822

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`tag:normalise` is part of the public hook API, but `resolveTags()` never dispatched it. Dispatch the hook before weights and dedupe keys are calculated, then invalidate cached and precomputed tags when hook registrations change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `tag:normalise` handling so it runs before tag weighting and deduplication.
  * Mutations from `tag:normalise` now reliably update rendered `headTags`, including after the hook is registered post-render and for default/precomputed tags.
  * Tag resolution now better invalidates and recomputes cached tag results when normalisation hooks are present.
* **Tests**
  * Added unit coverage for `tag:normalise` ordering, cache invalidation on late registration, and mutation of default-derived tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->