### PR TITLE
fix(vue): expose v2 legacy plugins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release v2
 
 permissions:
   contents: write
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     tags:
-      - 'v*'
+      - 'v2.*'
 
 jobs:
   release:
@@ -26,6 +26,11 @@ jobs:
           node-version: latest
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify release version
+        run: |
+          PACKAGE_VERSION=$(node -p "JSON.parse(require('node:fs').readFileSync('package.json', 'utf8')).version")
+          test "$GITHUB_REF_NAME" = "v$PACKAGE_VERSION"
 
       - name: Force Set pnpm Registry
         run: pnpm config set registry https://registry.npmjs.org

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v2
   pull_request:
     branches:
       - main
+      - v2
 
 jobs:
   test:

--- a/packages/vue/src/legacy.ts
+++ b/packages/vue/src/legacy.ts
@@ -1,4 +1,4 @@
-import type { ActiveHeadEntry, CreateClientHeadOptions, HeadEntryOptions } from 'unhead/types'
+import type { ActiveHeadEntry, CreateClientHeadOptions, HeadEntryOptions, HeadPluginInput } from 'unhead/types'
 import type {
   Ref,
 } from 'vue'
@@ -40,17 +40,17 @@ export function CapoPlugin() {
   })
 }
 
+/**
+ * The v2 compatibility plugins applied by the legacy `createHead` and
+ * `createServerHead` entrypoints.
+ */
+export const legacyPlugins: HeadPluginInput[] = [DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin, AliasSortingPlugin]
+
 export function createHead(options: CreateClientHeadOptions = {}): VueHeadClient {
   return createVueHead({
     disableCapoSorting: true,
     ...options,
-    plugins: [
-      DeprecationsPlugin,
-      PromisesPlugin,
-      TemplateParamsPlugin,
-      AliasSortingPlugin,
-      ...(options.plugins || []),
-    ],
+    plugins: [...legacyPlugins, ...(options.plugins || [])],
   }) as VueHeadClient
 }
 
@@ -58,13 +58,7 @@ export function createServerHead(options: CreateClientHeadOptions = {}): VueHead
   return createVueServerHead({
     disableCapoSorting: true,
     ...options,
-    plugins: [
-      DeprecationsPlugin,
-      PromisesPlugin,
-      TemplateParamsPlugin,
-      AliasSortingPlugin,
-      ...(options.plugins || []),
-    ],
+    plugins: [...legacyPlugins, ...(options.plugins || [])],
   })
 }
 

--- a/packages/vue/test/unit/legacy.test.ts
+++ b/packages/vue/test/unit/legacy.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { legacyPlugins } from '../../src/legacy'
+import { AliasSortingPlugin, DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin } from '../../src/plugins'
+
+describe('legacy', () => {
+  it('exports the v2 compatibility plugin set', () => {
+    expect(legacyPlugins).toEqual([
+      DeprecationsPlugin,
+      PromisesPlugin,
+      TemplateParamsPlugin,
+      AliasSortingPlugin,
+    ])
+  })
+})

--- a/test/exports/vue.yaml
+++ b/test/exports/vue.yaml
@@ -25,6 +25,7 @@
   createHeadCore: function
   createServerHead: function
   injectHead: function
+  legacyPlugins: object
   resolveUnrefHeadInput: function
   setHeadInjectionHandler: function
   useHead: function


### PR DESCRIPTION
### 🔗 Linked issue

Related to https://github.com/nuxt/ui/pull/6680

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt's Unhead v3 integration imports `legacyPlugins` from `@unhead/vue/legacy`. Nuxt UI 4.10.0 installs `@unhead/vue ^2.1.15`, so module resolution can select the v2 entry and fail during bundling.

Export the plugin set already used by the v2 legacy head factories. The v2 branch now runs CI for its pull requests, and its release workflow accepts matching `v2.*` tags before publishing to the npm `2x` dist-tag.