### PR TITLE
fix: tolerate mixed Unhead majors in Nuxt builds

### DIFF
--- a/packages/unhead/build.config.ts
+++ b/packages/unhead/build.config.ts
@@ -111,6 +111,7 @@ export default defineBuildConfig({
     { input: 'src/stream/client', name: 'stream/client' },
     { input: 'src/stream/iife', name: 'stream/iife' },
     { input: 'src/scripts/index', name: 'scripts' },
+    { input: 'src/scripts/node', name: 'scripts.node' },
     { input: 'src/scripts/triggers', name: 'scripts/triggers' },
     { input: 'src/utils', name: 'utils' },
     { input: 'src/plugins/index', name: 'plugins' },

--- a/packages/unhead/package.json
+++ b/packages/unhead/package.json
@@ -67,6 +67,7 @@
     },
     "./scripts": {
       "types": "./dist/scripts.d.ts",
+      "node": "./dist/scripts.node.mjs",
       "default": "./dist/scripts.mjs"
     },
     "./scripts/triggers": {

--- a/packages/unhead/src/legacy/index.ts
+++ b/packages/unhead/src/legacy/index.ts
@@ -1,52 +1,13 @@
 import type { CreateClientHeadOptions, CreateServerHeadOptions, HeadPluginInput, ResolvableHead, Unhead } from '../types'
 import { createHead as _createClientHead } from '../client'
 import { AliasSortingPlugin } from '../plugins/aliasSorting'
-import { defineHeadPlugin } from '../plugins/defineHeadPlugin'
+import { DeprecationsPlugin } from '../plugins/deprecations'
 import { PromisesPlugin } from '../plugins/promises'
 import { TemplateParamsPlugin } from '../plugins/templateParams'
 import { createHead as _createServerHead } from '../server'
 import { createUnhead } from '../unhead'
 
-/**
- * Maps unhead v1/v2 tag props (`children`, `hid`, `vmid`, `body`, `renderPriority`) to their
- * v3 equivalents (`innerHTML`, `key`, `tagPosition`, `tagPriority`).
- *
- * Intended as a temporary migration aid. Remove once all call sites use the v3 API.
- *
- * @deprecated Will be removed in v4. Migrate tag props to their v3 equivalents
- * (`innerHTML`, `key`, `tagPosition`, `tagPriority`) directly and drop this plugin.
- */
-export const DeprecationsPlugin = /* @__PURE__ */ defineHeadPlugin({
-  key: 'deprecations',
-  hooks: {
-    'entries:normalize': ({ tags }) => {
-      for (const tag of tags) {
-        if (tag.props.children) {
-          tag.innerHTML = tag.props.children
-          delete tag.props.children
-        }
-        if (tag.props.hid) {
-          tag.key = tag.props.hid
-          delete tag.props.hid
-        }
-        if (tag.props.vmid) {
-          tag.key = tag.props.vmid
-          delete tag.props.vmid
-        }
-        if ('body' in tag.props) {
-          if (tag.props.body) {
-            tag.tagPosition = 'bodyClose'
-          }
-          delete tag.props.body
-        }
-        if (tag.props.renderPriority != null) {
-          tag.tagPriority = tag.props.renderPriority
-          delete tag.props.renderPriority
-        }
-      }
-    },
-  },
-})
+export { DeprecationsPlugin }
 
 /**
  * The v2 migration plugins applied by the legacy `createHead`/`createServerHead`, including

--- a/packages/unhead/src/plugins/deprecations.ts
+++ b/packages/unhead/src/plugins/deprecations.ts
@@ -1,0 +1,42 @@
+import { defineHeadPlugin } from './defineHeadPlugin'
+
+/**
+ * Maps unhead v1/v2 tag props (`children`, `hid`, `vmid`, `body`, `renderPriority`) to their
+ * v3 equivalents (`innerHTML`, `key`, `tagPosition`, `tagPriority`).
+ *
+ * Intended as a temporary migration aid. Remove once all call sites use the v3 API.
+ *
+ * @deprecated Will be removed in v4. Migrate tag props to their v3 equivalents
+ * (`innerHTML`, `key`, `tagPosition`, `tagPriority`) directly and drop this plugin.
+ */
+export const DeprecationsPlugin = /* @__PURE__ */ defineHeadPlugin({
+  key: 'deprecations',
+  hooks: {
+    'entries:normalize': ({ tags }) => {
+      for (const tag of tags) {
+        if (tag.props.children) {
+          tag.innerHTML = tag.props.children
+          delete tag.props.children
+        }
+        if (tag.props.hid) {
+          tag.key = tag.props.hid
+          delete tag.props.hid
+        }
+        if (tag.props.vmid) {
+          tag.key = tag.props.vmid
+          delete tag.props.vmid
+        }
+        if ('body' in tag.props) {
+          if (tag.props.body) {
+            tag.tagPosition = 'bodyClose'
+          }
+          delete tag.props.body
+        }
+        if (tag.props.renderPriority != null) {
+          tag.tagPriority = tag.props.renderPriority
+          delete tag.props.renderPriority
+        }
+      }
+    },
+  },
+})

--- a/packages/unhead/src/plugins/index.ts
+++ b/packages/unhead/src/plugins/index.ts
@@ -2,6 +2,9 @@ export { AliasSortingPlugin } from './aliasSorting'
 export { CanonicalPlugin } from './canonical'
 export type { CanonicalPluginOptions } from './canonical'
 export { defineHeadPlugin } from './defineHeadPlugin'
+// Nuxt may bundle the v2 legacy plugin list while resolving this subpath from
+// a hoisted v3 install. Keep the deprecated plugin available during migration.
+export { DeprecationsPlugin } from './deprecations'
 export { FlatMetaPlugin } from './flatMeta' // optional
 export { InferSeoMetaPlugin } from './inferSeoMetaPlugin' // optional
 export { MinifyPlugin } from './minify' // optional

--- a/packages/unhead/src/scripts/node.ts
+++ b/packages/unhead/src/scripts/node.ts
@@ -1,0 +1,6 @@
+// Keep the server entry reachable for Node dependency tracers when multiple
+// Unhead versions are installed. The package is side-effect free, so bundlers
+// can discard this compatibility edge while Node tracers retain server.mjs.
+import 'unhead/server'
+
+export * from './index'

--- a/packages/unhead/test/unit/plugins/deprecations.test.ts
+++ b/packages/unhead/test/unit/plugins/deprecations.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { DeprecationsPlugin } from '../../../src/legacy'
+import { DeprecationsPlugin as DeprecationsPluginFromPlugins } from '../../../src/plugins'
 import { renderSSRHead } from '../../../src/server'
 import { createServerHeadWithContext } from '../../util'
 
 describe('deprecationsPlugin', () => {
+  it('is available from the plugins compatibility entry', () => {
+    expect(DeprecationsPluginFromPlugins).toBe(DeprecationsPlugin)
+  })
+
   it('maps v1/v2 tag props to v3 equivalents', async () => {
     const head = createServerHeadWithContext({ plugins: [DeprecationsPlugin] })
     head.push({

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -87,3 +87,15 @@ describe('package type paths', async () => {
     })
   }
 })
+
+describe('node compatibility exports', () => {
+  it('keeps the server entry traceable from unhead/scripts', () => {
+    const packagePath = join(import.meta.dirname, '../packages/unhead')
+    const packageJson = JSON.parse(readFileSync(join(packagePath, 'package.json'), 'utf8'))
+    const scriptsExport = packageJson.exports['./scripts']
+
+    expect(scriptsExport.node).toBe('./dist/scripts.node.mjs')
+    expect(scriptsExport.default).toBe('./dist/scripts.mjs')
+    expect(readFileSync(join(packagePath, scriptsExport.node), 'utf8')).toContain('import \'unhead/server\';')
+  })
+})

--- a/test/exports/react.yaml
+++ b/test/exports/react.yaml
@@ -20,6 +20,7 @@
   AliasSortingPlugin: object
   CanonicalPlugin: function
   defineHeadPlugin: function
+  DeprecationsPlugin: object
   FlatMetaPlugin: object
   InferSeoMetaPlugin: function
   MinifyPlugin: function

--- a/test/exports/solid-js.yaml
+++ b/test/exports/solid-js.yaml
@@ -17,6 +17,7 @@
   AliasSortingPlugin: object
   CanonicalPlugin: function
   defineHeadPlugin: function
+  DeprecationsPlugin: object
   FlatMetaPlugin: object
   InferSeoMetaPlugin: function
   MinifyPlugin: function

--- a/test/exports/svelte.yaml
+++ b/test/exports/svelte.yaml
@@ -18,6 +18,7 @@
   AliasSortingPlugin: object
   CanonicalPlugin: function
   defineHeadPlugin: function
+  DeprecationsPlugin: object
   FlatMetaPlugin: object
   InferSeoMetaPlugin: function
   MinifyPlugin: function

--- a/test/exports/unhead.yaml
+++ b/test/exports/unhead.yaml
@@ -34,6 +34,7 @@
   AliasSortingPlugin: object
   CanonicalPlugin: function
   defineHeadPlugin: function
+  DeprecationsPlugin: object
   FlatMetaPlugin: object
   InferSeoMetaPlugin: function
   MinifyPlugin: function

--- a/test/exports/vue.yaml
+++ b/test/exports/vue.yaml
@@ -33,6 +33,7 @@
   AliasSortingPlugin: object
   CanonicalPlugin: function
   defineHeadPlugin: function
+  DeprecationsPlugin: object
   FlatMetaPlugin: object
   InferSeoMetaPlugin: function
   MinifyPlugin: function


### PR DESCRIPTION
### 🔗 Linked issue

Related to https://github.com/nuxt/nuxt/issues/35256
Complements #861

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt 4.5 can resolve `@unhead/vue/legacy` from v2 while Nitro externalizes bare `unhead` imports to a hoisted v3 package. That mixed layout currently builds a partial v3 package, then fails SSR because `dist/server.mjs` and `DeprecationsPlugin` cannot be resolved.

The Node condition for `unhead/scripts` now keeps the v3 server entry in Nitro's trace, and `unhead/plugins` exports `DeprecationsPlugin` for v2 legacy bundles. The v2 `legacyPlugins` half is already merged in #861.