### PR TITLE
fix(bundler): preserve head.ssr mutation targets

### DIFF
--- a/packages/bundler/src/unplugin/SSRStaticReplace.ts
+++ b/packages/bundler/src/unplugin/SSRStaticReplace.ts
@@ -1,12 +1,23 @@
 import type { ConfigEnv, UserConfig } from 'vite'
 import type { BuildConsumer } from './utils'
 import MagicString from 'magic-string'
+import { parseAndWalk } from 'oxc-walker'
 import { createUnplugin } from 'unplugin'
 import { resolveBuildConsumer } from './utils'
 
 const UNHEAD_JS_MODULE_RE = /[\\/]node_modules[\\/](?:@unhead[\\/][^\\/]+|unhead)[\\/].*\.(?:c|m)?js$/
 const HEAD_SSR_FILTER_RE = /\bhead\.ssr\b/
-const HEAD_SSR_RE = new RegExp(HEAD_SSR_FILTER_RE.source, 'g')
+
+function isMutationTarget(parent: any, key: string | number | symbol | null | undefined): boolean {
+  if (key === 'left') {
+    return parent?.type === 'AssignmentExpression'
+      || parent?.type === 'ForInStatement'
+      || parent?.type === 'ForOfStatement'
+  }
+  return key === 'argument'
+    && (parent?.type === 'UpdateExpression'
+      || (parent?.type === 'UnaryExpression' && parent.operator === 'delete'))
+}
 
 export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() => {
   // Fallback build target for bundlers without a per-transform environment
@@ -51,9 +62,29 @@ export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() 
 
         const ssr = consumer === 'server'
         const s = new MagicString(code)
-        for (const match of code.matchAll(HEAD_SSR_RE)) {
-          s.overwrite(match.index!, match.index! + match[0].length, String(ssr))
-        }
+        let mutationTargetDepth = 0
+        parseAndWalk(code, id, {
+          parseOptions: { lang: 'js' },
+          enter(node: any, parent: any, { key }: any) {
+            if (isMutationTarget(parent, key))
+              mutationTargetDepth++
+            if (mutationTargetDepth
+              || node.type !== 'MemberExpression'
+              || node.computed
+              || node.object?.type !== 'Identifier'
+              || node.object.name !== 'head'
+              || node.property?.type !== 'Identifier'
+              || node.property.name !== 'ssr'
+              || code.slice(node.start, node.end) !== 'head.ssr') {
+              return
+            }
+            s.overwrite(node.start, node.end, String(ssr))
+          },
+          leave(_node: any, parent: any, { key }: any) {
+            if (isMutationTarget(parent, key))
+              mutationTargetDepth--
+          },
+        })
 
         if (s.hasChanged()) {
           return {

--- a/packages/bundler/test/ssrStaticReplace.test.ts
+++ b/packages/bundler/test/ssrStaticReplace.test.ts
@@ -43,6 +43,35 @@ describe('ssrStaticReplace', () => {
     expect(result?.code).toContain('if (true)')
   })
 
+  it('preserves head.ssr mutation targets while replacing reads', () => {
+    const plugin = createPlugin({ isSsrBuild: false, command: 'build' })
+    const code = [
+      'head.ssr = false;',
+      'head.ssr ||= true;',
+      'head.ssr++;',
+      'delete head.ssr;',
+      'for (head.ssr in source) {}',
+      'if (head.ssr) use(head.ssr);',
+    ].join('\n')
+    const result = transform(plugin, code, UNHEAD_MODULE_ID)
+
+    expect(result?.code).toBe([
+      'head.ssr = false;',
+      'head.ssr ||= true;',
+      'head.ssr++;',
+      'delete head.ssr;',
+      'for (head.ssr in source) {}',
+      'if (false) use(false);',
+    ].join('\n'))
+  })
+
+  it('preserves head.ssr reads nested inside mutation targets', () => {
+    const plugin = createPlugin({ isSsrBuild: true, command: 'build' })
+    const result = transform(plugin, 'head.ssr.value = 1; use(head.ssr);', UNHEAD_MODULE_ID)
+
+    expect(result?.code).toBe('head.ssr.value = 1; use(true);')
+  })
+
   it('should not apply in dev mode (vite serve)', () => {
     // in dev mode, head.ssr should NOT be statically replaced because both
     // SSR and client environments share the same vite dev server. The plugin


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue. 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`SSRStaticReplace` replaced every `head.ssr` occurrence, including the client adapter assignment. With Nuxt 4.5.0 and `@nuxtjs/seo`, that turned `head.ssr = false` into `false = false` during `cloudflare_module` builds.

Parse candidate modules before replacement and leave mutation targets intact. Read expressions are still folded to a static boolean, with regression coverage for assignment, update, delete, and loop targets.

Verified against the clean reproduction using packed local packages. The Cloudflare Worker served root, dynamic SSR, and client asset requests successfully, and both HTML routes included non-empty `WebSite`, `WebPage`, and `ReadAction` JSON-LD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSR static replacement for `head.ssr` in complex expressions.
  * Mutation operations such as assignments, updates, deletions, and loop targets now remain intact while eligible read-only references are replaced correctly.
  * Fixed replacement behavior when `head.ssr` is used alongside property access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->