### PR TITLE
fix(scripts): keep removed controllers terminal

### DIFF
--- a/docs/head/7.api/composables/4.use-script.md
+++ b/docs/head/7.api/composables/4.use-script.md
@@ -171,6 +171,8 @@ off()
 
 `remove()` disposes the shared head entry, cancels its triggers and warmup entry, aborts its signal, and moves it to `removed`. Because the script is shared, this affects every consumer of that controller.
 
+A removed controller is terminal. Calling `load()` again resolves through the completed lifecycle without adding another script. Call `useScript()` again with the same input to create a fresh controller.
+
 ## Consumer scopes
 
 The core API and Vue integration support `{ scope: true }`. A scope owns its callbacks and triggers while leaving the underlying script shared:

--- a/packages/angular/src/use-script.spec.ts
+++ b/packages/angular/src/use-script.spec.ts
@@ -23,7 +23,8 @@ describe('angular useScript callback disposal', () => {
     TestBed.flushEffects()
 
     const script = (head as any)._scripts['//angular-loaded.js']
-    head.hooks?.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    script.status = 'loaded'
+    head.hooks?.callHook('script:updated', { script })
     await script._loadPromise
 
     expect(calls).toEqual(['only'])
@@ -53,7 +54,8 @@ describe('angular useScript callback disposal', () => {
     offSecond()
 
     const script = (head as any)._scripts['//angular-ordered.js']
-    head.hooks?.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    script.status = 'loaded'
+    head.hooks?.callHook('script:updated', { script })
     await script._loadPromise
 
     // both handles disposed, so neither callback should fire
@@ -76,7 +78,8 @@ describe('angular useScript callback disposal', () => {
     TestBed.flushEffects()
 
     const script = (head as any)._scripts['//angular-keyed.js']
-    head.hooks?.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    script.status = 'loaded'
+    head.hooks?.callHook('script:updated', { script })
     await script._loadPromise
 
     expect(calls).toEqual(['first'])

--- a/packages/svelte/test/dom/use-script.test.ts
+++ b/packages/svelte/test/dom/use-script.test.ts
@@ -108,7 +108,8 @@ describe('svelte useScript', () => {
     })
 
     const script = (head as any)._scripts['//svelte-keyed.js']
-    head.hooks?.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    script.status = 'loaded'
+    head.hooks?.callHook('script:updated', { script })
     await script._loadPromise
 
     expect(onCall).toHaveBeenCalledOnce()

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -118,6 +118,8 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
     onerror = null
   }
   input.onload = (e: Event) => {
+    if (lifecycleController.signal.aborted)
+      return
     try {
       syncStatus('loaded')
       onload?.(e)
@@ -127,6 +129,8 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
     }
   }
   input.onerror = (e: Event) => {
+    if (lifecycleController.signal.aborted)
+      return
     try {
       lifecycleController.abort()
       syncStatus('error')
@@ -198,10 +202,14 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
         resolve(api)
     })
     let resolvingApi = false
-    const unhook = head.hooks?.hook('script:updated', ({ script }: { script: ScriptInstance<T> }) => {
+    const unhook = head.hooks?.hook('script:updated', ({ script: updatedScript }: { script: ScriptInstance<T> }) => {
+      // Same-id scripts can overlap while a removed entry finishes dispatching DOM events.
+      // eslint-disable-next-line ts/no-use-before-define
+      if (updatedScript !== script)
+        return
       // vue augmentation... not ideal
-      const status = script.status
-      if (script.id === id && (status === 'loaded' || status === 'error' || status === 'removed')) {
+      const status = updatedScript.status
+      if (status === 'loaded' || status === 'error' || status === 'removed') {
         if (status === 'loaded') {
           if (resolvingApi)
             return
@@ -224,7 +232,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
             }
           })()
           void useOutcome.then((outcome) => {
-            if (lifecycleController.signal.aborted || script.status === 'removed')
+            if (lifecycleController.signal.aborted || updatedScript.status === 'removed')
               return
             if (!outcome[0]) {
               failReadiness(outcome[1])
@@ -307,6 +315,9 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       return script._warmupEl
     },
     load(cb?: () => void | Promise<void>) {
+      // remove() aborts this instance's one-shot signal and load promise.
+      if (script.status === 'removed')
+        return loadPromise
       // cancel all pending triggers as we've started loading
       script._triggerAbortControllers?.forEach(ac => ac.abort())
       script._triggerAbortControllers?.clear()

--- a/packages/unhead/test/unit/scripts/dom.test.ts
+++ b/packages/unhead/test/unit/scripts/dom.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { useScript } from '../../../src/composables'
 import { useDelayedSerializedDom, useDOMHead } from '../../../test/util'
 
@@ -40,11 +40,12 @@ describe('dom useScript', () => {
 
     expect(instance.proxy.test('hello-world')).toEqual('hello-world')
   })
-  it('remove & re-add', async () => {
+  it('keeps removed handles terminal and re-adds through a new instance', async () => {
     const head = useDOMHead()
+    const src = 'https://cdn.example.com/script.js'
 
     const instance = useScript<{ test: (foo: string) => void }>(head, {
-      src: 'https://cdn.example.com/script.js',
+      src,
     })
 
     let dom = await useDelayedSerializedDom()
@@ -58,13 +59,23 @@ describe('dom useScript', () => {
     await new Promise(r => setTimeout(r, 100))
     dom = await useDelayedSerializedDom()
     expect(dom.split('\n').filter(l => l.trim().startsWith('<script'))).toMatchInlineSnapshot(`[]`)
-    // reload
-    instance.load()
+    await expect(instance.load()).resolves.toBe(false)
+    await new Promise(r => setTimeout(r, 100))
+    dom = await useDelayedSerializedDom()
+    expect(dom.split('\n').filter(l => l.trim().startsWith('<script'))).toMatchInlineSnapshot(`[]`)
+    expect(instance.entry).toBeUndefined()
+    expect(head._scripts?.[src]).toBeUndefined()
+
+    const nextInstance = useScript<{ test: (foo: string) => void }>(head, { src })
+    expect(nextInstance).not.toBe(instance)
+    await instance.load()
+    expect(instance.entry).toBeUndefined()
+    expect(head._scripts?.[src]).toBe(nextInstance)
     await new Promise(r => setTimeout(r, 100))
     dom = await useDelayedSerializedDom()
     expect(dom.split('\n').filter(l => l.trim().startsWith('<script'))).toMatchInlineSnapshot(`
       [
-        "<script defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" data-onload="" data-onerror=""></script></head>",
+        "<script defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" data-onload="" data-onerror=""></script><link href="https://cdn.example.com/script.js" rel="preload" crossorigin="anonymous" referrerpolicy="no-referrer" fetchpriority="low" as="script"></head>",
       ]
     `)
   })

--- a/packages/unhead/test/unit/scripts/events.test.ts
+++ b/packages/unhead/test/unit/scripts/events.test.ts
@@ -4,6 +4,11 @@ import { createHead } from '../../../src/client'
 import { useScript } from '../../../src/composables'
 import { createScriptWaitFor } from '../../../src/scripts/waitFor'
 
+function markLoaded(head: any, script: any) {
+  script.status = 'loaded'
+  return head.hooks.callHook('script:updated', { script })
+}
+
 describe('useScript events', () => {
   it('keeps invoking legacy use() callbacks without arguments', () => {
     const head = createHead()
@@ -25,7 +30,7 @@ describe('useScript events', () => {
         resolve(true)
       })
       // Trigger the hook to simulate the script being loaded
-      head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+      markLoaded(head, instance)
     })).toBeTruthy()
   })
   it('fires onLoaded when requestAnimationFrame is suspended (hidden tab) - #771', async () => {
@@ -41,7 +46,7 @@ describe('useScript events', () => {
         instance.onLoaded(() => {
           resolve(true)
         })
-        head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+        markLoaded(head, instance)
       })).resolves.toBeTruthy()
     }
     finally {
@@ -58,7 +63,7 @@ describe('useScript events', () => {
       const instance = useScript(head, '/script.js', {
         trigger: 'server',
       })
-      head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+      markLoaded(head, instance)
       // register after the load hook already fired
       await expect(new Promise<true>((resolve) => {
         instance.onLoaded(() => {
@@ -92,7 +97,7 @@ describe('useScript events', () => {
         resolve()
       })
       // Trigger the hook to simulate the script being loaded
-      head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+      markLoaded(head, instance)
     })
     expect(calls).toMatchInlineSnapshot(`
       [
@@ -124,7 +129,7 @@ describe('useScript events', () => {
     })
 
     expect(instance._cbs.loaded).toHaveLength(1)
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     await instance._loadPromise
 
     expect(calls).toEqual(['b'])
@@ -269,6 +274,39 @@ describe('useScript events', () => {
     expect(head._scripts?.[second.id]).toBe(second)
   })
 
+  it('ignores late lifecycle updates from a removed same-id script', async () => {
+    const head = createHead()
+    const first = useScript(head, '/same-id.js', { trigger: 'manual' })
+    first.load()
+    const firstInput = (first as any).input
+    first.remove()
+    await first._loadPromise
+
+    const api = { ready: true }
+    const second = useScript(head, '/same-id.js', {
+      trigger: 'manual',
+      use: () => api,
+    })
+    const onLoaded = vi.fn()
+    second.onLoaded(onLoaded)
+    second.load()
+
+    firstInput.onload(new Event('load'))
+    await Promise.resolve()
+    expect(first.status).toBe('removed')
+    expect(second.status).toBe('loading')
+    expect(onLoaded).not.toHaveBeenCalled()
+
+    first.status = 'loaded'
+    await head.hooks.callHook('script:updated', { script: first })
+    expect(second.status).toBe('loading')
+    expect(onLoaded).not.toHaveBeenCalled()
+
+    ;(second as any).input.onload(new Event('load'))
+    await expect(second._loadPromise).resolves.toBe(api)
+    expect(onLoaded).toHaveBeenCalledWith(api)
+  })
+
   it('drops settled trigger abort controllers from the set', async () => {
     const head = createHead()
     let resolveTrigger!: (value: boolean) => void
@@ -383,7 +421,7 @@ describe('useScript events', () => {
     const onLoaded = vi.fn()
     instance.onLoaded(onLoaded)
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     await Promise.resolve()
     expect(onLoaded).not.toHaveBeenCalled()
 
@@ -408,7 +446,7 @@ describe('useScript events', () => {
     })
     instance.onLoaded(afterError)
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     await instance._loadPromise
     await Promise.resolve()
 
@@ -431,7 +469,7 @@ describe('useScript events', () => {
       }),
     })
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     const api = { ready: true as const }
     resolveReady(api)
 
@@ -447,7 +485,7 @@ describe('useScript events', () => {
       resolve: ({ waitFor }) => waitFor(resolve => resolve(api)),
     })
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
 
     await expect(instance._loadPromise).resolves.toBe(api)
   })
@@ -472,7 +510,7 @@ describe('useScript events', () => {
       }),
     })
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     instance.remove()
 
     await expect(instance._loadPromise).resolves.toBe(false)
@@ -496,7 +534,7 @@ describe('useScript events', () => {
     const onLoaded = vi.fn()
     instance.onLoaded(onLoaded)
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     instance.remove()
 
     expect(signal.aborted).toBe(true)
@@ -518,7 +556,7 @@ describe('useScript events', () => {
     const onError = vi.fn()
     instance.onError(onError)
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     await expect(instance._loadPromise).resolves.toBe(false)
     expect(instance.status).toBe('error')
     expect(onError).toHaveBeenCalledWith(error)
@@ -534,7 +572,7 @@ describe('useScript events', () => {
     const onError = vi.fn()
     instance.onError(onError)
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     reject(undefined)
     await expect(instance._loadPromise).resolves.toBe(false)
     expect(instance.status).toBe('error')
@@ -548,7 +586,7 @@ describe('useScript events', () => {
       use: async () => undefined,
     })
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     await expect(instance._loadPromise).resolves.toBe(false)
 
     const onError = vi.fn()
@@ -570,7 +608,7 @@ describe('useScript events', () => {
     const onError = vi.fn()
     instance.onError(onError)
 
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    markLoaded(head, instance)
     await expect(instance._loadPromise).resolves.toBe(false)
     expect(instance.status).toBe('error')
     expect(onError).toHaveBeenCalledWith(error)

--- a/packages/unhead/test/unit/scripts/proxy.test.ts
+++ b/packages/unhead/test/unit/scripts/proxy.test.ts
@@ -157,7 +157,8 @@ describe('proxy chain', () => {
     const greet = vi.fn((foo: string) => foo)
 
     instance.proxy.greet('hello-world')
-    head.hooks.callHook('script:updated', { script: { id: instance.id, status: 'loaded' } as any })
+    instance.status = 'loaded'
+    head.hooks.callHook('script:updated', { script: instance })
     resolve({ greet })
     await instance._loadPromise
 

--- a/packages/unhead/test/unit/scripts/scope.test.ts
+++ b/packages/unhead/test/unit/scripts/scope.test.ts
@@ -45,7 +45,8 @@ describe('script scope', () => {
     expect(cleanupB).not.toHaveBeenCalled()
 
     scopeB.load()
-    head.hooks.callHook('script:updated', { script: { id: scopeB.id, status: 'loaded' } as any })
+    scopeB.script.status = 'loaded'
+    head.hooks.callHook('script:updated', { script: scopeB.script })
     await scopeB.script._loadPromise
 
     expect(loadedA).not.toHaveBeenCalled()
@@ -90,7 +91,8 @@ describe('script scope', () => {
     const script = scope.script
 
     script.load()
-    head.hooks.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    script.status = 'loaded'
+    head.hooks.callHook('script:updated', { script })
     await script._loadPromise
     scope.dispose()
 

--- a/packages/vue/test/unit/useScript.test.ts
+++ b/packages/vue/test/unit/useScript.test.ts
@@ -295,7 +295,8 @@ describe('vue e2e scripts', () => {
     offSecond()
 
     const script = (head as any)._scripts['//ordered-callbacks.js']
-    head.hooks?.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    script.status = 'loaded'
+    head.hooks?.callHook('script:updated', { script })
     await script._loadPromise
 
     // both handles disposed, so neither callback should fire
@@ -322,7 +323,8 @@ describe('vue e2e scripts', () => {
     app.mount(el)
 
     const script = (head as any)._scripts['//vue-keyed.js']
-    head.hooks?.callHook('script:updated', { script: { id: script.id, status: 'loaded' } as any })
+    script.status = 'loaded'
+    head.hooks?.callHook('script:updated', { script })
     await script._loadPromise
 
     expect(calls).toEqual(['first'])


### PR DESCRIPTION
### 🔗 Linked issue

Related to [nuxt/scripts#832](https://github.com/nuxt/scripts/pull/832)

### ❓ Type of change

- [x] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`remove()` aborts a controller and settles its load promise, but a later `load()` could still insert a tag. A late event from that removed controller could also resolve a fresh same-source controller because `script:updated` matched by ID alone. Removed controllers now stay terminal, while lifecycle events are matched by controller identity; callers can use `useScript()` again to create a fresh controller.