### PR TITLE
fix(stream): resolve reactive entries before serialization

### DIFF
--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -3,6 +3,7 @@ import type { ServerUnhead } from '../server/createHead'
 import type { CreateStreamableServerHeadOptions, ResolvableHead, SSRHeadPayload, Unhead } from '../types'
 import { applyHeadToHtml, parseHtmlForIndexes } from '../parser'
 import { createHead } from '../server/createHead'
+import { resolveHeadInput } from '../utils/normalize'
 import { DEFAULT_STREAM_KEY } from './client'
 
 const LT_RE = /</g
@@ -217,19 +218,20 @@ export function renderSSRHeadSuspenseChunk(head: Unhead<any>): string {
     return ''
 
   const streamKey = getStreamKey(head)
-  const inputs = Array.from(head.entries.values(), e => e.input)
-  // Serialize before clearing so a failure (cyclic value, BigInt, ...) leaves
-  // the valid entries intact for the next chunk.
+  const propResolvers = head.resolvedOptions.propResolvers || []
+  // Resolve and serialize before clearing so a failure leaves the valid
+  // entries intact for the next chunk.
   let serialized: string
   try {
+    const inputs = Array.from(head.entries.values(), e => resolveHeadInput(e.input, propResolvers))
     serialized = safeJsonStringify(inputs)
   }
   catch (error) {
-    // Drop only the entries that can't serialize: keeping them would poison
-    // every subsequent chunk render with the same error.
+    // Drop only entries that cannot resolve or serialize. Keeping one would
+    // poison every subsequent chunk render with the same error.
     for (const [key, entry] of head.entries) {
       try {
-        safeJsonStringify(entry.input)
+        safeJsonStringify(resolveHeadInput(entry.input, propResolvers))
       }
       catch {
         head.entries.delete(key)

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -84,6 +84,20 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
   return tag
 }
 
+export function resolveHeadInput(input: any, propResolvers: PropResolver[]): any {
+  let resolve: PropResolver | undefined
+  if (propResolvers.length) {
+    resolve = (key, val) => {
+      for (let i = 0; i < propResolvers.length; i++)
+        val = propResolvers[i](key, val)
+      return val
+    }
+    // Resolve the root before walking so ref-wrapped functions are unwrapped.
+    input = resolve(undefined, input)
+  }
+  return walkResolver(input, resolve)
+}
+
 function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string): HeadTag | HeadTag[] {
   const input = typeof _input === 'object' && typeof _input !== 'function'
     ? _input
@@ -119,20 +133,9 @@ export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]):
     return []
   if (typeof input === 'function')
     input = input()
-  let resolve: PropResolver | undefined
-  if (propResolvers.length) {
-    resolve = (key, val) => {
-      for (let i = 0; i < propResolvers.length; i++)
-        val = propResolvers[i](key, val)
-      return val
-    }
-    // load-bearing: walkResolver unwraps functions BEFORE resolving, so a
-    // resolvable yielding a function (e.g. `useHead(ref(() => ({...})))`,
-    // see vite-pwa/vite-plugin-pwa#832) only renders if a resolve pass runs
-    // first. The root intentionally passes through the resolver chain twice.
-    input = resolve(undefined, input)
-  }
-  input = walkResolver(input, resolve)
+  // The root intentionally passes through the resolver chain twice. The first
+  // pass unwraps refs, then walkResolver invokes a function returned by a ref.
+  input = resolveHeadInput(input, propResolvers)
   const tags: HeadTag[] = []
   for (const key in input) {
     const value = input[key]

--- a/packages/vue/test/streaming.test.ts
+++ b/packages/vue/test/streaming.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import type { SSRHeadPayload } from 'unhead/types'
 import { describe, expect, expectTypeOf, it } from 'vitest'
+import { computed } from 'vue'
+import { useHead } from '../src/composables'
 import {
   createBootstrapScript,
   createStreamableHead,
@@ -103,6 +105,19 @@ describe('vue streaming SSR', () => {
       expect(result).toContain('window.__unhead__.push')
       expect(result).toContain('Updated Title')
       expect(result).toContain('New description')
+    })
+
+    it('resolves computed values before serializing entries', () => {
+      const { head } = createStreamableHead()
+      renderSSRHeadShell(head, '<html><head></head><body>')
+
+      useHead({
+        style: [{ innerHTML: computed(() => 'body{background:red}') }],
+      }, { head })
+
+      const result = renderSSRHeadSuspenseChunk(head)
+
+      expect(result).toContain('body{background:red}')
     })
 
     it('clears entries after rendering chunk', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #869

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`renderSSRHeadSuspenseChunk` serialized raw entry inputs, so Vue computed refs caused circular JSON errors during SSR streaming. Resolve queued inputs through the configured prop resolvers before serialization, with a regression test covering `useHead` and a computed style value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered streaming updates so computed and dynamically resolved head values are serialized correctly.
  * Prevented a single invalid head entry from blocking subsequent streaming updates.
  * Ensured resolved styles and other head content appear correctly in streamed HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->