### PR TITLE
fix(schema-org): keep logo on organization identity

### DIFF
--- a/docs/schema-org/5.api/9.schema/organization.md
+++ b/docs/schema-org/5.api/9.schema/organization.md
@@ -115,7 +115,7 @@ defineOrganization({
 })
 ```
 
-The logo URL resolves into an ImageObject with the ID `#logo`. The primary identity references related content, while a compact Organization node at `#organization` carries the absolute logo URL for Google's organization markup.
+The logo URL resolves into an ImageObject with the ID `#logo`, referenced by the primary Organization identity.
 
 ```json
 {
@@ -124,6 +124,9 @@ The logo URL resolves into an ImageObject with the ID `#logo`. The primary ident
     {
       "@id": "https://nuxtjs.org/#identity",
       "@type": "Organization",
+      "logo": {
+        "@id": "https://nuxtjs.org/#logo"
+      },
       "name": "Nuxt.js",
       "url": "https://nuxtjs.org/"
     },
@@ -133,13 +136,6 @@ The logo URL resolves into an ImageObject with the ID `#logo`. The primary ident
       "caption": "Nuxt.js",
       "contentUrl": "https://nuxtjs.org/img/logo.png",
       "url": "https://nuxtjs.org/img/logo.png"
-    },
-    {
-      "@id": "https://nuxtjs.org/#organization",
-      "@type": "Organization",
-      "logo": "https://nuxtjs.org/img/logo.png",
-      "name": "Nuxt.js",
-      "url": "https://nuxtjs.org/"
     }
   ]
 }

--- a/packages/schema-org/src/nodes/Article/index.test.ts
+++ b/packages/schema-org/src/nodes/Article/index.test.ts
@@ -308,6 +308,9 @@ describe('defineArticle', () => {
           {
             "@id": "https://example.com/#identity",
             "@type": "Organization",
+            "logo": {
+              "@id": "https://example.com/#logo",
+            },
             "name": "Identity",
             "url": "https://example.com/",
           },
@@ -381,13 +384,6 @@ describe('defineArticle', () => {
             "contentUrl": "https://example.com/test.png",
             "inLanguage": "en-AU",
             "url": "https://example.com/test.png",
-          },
-          {
-            "@id": "https://example.com/#organization",
-            "@type": "Organization",
-            "logo": "https://example.com/test.png",
-            "name": "Identity",
-            "url": "https://example.com/",
           },
           {
             "@id": "https://example.com/#/schema/image/1",

--- a/packages/schema-org/src/nodes/Organization/index.test.ts
+++ b/packages/schema-org/src/nodes/Organization/index.test.ts
@@ -3,7 +3,7 @@ import { defineOrganization, useSchemaOrg } from '../../'
 import { injectSchemaOrg, useSetup } from '../../../test'
 
 describe('defineOrganization', () => {
-  it('can be registered', async () => {
+  it('keeps a logo on the identity organization', async () => {
     await useSetup(async (head) => {
       useSchemaOrg(head, [
         defineOrganization({
@@ -30,6 +30,9 @@ describe('defineOrganization', () => {
               "postalCode": "2000",
               "streetAddress": "123 st",
             },
+            "logo": {
+              "@id": "https://example.com/#logo",
+            },
             "name": "test",
             "url": "https://example.com/",
           },
@@ -40,19 +43,6 @@ describe('defineOrganization', () => {
             "contentUrl": "https://example.com/logo.png",
             "inLanguage": "en-AU",
             "url": "https://example.com/logo.png",
-          },
-          {
-            "@id": "https://example.com/#organization",
-            "@type": "Organization",
-            "address": {
-              "@type": "PostalAddress",
-              "addressCountry": "Australia",
-              "postalCode": "2000",
-              "streetAddress": "123 st",
-            },
-            "logo": "https://example.com/logo.png",
-            "name": "test",
-            "url": "https://example.com/",
           },
         ]
       `)
@@ -69,9 +59,12 @@ describe('defineOrganization', () => {
       ])
 
       const graph = await injectSchemaOrg(head)
-      const organization = graph.find(node => node['@id'] === 'https://example.com/#organization')
+      const organization = graph.find(node => node['@id'] === 'https://example.com/#identity')
+      const logo = graph.find(node => node['@id'] === 'https://example.com/#logo')
 
-      expect(organization?.logo).toBe('https://example.com/primary-logo.png')
+      expect(organization?.logo).toEqual({ '@id': 'https://example.com/#logo' })
+      expect(logo?.contentUrl).toBe('https://example.com/primary-logo.png')
+      expect(graph.filter(node => node['@type'] === 'Organization')).toHaveLength(1)
       expect(graph.filter(node => node['@type'] === 'ImageObject')).toHaveLength(1)
     })
   })

--- a/packages/schema-org/src/nodes/Organization/index.test.ts
+++ b/packages/schema-org/src/nodes/Organization/index.test.ts
@@ -68,4 +68,27 @@ describe('defineOrganization', () => {
       expect(graph.filter(node => node['@type'] === 'ImageObject')).toHaveLength(1)
     })
   })
+
+  it('retains a compact node for specialized organizations', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        defineOrganization({
+          '@type': 'Corporation',
+          'name': 'test',
+          'logo': '/logo.png',
+        }),
+      ])
+
+      const graph = await injectSchemaOrg(head)
+      const identity = graph.find(node => node['@id'] === 'https://example.com/#identity')
+      const organization = graph.find(node => node['@id'] === 'https://example.com/#organization')
+
+      expect(identity).toMatchObject({ '@type': ['Organization', 'Corporation'] })
+      expect(identity).not.toHaveProperty('logo')
+      expect(organization).toMatchObject({
+        '@type': 'Organization',
+        'logo': 'https://example.com/logo.png',
+      })
+    })
+  })
 })

--- a/packages/schema-org/src/nodes/Organization/index.ts
+++ b/packages/schema-org/src/nodes/Organization/index.ts
@@ -98,21 +98,26 @@ export const organizationResolver
       const isIdentity = resolveAsGraphKey(node['@id']) === IdentityId
       const webPage = ctx.find(PrimaryWebPageId)
       if (node.logo && isIdentity) {
+        const logoInput = Array.isArray(node.logo) ? node.logo[0] : node.logo
+        // Google expects a single logo, so use the first configured image.
+        const logoNode = resolveRelation(logoInput, ctx, imageResolver, {
+          root: true,
+          afterResolve(logo) {
+            logo['@id'] = prefixId(ctx.meta.host, '#logo')
+            setIfEmpty(logo, 'caption', node.name)
+          },
+        })
+
+        if (webPage && logoNode)
+          setIfEmpty(webPage, 'primaryImageOfPage', idReference(logoNode))
+
+        if (node['@type'] === 'Organization') {
+          node.logo = logoNode
+        }
+        // Specialized organizations retain a compact Organization node for
+        // Google's Organization rich result.
         // eslint-disable-next-line e18e/prefer-array-some -- ctx.find is not Array.find
-        if (!ctx.find('#organization')) {
-          const logoInput = Array.isArray(node.logo) ? node.logo[0] : node.logo
-          // Google expects a single logo, so use the first configured image.
-          const logoNode = resolveRelation(logoInput, ctx, imageResolver, {
-            root: true,
-            afterResolve(logo) {
-              logo['@id'] = prefixId(ctx.meta.host, '#logo')
-              setIfEmpty(logo, 'caption', node.name)
-            },
-          })
-
-          if (webPage && logoNode)
-            setIfEmpty(webPage, 'primaryImageOfPage', idReference(logoNode))
-
+        else if (!ctx.find('#organization')) {
           const resolvedLogo = logoNode && typeof logoNode === 'object' && logoNode['@id']
             ? ctx.find(logoNode['@id'], isImageObject)
             : null
@@ -133,7 +138,8 @@ export const organizationResolver
             '@id': prefixId(ctx.meta.host, '#organization'), // avoid the id so nothing can link to it
           })
         }
-        delete node.logo
+        if (node['@type'] !== 'Organization')
+          delete node.logo
       }
 
       if (isIdentity && webPage)

--- a/packages/schema-org/src/nodes/WebPage/index.test.ts
+++ b/packages/schema-org/src/nodes/WebPage/index.test.ts
@@ -325,6 +325,9 @@ describe('defineWebPage', () => {
           {
             "@id": "https://example.com/#identity",
             "@type": "Organization",
+            "logo": {
+              "@id": "https://example.com/#logo",
+            },
             "name": "Harlan Wilton",
             "url": "https://example.com/",
           },
@@ -345,13 +348,6 @@ describe('defineWebPage', () => {
             "contentUrl": "https://example.com/logo.png",
             "inLanguage": "en-AU",
             "url": "https://example.com/logo.png",
-          },
-          {
-            "@id": "https://example.com/#organization",
-            "@type": "Organization",
-            "logo": "https://example.com/logo.png",
-            "name": "Harlan Wilton",
-            "url": "https://example.com/",
           },
         ]
       `)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves harlan-zw/nuxt-schema-org#137

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`defineOrganization()` moved logos onto a second `#organization` node, leaving `#identity` without its logo. Keep the `#logo` reference on plain Organization identities, while preserving the compact node used by specialized organization types.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Schema.org organization logo handling by emitting `logo` as a linked `ImageObject` reference instead of a direct URL.
  * Removed duplicate/extra organization entries from the generated Schema.org graph.
  * Preserved logo metadata and ensured correct primary image relationships.
* **Documentation**
  * Updated the `Organization` logo “Resolves” example to match the simplified output graph.
* **Tests**
  * Updated and expanded Organization/WebPage test snapshots to validate the new logo graph structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->