### PR TITLE
fix(types): support document speculation rules

### DIFF
--- a/packages/unhead/src/types/schema/head.ts
+++ b/packages/unhead/src/types/schema/head.ts
@@ -357,7 +357,16 @@ export type {
 
 // Other types
 export type { MetaFlat } from './metaFlat'
-export type { SpeculationRules } from './struct/speculationRules'
+export type {
+  SpeculationRule,
+  SpeculationRuleDocument,
+  SpeculationRuleEagerness,
+  SpeculationRuleList,
+  SpeculationRuleRequirement,
+  SpeculationRules,
+  SpeculationRuleUrlPattern,
+  SpeculationRuleWhere,
+} from './struct/speculationRules'
 
 // ============================================================================
 // Utility Types for Internal Use

--- a/packages/unhead/src/types/schema/struct/speculationRules.ts
+++ b/packages/unhead/src/types/schema/struct/speculationRules.ts
@@ -1,71 +1,125 @@
 import type { ReferrerPolicy } from '../shared'
 
+/**
+ * A JSON speculation rule set.
+ *
+ * @see https://html.spec.whatwg.org/multipage/speculative-loading.html#speculation-rules
+ */
 export interface SpeculationRules {
+  /** Identifies speculative requests through the `Sec-Speculation-Tags` header. */
+  tag?: string | null
   prefetch?: readonly SpeculationRule[]
   prerender?: readonly SpeculationRule[]
 }
 
-/**
- * A single speculation rule entry.
- *
- * List rules provide explicit `urls`; document rules provide a `where` selector.
- * Both shapes share the same interface so TypeScript doesn't require exact
- * literal `source` values, which avoids widening issues inside `useHead`.
- *
- * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md
- */
-export interface SpeculationRule {
-  /**
-   * The rule source type.
-   *
-   * `'list'` for explicit URL lists, `'document'` for selector-based rules.
-   *
-   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md
-   */
-  source?: 'list' | 'document' | (string & Record<never, never>)
-  /**
-   * Explicit URLs to speculate on (list rules).
-   *
-   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#list-rules
-   */
-  urls?: readonly string[]
-  /**
-   * Selector conditions for document rules.
-   *
-   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#document-rules
-   */
-  where?: SpeculationRuleWhere
-  /**
-   * A hint about how likely the user is to navigate to the URL.
-   *
-   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#scores
-   */
-  score?: number
-  /**
-   * Parse urls/patterns relative to the document's base url.
-   *
-   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#using-the-documents-base-url-for-external-speculation-rule-sets
-   */
-  relative_to?: 'document' | (string & Record<never, never>)
-  /**
-   * Assertions about user agent capabilities required to execute the rule.
-   *
-   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#requirements
-   */
-  requires?: readonly ('anonymous-client-ip-when-cross-origin' | (string & Record<never, never>))[]
-  /**
-   * Where the page expects the prerendered content to be activated.
-   *
-   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#window-name-targeting-hints
-   */
-  target_hint?: '_blank' | '_self' | '_parent' | '_top' | (string & Record<never, never>)
-  /**
-   * The referrer policy for the speculative request.
-   *
-   * @see https://github.com/WICG/nav-speculation/blob/main/triggers.md#explicit-referrer-policy
-   */
+export type SpeculationRuleEagerness
+  = | 'immediate'
+    | 'eager'
+    | 'moderate'
+    | 'conservative'
+    | (string & Record<never, never>)
+
+export type SpeculationRuleRequirement
+  = 'anonymous-client-ip-when-cross-origin'
+
+interface SpeculationRuleBase {
+  /** A hint about when the browser should consider the speculative load. */
+  eagerness?: SpeculationRuleEagerness
+  /** The referrer policy for the speculative request. */
   referrer_policy?: ReferrerPolicy
+  /** Identifies this rule through the `Sec-Speculation-Tags` header. */
+  tag?: string | null
+  /** Required browser capabilities for executing the rule. */
+  requires?: readonly SpeculationRuleRequirement[]
+  /** Expected `No-Vary-Search` response header value. */
+  expects_no_vary_search?: string
+  /** The browsing context in which a prerendered page is expected to open. */
+  target_hint?: '_blank' | '_self' | '_parent' | '_top' | (string & Record<never, never>)
 }
 
-export type SpeculationRuleFn = 'and' | 'or' | 'href_matches' | 'selector_matches' | 'not'
-export type SpeculationRuleWhere = Partial<Record<SpeculationRuleFn, readonly Partial<(Record<SpeculationRuleFn, (Partial<Record<SpeculationRuleFn, string>>) | string>)>[]>>
+/** An explicit list of URLs to speculate. */
+export type SpeculationRuleList = SpeculationRuleBase & {
+  source?: 'list'
+  urls: readonly string[]
+  where?: never
+  /** Selects the base URL used to resolve `urls`. */
+  relative_to?: 'ruleset' | 'document'
+}
+
+/** A rule which selects links from the current document. */
+export type SpeculationRuleDocument = SpeculationRuleBase & {
+  urls?: never
+  relative_to?: never
+} & (
+  | {
+    source: 'document'
+    where?: SpeculationRuleWhere
+  }
+  | {
+    source?: never
+    where: SpeculationRuleWhere
+  }
+)
+
+export type SpeculationRule = SpeculationRuleList | SpeculationRuleDocument
+
+/** The object form accepted by `href_matches`, equivalent to `URLPatternInit`. */
+export interface SpeculationRuleUrlPattern {
+  baseURL?: string
+  protocol?: string
+  username?: string
+  password?: string
+  hostname?: string
+  port?: string
+  pathname?: string
+  search?: string
+  hash?: string
+}
+
+type SpeculationRuleUrlPatternInput = string | SpeculationRuleUrlPattern
+
+/**
+ * A recursive document rule predicate. Exactly one predicate operator is valid
+ * at each level; only `href_matches` also accepts `relative_to`.
+ */
+export type SpeculationRuleWhere
+  = | {
+    and: readonly SpeculationRuleWhere[]
+    or?: never
+    not?: never
+    href_matches?: never
+    selector_matches?: never
+    relative_to?: never
+  }
+  | {
+    and?: never
+    or: readonly SpeculationRuleWhere[]
+    not?: never
+    href_matches?: never
+    selector_matches?: never
+    relative_to?: never
+  }
+  | {
+    and?: never
+    or?: never
+    not: SpeculationRuleWhere
+    href_matches?: never
+    selector_matches?: never
+    relative_to?: never
+  }
+  | {
+    and?: never
+    or?: never
+    not?: never
+    href_matches: SpeculationRuleUrlPatternInput | readonly SpeculationRuleUrlPatternInput[]
+    selector_matches?: never
+    relative_to?: 'ruleset' | 'document'
+  }
+  | {
+    and?: never
+    or?: never
+    not?: never
+    href_matches?: never
+    selector_matches: string | readonly string[]
+    relative_to?: never
+  }

--- a/packages/unhead/test/unit/client/innerHTML.test.ts
+++ b/packages/unhead/test/unit/client/innerHTML.test.ts
@@ -1,4 +1,3 @@
-import type { SpeculationRules } from '../../../src/types'
 import { describe, it } from 'vitest'
 import { useHead } from '../../../src'
 import { useDelayedSerializedDom, useDOMHead } from '../../util'
@@ -19,7 +18,7 @@ describe('dom innerHTML', () => {
         },
         {
           type: 'speculationrules',
-          innerHTML: <SpeculationRules> {
+          innerHTML: {
             prefetch: [
               {
                 source: 'list',

--- a/packages/unhead/test/unit/define.test.ts
+++ b/packages/unhead/test/unit/define.test.ts
@@ -1,3 +1,4 @@
+import type { SpeculationRule, SpeculationRules } from '../../src/types'
 import { useHead } from '../../src/composables'
 import { defineLink, defineScript } from '../../src/define'
 import { createHead } from '../../src/server'
@@ -174,6 +175,55 @@ describe('defineScript', () => {
         },
       }],
     })
+  })
+
+  it('accepts Nuxt noScripts document rules without a cast', () => {
+    const head = createHead()
+    const patterns = ['/about', '/products/*']
+    const rules = patterns.map(href_matches => ({
+      where: { href_matches },
+      eagerness: 'moderate',
+    }))
+    const innerHTML: SpeculationRules = {
+      prefetch: rules,
+      prerender: rules,
+    }
+    head.push({
+      script: [{
+        type: 'speculationrules',
+        innerHTML,
+      }],
+    })
+  })
+
+  it('models the current speculation rules grammar', () => {
+    const rules: SpeculationRules = {
+      tag: 'navigation',
+      prefetch: [{
+        urls: ['/products'],
+        relative_to: 'document',
+        eagerness: 'eager',
+        expects_no_vary_search: 'params=("id")',
+        tag: 'products',
+      }],
+      prerender: [{
+        source: 'document',
+        where: {
+          and: [
+            {
+              href_matches: [{ pathname: '/products/*' }],
+              relative_to: 'document',
+            },
+            { not: { selector_matches: ['[rel~=nofollow]', '.no-prerender'] } },
+          ],
+        },
+      }],
+    }
+    defineScript({ type: 'speculationrules', textContent: rules })
+
+    const acceptRule = (rule: SpeculationRule) => rule
+    // @ts-expect-error list and document selectors are mutually exclusive
+    acceptRule({ urls: ['/'], where: { href_matches: '/*' } })
   })
 
   // Nuxt importmap: structured innerHTML with imports object

--- a/packages/unhead/test/unit/server/innerHTML.test.ts
+++ b/packages/unhead/test/unit/server/innerHTML.test.ts
@@ -55,6 +55,25 @@ describe('ssr innerHTML', () => {
     `)
   })
 
+  it('serializes Nuxt noScripts speculation rules', () => {
+    const head = createServerHeadWithContext()
+    const rules = ['/about', '/products/*'].map(href_matches => ({
+      where: { href_matches },
+      eagerness: 'moderate',
+    }))
+    head.push({
+      script: [{
+        type: 'speculationrules',
+        innerHTML: {
+          prefetch: rules,
+          prerender: rules,
+        },
+      }],
+    })
+
+    expect(renderSSRHead(head).headTags).toBe('<script type="speculationrules">{"prefetch":[{"where":{"href_matches":"/about"},"eagerness":"moderate"},{"where":{"href_matches":"/products/*"},"eagerness":"moderate"}],"prerender":[{"where":{"href_matches":"/about"},"eagerness":"moderate"},{"where":{"href_matches":"/products/*"},"eagerness":"moderate"}]}</script>')
+  })
+
   it('noscript', async () => {
     const head = createServerHeadWithContext()
     head.push({


### PR DESCRIPTION
### 🔗 Linked issue

Related to nuxt/nuxt#35803

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt's `noScripts` renderer emits document speculation rules with `href_matches` and `eagerness`, which Unhead's current types reject without a cast. This updates the types to match the current WHATWG grammar and adds DOM and SSR coverage for structured rule serialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded TypeScript support for speculation rules, including structured rule types, eagerness settings, URL patterns, requirements, and nested conditions.
  - Added support for optional speculation-rule tags.
  - Added stronger type validation for mutually exclusive rule properties.

- **Bug Fixes**
  - Improved client-side and server-side handling and serialization of speculation rules in generated HTML.

- **Tests**
  - Added coverage for typed speculation rules, SSR output, and invalid rule combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->