### PR TITLE
fix: minify declarative JSON script content

### DIFF
--- a/docs/head/1.guides/build-plugins/3.minify-transform.md
+++ b/docs/head/1.guides/build-plugins/3.minify-transform.md
@@ -35,7 +35,7 @@ useHead({
 
 ::
 
-The transform automatically skips `application/json`, `application/ld+json`, `speculationrules`, and `importmap` script types. It ignores strings shorter than 20 characters and dynamic content, including template literals with expressions.
+The transform minifies `application/json`, `application/ld+json`, `speculationrules`, and `importmap` script types with Unhead's built-in JSON minifier. It ignores strings shorter than 20 characters and dynamic content, including template literals with expressions.
 
 ## Setup
 

--- a/docs/head/1.guides/plugins/minify.md
+++ b/docs/head/1.guides/plugins/minify.md
@@ -12,9 +12,9 @@ The Minify plugin hooks into the SSR render pipeline and minifies `innerHTML` co
 
 - **Inline scripts**: Strips comments, preserves string literals, and retains line breaks in common automatic-semicolon-insertion cases
 - **Inline styles**: Strips comments, collapses whitespace, removes trailing semicolons, and strips leading zeros
-- **JSON-LD / application/json**: Re-serializes the value without pretty-printing whitespace
+- **JSON scripts**: Re-serializes `application/ld+json`, `application/json`, `speculationrules`, and `importmap` values without pretty-printing whitespace
 
-It automatically skips `speculationrules` and `importmap` script types, and never increases content length.
+It never increases content length.
 
 Content stored in `textContent` is not minified. Use `innerHTML` or the string shorthand for trusted static code when you want this plugin to process it.
 
@@ -55,7 +55,8 @@ export interface MinifyPluginOptions {
    */
   css?: false | ((code: string) => string)
   /**
-   * Minify JSON script types (application/ld+json, application/json).
+   * Minify JSON script types (application/ld+json, application/json,
+   * speculationrules, importmap).
    * @default true
    */
   json?: boolean

--- a/docs/head/1.guides/plugins/minify.md
+++ b/docs/head/1.guides/plugins/minify.md
@@ -12,7 +12,7 @@ The Minify plugin hooks into the SSR render pipeline and minifies `innerHTML` co
 
 - **Inline scripts**: Strips comments, preserves string literals, and retains line breaks in common automatic-semicolon-insertion cases
 - **Inline styles**: Strips comments, collapses whitespace, removes trailing semicolons, and strips leading zeros
-- **JSON scripts**: Re-serializes `application/ld+json`, `application/json`, `speculationrules`, and `importmap` values without pretty-printing whitespace
+- **JSON scripts**: Strips insignificant whitespace from `application/ld+json`, `application/json`, `speculationrules`, and `importmap` values without changing their tokens
 
 It never increases content length.
 

--- a/packages/bundler/src/unplugin/MinifyTransform.ts
+++ b/packages/bundler/src/unplugin/MinifyTransform.ts
@@ -9,13 +9,14 @@ import { createJsVueTransformIdFilter, isVueScriptRequest, NODE_MODULES_RE, spli
 const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
 const HEAD_RE = /\buse(?:Server)?Head\b/
 
-const SKIP_JS_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
+const JSON_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
 const HEAD_FN_NAMES = new Set(['useHead', 'useServerHead'])
 const CONTENT_PROP_NAMES = ['innerHTML', 'textContent']
 const CONTENT_PROPS = new Set(CONTENT_PROP_NAMES)
 const MINIFY_CACHE_MAX = 100
 
-type TagType = 'script' | 'style'
+type ContentType = 'script' | 'style' | 'json'
+type TagType = Exclude<ContentType, 'json'>
 
 interface PendingMinification {
   end: number
@@ -25,6 +26,16 @@ interface PendingMinification {
 }
 
 export type MinifyFn = (code: string) => Promise<string | null>
+
+const jsonMinifier: MinifyFn = async (code) => {
+  try {
+    return JSON.stringify(JSON.parse(code))
+  }
+  catch {
+    // Invalid declarative JSON stays untouched instead of being interpreted as JavaScript.
+    return code
+  }
+}
 
 export interface MinifyTransformOptions extends BaseTransformerTypes {
   /**
@@ -56,7 +67,8 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
   const doJS = !!jsMinifier
   const doCSS = !!cssMinifier
 
-  const minifyCache: Record<TagType, Map<string, Promise<string | null>>> = {
+  const minifyCache: Record<ContentType, Map<string, Promise<string | null>>> = {
+    json: new Map(),
     script: new Map(),
     style: new Map(),
   }
@@ -143,8 +155,6 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
               if (tagType !== 'script' && tagType !== 'style')
                 continue
 
-              if (tagType === 'script' && !doJS)
-                continue
               if (tagType === 'style' && !doCSS)
                 continue
 
@@ -222,12 +232,14 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
     tagType: TagType,
     pendingMinifications: PendingMinification[],
   ) {
-    // for scripts, check if it's a skippable type
+    let contentType: ContentType = tagType
     if (tagType === 'script') {
       const typeProp = objectNode.properties.find(
         (p: any) => p.type === 'Property' && p.key?.type === 'Identifier' && p.key.name === 'type',
       )
-      if (typeProp?.value?.type === 'Literal' && SKIP_JS_TYPES.has(typeProp.value.value))
+      if (typeProp?.value?.type === 'Literal' && JSON_TYPES.has(typeProp.value.value))
+        contentType = 'json'
+      else if (!doJS)
         return
     }
 
@@ -247,7 +259,7 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
 
         pendingMinifications.push({
           end: prop.value.end,
-          minified: minifyStringContent(raw, tagType),
+          minified: minifyStringContent(raw, contentType),
           raw,
           start: prop.value.start,
         })
@@ -259,7 +271,7 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
 
         pendingMinifications.push({
           end: prop.value.end,
-          minified: minifyStringContent(raw, tagType),
+          minified: minifyStringContent(raw, contentType),
           raw,
           start: prop.value.start,
         })
@@ -267,12 +279,12 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
     }
   }
 
-  function minifyStringContent(content: string, tagType: TagType): Promise<string | null> {
-    const minifier = tagType === 'script' ? jsMinifier : cssMinifier
+  function minifyStringContent(content: string, contentType: ContentType): Promise<string | null> {
+    const minifier = contentType === 'json' ? jsonMinifier : contentType === 'script' ? jsMinifier : cssMinifier
     if (!minifier)
       return Promise.resolve(null)
 
-    const cache = minifyCache[tagType]
+    const cache = minifyCache[contentType]
     const cached = cache.get(content)
     if (cached) {
       cache.delete(content)

--- a/packages/bundler/src/unplugin/MinifyTransform.ts
+++ b/packages/bundler/src/unplugin/MinifyTransform.ts
@@ -3,6 +3,7 @@ import type { BaseTransformerTypes } from './types'
 import MagicString from 'magic-string'
 import { parseSync } from 'oxc-parser'
 import { ScopeTracker, ScopeTrackerImport, walk } from 'oxc-walker'
+import { minifyJSON } from 'unhead/minify'
 import { createUnplugin } from 'unplugin'
 import { createJsVueTransformIdFilter, isVueScriptRequest, NODE_MODULES_RE, splitTransformId } from './utils'
 
@@ -27,15 +28,7 @@ interface PendingMinification {
 
 export type MinifyFn = (code: string) => Promise<string | null>
 
-const jsonMinifier: MinifyFn = async (code) => {
-  try {
-    return JSON.stringify(JSON.parse(code))
-  }
-  catch {
-    // Invalid declarative JSON stays untouched instead of being interpreted as JavaScript.
-    return code
-  }
-}
+const jsonMinifier: MinifyFn = code => Promise.resolve(minifyJSON(code))
 
 export interface MinifyTransformOptions extends BaseTransformerTypes {
   /**
@@ -235,7 +228,10 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
     let contentType: ContentType = tagType
     if (tagType === 'script') {
       const typeProp = objectNode.properties.find(
-        (p: any) => p.type === 'Property' && p.key?.type === 'Identifier' && p.key.name === 'type',
+        (p: any) => p.type === 'Property'
+          && !p.computed
+          && ((p.key?.type === 'Identifier' && p.key.name === 'type')
+            || (p.key?.type === 'Literal' && p.key.value === 'type')),
       )
       if (typeProp?.value?.type === 'Literal' && JSON_TYPES.has(typeProp.value.value))
         contentType = 'json'

--- a/packages/bundler/test/minifyTransform.test.ts
+++ b/packages/bundler/test/minifyTransform.test.ts
@@ -126,6 +126,31 @@ describe('minifyTransform', () => {
     expect(code).toBeUndefined()
   })
 
+  it('minifies declarative JSON with a quoted type key when JS minification is disabled', async () => {
+    const code = await transform([
+      `import { useHead } from 'unhead'`,
+      `useHead({`,
+      `  script: [{ 'type': 'speculationrules', innerHTML: '{ "prefetch":  [{ "urls": [] }] }' }]`,
+      `})`,
+    ], { js: false })
+
+    expect(code).toBeDefined()
+    expect(code).toContain(JSON.stringify('{"prefetch":[{"urls":[]}]}'))
+  })
+
+  it('preserves encoded closing tags in declarative JSON', async () => {
+    const code = await transform([
+      `import { useHead } from 'unhead'`,
+      `useHead({`,
+      `  script: [{ type: 'importmap', innerHTML: '{ "imports": { "x": "\\\\u003C/script>" } }' }]`,
+      `})`,
+    ], { js: mockJSMinifier })
+
+    expect(code).toBeDefined()
+    expect(code).toContain('\\\\u003C/script>')
+    expect(code).not.toContain('<\/script>')
+  })
+
   it('skips short strings below default threshold', async () => {
     const code = await transform([
       `import { useHead } from 'unhead'`,

--- a/packages/bundler/test/minifyTransform.test.ts
+++ b/packages/bundler/test/minifyTransform.test.ts
@@ -98,33 +98,28 @@ describe('minifyTransform', () => {
     expect(code).toBeUndefined()
   })
 
-  it('skips application/ld+json script types', async () => {
+  it.each([
+    ['application/ld+json', '{ "name":  "test",  "value":   123 }', '{"name":"test","value":123}'],
+    ['speculationrules', '{ "prerender":  [{ "where": {} }] }', '{"prerender":[{"where":{}}]}'],
+    ['importmap', '{ "imports":  { "lodash":  "/lodash.js" } }', '{"imports":{"lodash":"/lodash.js"}}'],
+  ])('minifies %s scripts as JSON', async (type, input, output) => {
     const code = await transform([
       `import { useHead } from 'unhead'`,
       `useHead({`,
-      `  script: [{ type: 'application/ld+json', innerHTML: '{ "name":  "test",  "value":   123 }' }]`,
+      `  script: [{ type: '${type}', innerHTML: '${input}' }]`,
       `})`,
     ], { js: mockJSMinifier })
 
-    expect(code).toBeUndefined()
+    expect(code).toBeDefined()
+    expect(code).toContain(JSON.stringify(output))
+    expect(code).not.toContain(input)
   })
 
-  it('skips speculationrules script types', async () => {
+  it('leaves invalid declarative JSON untouched', async () => {
     const code = await transform([
       `import { useHead } from 'unhead'`,
       `useHead({`,
-      `  script: [{ type: 'speculationrules', innerHTML: '{ "prerender":  [{ "where": {} }] }' }]`,
-      `})`,
-    ], { js: mockJSMinifier })
-
-    expect(code).toBeUndefined()
-  })
-
-  it('skips importmap script types', async () => {
-    const code = await transform([
-      `import { useHead } from 'unhead'`,
-      `useHead({`,
-      `  script: [{ type: 'importmap', innerHTML: '{ "imports":  { "lodash":  "/lodash.js" } }' }]`,
+      `  script: [{ type: 'speculationrules', innerHTML: '{ invalid:  JSON with padding }' }]`,
       `})`,
     ], { js: mockJSMinifier })
 

--- a/packages/bundler/vitest.config.ts
+++ b/packages/bundler/vitest.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'node:path'
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  resolve: {
+    alias: {
+      'unhead/minify': resolve(__dirname, '../unhead/src/minify/index.ts'),
+    },
+  },
+  test: {
+    globals: true,
+  },
+})

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       'unhead/stream/unplugin': resolve(__dirname, '../unhead/src/stream/unplugin.ts'),
       'unhead/server': resolve(__dirname, '../unhead/src/server/index.ts'),
       'unhead/client': resolve(__dirname, '../unhead/src/client/index.ts'),
+      'unhead/minify': resolve(__dirname, '../unhead/src/minify/index.ts'),
       'unhead/types': resolve(__dirname, '../unhead/src/types/index.ts'),
       'unhead/plugins': resolve(__dirname, '../unhead/src/plugins/index.ts'),
       'unhead/utils': resolve(__dirname, '../unhead/src/utils/index.ts'),

--- a/packages/solid-js/vitest.config.ts
+++ b/packages/solid-js/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineProject({
       'unhead/stream/unplugin': resolve(__dirname, '../unhead/src/stream/unplugin.ts'),
       'unhead/server': resolve(__dirname, '../unhead/src/server/index.ts'),
       'unhead/client': resolve(__dirname, '../unhead/src/client/index.ts'),
+      'unhead/minify': resolve(__dirname, '../unhead/src/minify/index.ts'),
       'unhead/types': resolve(__dirname, '../unhead/src/types/index.ts'),
       'unhead/plugins': resolve(__dirname, '../unhead/src/plugins/index.ts'),
       'unhead/utils': resolve(__dirname, '../unhead/src/utils/index.ts'),

--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineProject({
       'unhead/stream/unplugin': resolve(__dirname, '../unhead/src/stream/unplugin.ts'),
       'unhead/server': resolve(__dirname, '../unhead/src/server/index.ts'),
       'unhead/client': resolve(__dirname, '../unhead/src/client/index.ts'),
+      'unhead/minify': resolve(__dirname, '../unhead/src/minify/index.ts'),
       'unhead/types': resolve(__dirname, '../unhead/src/types/index.ts'),
       'unhead/plugins': resolve(__dirname, '../unhead/src/plugins/index.ts'),
       'unhead/utils': resolve(__dirname, '../unhead/src/utils/index.ts'),

--- a/packages/unhead/src/minify/json.ts
+++ b/packages/unhead/src/minify/json.ts
@@ -1,12 +1,54 @@
+function isJsonWhitespace(char: string): boolean {
+  return char === ' ' || char === '\n' || char === '\r' || char === '\t'
+}
+
 /**
- * Minify JSON by re-serializing (strips whitespace).
- * Returns the original string unchanged if parsing fails.
+ * Minify JSON by stripping insignificant whitespace without re-serializing tokens.
+ * Returns compact or invalid JSON unchanged.
  */
 export function minifyJSON(code: string): string {
+  let escaped = false
+  let inString = false
+  let segmentStart = 0
+  let chunks: string[] | undefined
+
+  for (let i = 0; i < code.length; i++) {
+    const char = code[i]
+    if (inString) {
+      if (escaped)
+        escaped = false
+      else if (char === '\\')
+        escaped = true
+      else if (char === '"')
+        inString = false
+      continue
+    }
+
+    if (char === '"') {
+      inString = true
+      continue
+    }
+
+    if (isJsonWhitespace(char)) {
+      chunks ||= []
+      if (segmentStart < i)
+        chunks.push(code.slice(segmentStart, i))
+      segmentStart = i + 1
+    }
+  }
+
+  if (!chunks)
+    return code
+
   try {
-    return JSON.stringify(JSON.parse(code))
+    JSON.parse(code)
   }
   catch {
+    // Invalid JSON remains byte-for-byte unchanged.
     return code
   }
+
+  if (segmentStart < code.length)
+    chunks.push(code.slice(segmentStart))
+  return chunks.join('')
 }

--- a/packages/unhead/src/plugins/minify.ts
+++ b/packages/unhead/src/plugins/minify.ts
@@ -15,7 +15,8 @@ export interface MinifyPluginOptions {
    */
   css?: false | ((code: string) => string)
   /**
-   * Minify JSON script types (application/ld+json, application/json).
+   * Minify JSON script types (application/ld+json, application/json,
+   * speculationrules, importmap).
    * @default true
    */
   json?: boolean
@@ -30,8 +31,7 @@ export interface MinifyPluginOptions {
   omitLineBreaks?: boolean
 }
 
-const JSON_TYPES = new Set(['application/json', 'application/ld+json'])
-const SKIP_JS_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
+const JSON_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
 
 /**
  * Minifies inline script and style tag content during SSR rendering.
@@ -76,8 +76,6 @@ export function MinifyPlugin(options?: MinifyPluginOptions): HeadPluginInput {
               }
               continue
             }
-            if (type && SKIP_JS_TYPES.has(type))
-              continue
             if (jsMinify) {
               const min = jsMinify(content)
               if (min.length < content.length)

--- a/packages/unhead/test/unit/minify.test.ts
+++ b/packages/unhead/test/unit/minify.test.ts
@@ -1,3 +1,4 @@
+import { fc, it as fcIt } from '@fast-check/vitest'
 import { describe, expect, it } from 'vitest'
 import { minifyCSS, minifyJS, minifyJSON } from '../../src/minify'
 
@@ -134,5 +135,17 @@ describe('minifyJSON', () => {
 
   it('preserves whitespace inside strings', () => {
     expect(minifyJSON('{ "value": "a  b\\tc" }')).toBe('{"value":"a  b\\tc"}')
+  })
+
+  fcIt.prop([fc.jsonValue()])('preserves arbitrary valid JSON', (value) => {
+    const compact = JSON.stringify(value)
+    const pretty = JSON.stringify(value, null, 2)
+    expect(minifyJSON(compact)).toBe(compact)
+    expect(minifyJSON(pretty)).toBe(compact)
+  })
+
+  fcIt.prop([fc.jsonValue()])('returns arbitrary invalid JSON unchanged', (value) => {
+    const invalid = ` \n${JSON.stringify(value)} trailing`
+    expect(minifyJSON(invalid)).toBe(invalid)
   })
 })

--- a/packages/unhead/test/unit/minify.test.ts
+++ b/packages/unhead/test/unit/minify.test.ts
@@ -118,7 +118,21 @@ describe('minifyJSON', () => {
     expect(minifyJSON(input)).toBe('{"a":1,"b":[1,2,3]}')
   })
 
+  it('returns compact JSON unchanged', () => {
+    const input = '{"value":"spaces stay inside strings"}'
+    expect(minifyJSON(input)).toBe(input)
+  })
+
   it('returns invalid JSON unchanged', () => {
     expect(minifyJSON('not json')).toBe('not json')
+  })
+
+  it('preserves numeric tokens and encoded closing tags', () => {
+    const input = '{\n  "id": 9007199254740993,\n  "close": "\\u003C/script>"\n}'
+    expect(minifyJSON(input)).toBe('{"id":9007199254740993,"close":"\\u003C/script>"}')
+  })
+
+  it('preserves whitespace inside strings', () => {
+    expect(minifyJSON('{ "value": "a  b\\tc" }')).toBe('{"value":"a  b\\tc"}')
   })
 })

--- a/packages/unhead/test/unit/plugins/minify.test.ts
+++ b/packages/unhead/test/unit/plugins/minify.test.ts
@@ -65,22 +65,23 @@ describe('minifyPlugin', () => {
     expect(headTags).toContain('{"@context":"https://schema.org","@type":"Organization","name":"Example Inc"}')
   })
 
-  it('skips speculationrules and importmap types', () => {
+  it.each([
+    ['speculationrules', { prerender: [{ where: { href_matches: '/*' } }] }],
+    ['importmap', { imports: { lodash: '/lodash.js' } }],
+  ] as const)('minifies %s scripts as JSON', (type, value) => {
     const head = createServerHeadWithContext({
       plugins: [MinifyPlugin()],
     })
-    const speculationContent = JSON.stringify({
-      prerender: [{ where: { href_matches: '/*' } }],
-    }, null, 2)
+    const json = JSON.stringify(value, null, 2)
     head.push({
-      script: [{
-        type: 'speculationrules',
-        innerHTML: speculationContent,
-      }],
+      script: type === 'speculationrules'
+        ? [{ type: 'speculationrules', innerHTML: json }]
+        : [{ type: 'importmap', innerHTML: json }],
     })
 
     const { headTags } = head.render()
-    expect(headTags).toContain(speculationContent)
+    expect(headTags).toContain(JSON.stringify(value))
+    expect(headTags).not.toContain(json)
   })
 
   it('skips content shorter than threshold', () => {
@@ -181,13 +182,13 @@ describe('minifyPlugin', () => {
 
   it('omitLineBreaks drops inter-tag separators surgically', () => {
     const head = createServerHeadWithContext({
-      plugins: [MinifyPlugin({ omitLineBreaks: true })],
+      plugins: [MinifyPlugin({ js: false, css: false, json: false, omitLineBreaks: true })],
     })
     head.push({
       script: [
         { innerHTML: 'const a = 1;\nconst b = 2;' },
-        // content minify never touches: its internal newlines must survive,
-        // proving this is a renderer-level join change and not a blanket strip
+        // disabled content minifiers preserve internal newlines, proving this
+        // is a renderer-level join change and not a blanket strip
         { type: 'speculationrules', innerHTML: '{\n  "prerender": []\n}' },
         { type: 'importmap', innerHTML: '{\n  "imports": {}\n}' },
         { innerHTML: 'a =\n1' }, // under the 20-char minify threshold

--- a/packages/unhead/test/unit/plugins/minify.test.ts
+++ b/packages/unhead/test/unit/plugins/minify.test.ts
@@ -84,6 +84,20 @@ describe('minifyPlugin', () => {
     expect(headTags).not.toContain(json)
   })
 
+  it('preserves encoded closing tags in rendered JSON scripts', () => {
+    const head = createServerHeadWithContext({
+      plugins: [MinifyPlugin()],
+    })
+    head.push({
+      script: [{
+        type: 'importmap',
+        innerHTML: '{\n  "imports": {\n    "x": "\\u003C/script>"\n  }\n}',
+      }],
+    })
+
+    expect(head.render().headTags).toBe('<script type="importmap">{"imports":{"x":"\\u003C/script>"}}</script>')
+  })
+
   it('skips content shorter than threshold', () => {
     const head = createServerHeadWithContext({
       plugins: [MinifyPlugin()],

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineProject({
       'unhead/stream/iife': resolve(__dirname, '../unhead/src/stream/iife.ts'),
       'unhead/server': resolve(__dirname, '../unhead/src/server/index.ts'),
       'unhead/client': resolve(__dirname, '../unhead/src/client/index.ts'),
+      'unhead/minify': resolve(__dirname, '../unhead/src/minify/index.ts'),
       'unhead/types': resolve(__dirname, '../unhead/src/types/index.ts'),
       'unhead/plugins': resolve(__dirname, '../unhead/src/plugins/index.ts'),
       'unhead/utils': resolve(__dirname, '../unhead/src/utils/index.ts'),


### PR DESCRIPTION
### 🔗 Linked issue

Related to https://github.com/nuxt/nuxt/pull/35803

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The runtime minifier skipped `speculationrules` and `importmap`, while the build transform skipped every declarative JSON script type. Both now strip insignificant whitespace while preserving numeric and escaped tokens. Compact JSON bypasses parsing, and invalid JSON stays unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON-based script content (`application/json`, `application/ld+json`, `speculationrules`, `importmap`) is now compacted automatically during builds and server-side rendering, including declarative `type` handling.

* **Bug Fixes**
  * JSON minification is now whitespace-stripping (no structural reformatting) and preserves dynamic content, invalid JSON, and encoded closing-tag-like sequences inside strings.

* **Documentation**
  * Updated minify plugin and build-time transform docs to reflect the expanded JSON script type support and behavior.

* **Tests / Chores**
  * Expanded minify/transform test coverage for JSON edge cases and added resolver aliases for `unhead/minify` in Vitest configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->