### PR TITLE
fix(vue): reject ignored server prop resolvers

### DIFF
--- a/packages/vue/src/server.ts
+++ b/packages/vue/src/server.ts
@@ -8,7 +8,7 @@ export { VueHeadMixin } from './VueHeadMixin'
 export { type PreparedTemplate, prepareTemplate, propsToString, renderSSRHead, type SSRHeadPayload, transformHtmlTemplate } from 'unhead/server'
 
 /* @__NO_SIDE_EFFECTS__ */
-export function createHead(options: Omit<CreateServerHeadOptions, 'propsResolver'> = {}): VueHeadClient<UseHeadInput, SSRHeadPayload> {
+export function createHead(options: Omit<CreateServerHeadOptions, 'propResolvers'> = {}): VueHeadClient<UseHeadInput, SSRHeadPayload> {
   const head = _createServerHead({
     ...options,
     propResolvers: [VueResolver],

--- a/packages/vue/src/stream/server.ts
+++ b/packages/vue/src/stream/server.ts
@@ -52,7 +52,7 @@ export interface VueStreamableHeadContext extends Omit<WebStreamableHeadContext<
  * ```
  */
 export function createStreamableHead(
-  options: Omit<CreateStreamableServerHeadOptions, 'propsResolver'> = {},
+  options: Omit<CreateStreamableServerHeadOptions, 'propResolvers'> = {},
 ): VueStreamableHeadContext {
   const { head } = _createStreamableHead({
     ...options,

--- a/packages/vue/test/unit/types.test.ts
+++ b/packages/vue/test/unit/types.test.ts
@@ -4,6 +4,7 @@ import { createHead } from '@unhead/vue/client'
 import { createHead as createServerHead } from '@unhead/vue/server'
 import { computed } from 'vue'
 import { useHead, useHeadSafe } from '../../src/composables'
+import { createStreamableHead } from '../../src/stream/server'
 
 describe('types', () => {
   it('types useHead', () => {
@@ -136,6 +137,12 @@ describe('types', () => {
 
     // @ts-expect-error server render() should not be assignable to boolean
     serverHead.render() satisfies boolean
+  })
+  it('does not accept custom server prop resolvers', () => {
+    // @ts-expect-error Vue installs its own prop resolver
+    createServerHead({ propResolvers: [] })
+    // @ts-expect-error Vue installs its own prop resolver
+    createStreamableHead({ propResolvers: [] })
   })
   it('types nuxt core', () => {
     const payloadURL = 'test'


### PR DESCRIPTION
### 🔗 Linked issue

Found while auditing Nuxt integration types.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The Vue server adapters install `VueResolver` and replace `propResolvers`. Their public types omitted the misspelled `propsResolver`, so callers could pass `propResolvers` even though the adapters discarded it.

This corrects both Vue server entry points, aligns them with the legacy API, and adds type regressions.

Testing: `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `pnpm vitest run`, with 1,782 passed and 8 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected server-side head creation option typing to properly handle built-in Vue property resolvers.
  * Prevented unsupported custom property resolver options from being accepted during type checking.

* **Tests**
  * Added coverage for server and streamable head creation APIs to verify invalid resolver options are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->