### PR TITLE
fix(unhead): render fresh server head into DOM

### DIFF
--- a/packages/unhead/src/client/renderDOMHead.ts
+++ b/packages/unhead/src/client/renderDOMHead.ts
@@ -86,7 +86,7 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
   const dom: Document | undefined = options.document || head.resolvedOptions.document
   const activeState = head._dom as DomStateInternal | undefined
   const documentChanged = !!activeState && activeState._d !== dom
-  if (!dom || (!documentChanged && !head.dirty && !hasPendingEntries(head)))
+  if (!dom || (activeState && !documentChanged && !head.dirty && !hasPendingEntries(head)))
     return false
   if (head._du)
     return false

--- a/packages/unhead/test/unit/client/dom.test.ts
+++ b/packages/unhead/test/unit/client/dom.test.ts
@@ -1,9 +1,23 @@
 import { renderDOMHead } from '@unhead/dom'
 import { describe, expect, it } from 'vitest'
 import { useHead } from '../../../src'
-import { basicSchema, useDelayedSerializedDom, useDOMHead } from '../../util'
+import { basicSchema, createServerHeadWithContext, useDelayedSerializedDom, useDom, useDOMHead } from '../../util'
 
 describe('dom', () => {
+  it('renders a fresh server head into an explicit document once', () => {
+    const document = useDom().window.document
+    const head = createServerHeadWithContext()
+    head.push({
+      title: 'Server title',
+      meta: [{ name: 'description', content: 'Server description' }],
+    })
+
+    expect(renderDOMHead(head, { document })).toBe(true)
+    expect(document.title).toBe('Server title')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Server description')
+    expect(renderDOMHead(head, { document })).toBe(false)
+  })
+
   it('basic', async () => {
     const head = useDOMHead()
 


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`renderDOMHead()` skipped a fresh server head when callers supplied a document because the clean-state guard ran before DOM state initialization. The guard now waits for initialized DOM state, with coverage for the first render and the following clean no-op.