### PR TITLE
fix(react): preserve Helmet default title fallback

### DIFF
--- a/docs/0.react/head/guides/0.get-started/migrate-from-react-helmet.md
+++ b/docs/0.react/head/guides/0.get-started/migrate-from-react-helmet.md
@@ -71,6 +71,8 @@ npm install @unhead/react
 
 For the supported props, your existing `<Helmet>` usage can remain unchanged. On the client, `<Helmet>` automatically creates and manages a head instance, so no provider is needed. Check custom or less common React Helmet props before treating the component as a complete API replacement.
 
+`titleTemplate` applies to a page title. When no title exists, `defaultTitle` is emitted unchanged.
+
 ::note
 For SSR, you still need to wrap your app with `<UnheadProvider>` so you can pass the head instance to `renderSSRHead()`. See [Update Server Rendering](#4-update-server-rendering) below.
 ::

--- a/packages/react/src/helmet.ts
+++ b/packages/react/src/helmet.ts
@@ -29,13 +29,14 @@ function useHelmetHead(): Unhead {
 export interface HelmetProps {
   children?: ReactNode
   /**
-   * A default title to use when no `<title>` child is provided.
+   * A default title to use unchanged when no title is provided.
    *
    * Equivalent to react-helmet's `defaultTitle`.
    */
   defaultTitle?: string
   /**
    * A template for the title. Use `%s` as a placeholder for the page title.
+   * The template is not applied to `defaultTitle`.
    *
    * @example `%s | My Site`
    */
@@ -123,7 +124,9 @@ const Helmet: React.FC<HelmetProps> = ({
     const input: UseHeadInput = {}
 
     if (titleTemplate) {
-      input.titleTemplate = titleTemplate
+      input.titleTemplate = defaultTitle
+        ? title => title ? titleTemplate : defaultTitle
+        : titleTemplate
     }
 
     // Apply prop-based API values first (children override these)
@@ -199,16 +202,12 @@ const Helmet: React.FC<HelmetProps> = ({
       }
     }
 
-    // Apply defaultTitle when no title is provided via props or children
-    if (!hasTitle && defaultTitle) {
-      input.title = defaultTitle
-    }
-
-    // Pass defaultTitle through templateParams for titleTemplate support
-    if (defaultTitle) {
-      input.templateParams = {
-        ...input.templateParams as any,
-        defaultTitle,
+    // A low-priority title acts as a fallback across sibling Helmet entries.
+    // When titleTemplate exists, its resolver emits defaultTitle only if no real title won.
+    if (!hasTitle && defaultTitle && !titleTemplate) {
+      input.title = {
+        textContent: defaultTitle,
+        tagPriority: 'low',
       }
     }
 

--- a/packages/react/test/helmet.test.tsx
+++ b/packages/react/test/helmet.test.tsx
@@ -73,7 +73,7 @@ describe('helmet compat', () => {
     expect(headTags).not.toContain('My Site')
   })
 
-  it('uses defaultTitle with titleTemplate', async () => {
+  it('does not apply titleTemplate to defaultTitle', async () => {
     const head = createHead()
 
     render(
@@ -85,7 +85,26 @@ describe('helmet compat', () => {
     )
 
     const { headTags } = renderSSRHead(head)
-    expect(headTags).toContain('<title>Home | My Site</title>')
+    expect(headTags).toContain('<title>Home</title>')
+    expect(headTags).not.toContain('Home | My Site')
+  })
+
+  it('does not let a later root fallback override a sibling page title', async () => {
+    const head = createHead()
+
+    render(
+      <UnheadProvider head={head}>
+        <>
+          <Helmet>
+            <title>Explore</title>
+          </Helmet>
+          <Helmet defaultTitle="Mastodon" titleTemplate="%s | Mastodon" />
+        </>
+      </UnheadProvider>,
+    )
+
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).toContain('<title>Explore | Mastodon</title>')
   })
 
   it('calls onChangeClientState after DOM render', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The React Helmet adapter treated `defaultTitle` as a normal title, so a later root entry could replace the page title. It now keeps `defaultTitle` as a low-priority fallback and applies `titleTemplate` only to a real page title.