### PR TITLE
fix(react): standardize provider instance prop

### DIFF
--- a/docs/0.react/head/guides/0.get-started/1.installation.md
+++ b/docs/0.react/head/guides/0.get-started/1.installation.md
@@ -28,6 +28,8 @@ Install the `@unhead/react`{lang="bash"} dependency in your project.
 
 Create the browser instance from `@unhead/react/client`{lang="bash"}. In a Vite SSR app this usually belongs in `entry-client.ts`; in an SPA, put it in the main entry.
 
+The `value` prop supplies the head instance for browser, server, and streaming providers. The browser provider also accepts the deprecated `head` prop for compatibility.
+
 ```tsx {1,7,12,14} [src/entry-client.ts]
 import { createHead, UnheadProvider } from '@unhead/react/client'
 import { StrictMode } from 'react'
@@ -40,7 +42,7 @@ const head = createHead()
 hydrateRoot(
   document.getElementById('root') as HTMLElement,
   <StrictMode>
-    <UnheadProvider head={head}>
+    <UnheadProvider value={head}>
       <App />
     </UnheadProvider>
   </StrictMode>,

--- a/docs/0.react/head/guides/1.core-concepts/2.reactivity.md
+++ b/docs/0.react/head/guides/1.core-concepts/2.reactivity.md
@@ -23,7 +23,7 @@ const head = createHead()
 
 function App() {
   return (
-    <UnheadProvider head={head}>
+    <UnheadProvider value={head}>
       <YourApp />
     </UnheadProvider>
   )

--- a/examples/vite-ssr-react-ts/src/entry-client.tsx
+++ b/examples/vite-ssr-react-ts/src/entry-client.tsx
@@ -9,8 +9,8 @@ const head = createHead({ /* config */ })
 hydrateRoot(
   document.getElementById('root') as HTMLElement,
   <StrictMode>
-    <UnheadProvider head={head}>
-    <App />
+    <UnheadProvider value={head}>
+      <App />
     </UnheadProvider>
   </StrictMode>,
 )

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -45,12 +45,14 @@ const head = createHead({ /* config */ })
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <UnheadProvider head={head}>
+    <UnheadProvider value={head}>
       <App />
     </UnheadProvider>
   </StrictMode>
 )
 ```
+
+Use the `value` prop with client, server, and streaming providers. The client provider still accepts the deprecated `head` prop for compatibility.
 
 #### Server-side (SSR)
 
@@ -86,7 +88,7 @@ const head = createHead({ /* config */ })
 hydrateRoot(
   document.getElementById('root'),
   <StrictMode>
-    <UnheadProvider head={head}>
+    <UnheadProvider value={head}>
       <App />
     </UnheadProvider>
   </StrictMode>

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import type { ClientUnhead } from 'unhead/client'
 import type { CreateClientHeadOptions, Unhead } from 'unhead/types'
+import type { UniversalUnheadProviderProps } from './context'
 import { createElement, useRef } from 'react'
 import { createHead as _createHead, createDebouncedFn, createDomRenderer } from 'unhead/client'
 import { UnheadContext } from './context'
@@ -15,16 +16,28 @@ export function createHead(options: CreateClientHeadOptions = {}): ClientUnhead 
   return head
 }
 
-export interface UnheadProviderProps {
+interface LegacyUnheadProviderProps {
   children: ReactNode
-  head?: Unhead<any, any>
+  value?: never
+  /**
+   * @deprecated Use `value` for a consistent provider API across client and server entries.
+   */
+  head?: Unhead
 }
 
-export function UnheadProvider({ children, head }: UnheadProviderProps) {
-  const headRef = useRef<Unhead<any, any> | null>(null)
-  if (!head && !headRef.current)
+export type UnheadProviderProps
+  = | (UniversalUnheadProviderProps & { head?: never })
+    | LegacyUnheadProviderProps
+
+export function UnheadProvider({ children, value, head }: UnheadProviderProps) {
+  const headRef = useRef<Unhead | null>(null)
+  if (value !== undefined && head !== undefined)
+    throw new TypeError('UnheadProvider received both value and head props')
+
+  const suppliedHead = value ?? head
+  if (suppliedHead === undefined && headRef.current === null)
     headRef.current = createHead()
-  return createElement(UnheadContext.Provider, { value: head || headRef.current }, children)
+  return createElement(UnheadContext.Provider, { value: suppliedHead ?? headRef.current }, children)
 }
 
 export type {

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,4 +1,10 @@
+import type { ReactNode } from 'react'
 import type { Unhead } from 'unhead/types'
 import { createContext } from 'react'
+
+export interface UniversalUnheadProviderProps {
+  children: ReactNode
+  value: Unhead
+}
 
 export const UnheadContext = /* @__PURE__ */ createContext<Unhead | null>(null)

--- a/packages/react/src/server.ts
+++ b/packages/react/src/server.ts
@@ -1,14 +1,10 @@
-import type { ReactNode } from 'react'
-import type { Unhead } from 'unhead/types'
+import type { UniversalUnheadProviderProps } from './context'
 import { createElement } from 'react'
 import { UnheadContext } from './context'
 
 export { createHead, type PreparedTemplate, prepareTemplate, renderSSRHead, transformHtmlTemplate } from 'unhead/server'
 
-export interface UnheadProviderProps {
-  children: ReactNode
-  value: Unhead
-}
+export type UnheadProviderProps = UniversalUnheadProviderProps
 
 export function UnheadProvider({ children, value }: UnheadProviderProps) {
   return createElement(UnheadContext.Provider, { value }, children)

--- a/packages/react/src/stream/client.ts
+++ b/packages/react/src/stream/client.ts
@@ -1,12 +1,9 @@
 import type { ReactNode } from 'react'
-import type { Unhead } from 'unhead/types'
+import type { UniversalUnheadProviderProps } from '../context'
 import { createElement } from 'react'
 import { UnheadContext } from '../context'
 
-export interface UnheadProviderProps {
-  children: ReactNode
-  value: Unhead
-}
+export type UnheadProviderProps = UniversalUnheadProviderProps
 
 export function UnheadProvider({ value, children }: UnheadProviderProps): ReactNode {
   return createElement(UnheadContext.Provider, { value }, children)

--- a/packages/react/src/stream/server.ts
+++ b/packages/react/src/stream/server.ts
@@ -1,7 +1,8 @@
 import type { Writable } from 'node:stream'
 import type { ReactNode } from 'react'
 import type { CreateStreamableServerHeadOptions, PreparedTemplate, StreamableHeadContext } from 'unhead/stream/server'
-import type { ResolvableHead, Unhead } from 'unhead/types'
+import type { ResolvableHead } from 'unhead/types'
+import type { UniversalUnheadProviderProps } from '../context'
 import { PassThrough } from 'node:stream'
 import { createElement, useContext } from 'react'
 import {
@@ -11,10 +12,7 @@ import {
 } from 'unhead/stream/server'
 import { UnheadContext } from '../context'
 
-export interface UnheadProviderProps {
-  children: ReactNode
-  value: Unhead
-}
+export type UnheadProviderProps = UniversalUnheadProviderProps
 
 export function UnheadProvider({ value, children }: UnheadProviderProps): ReactNode {
   return createElement(UnheadContext.Provider, { value }, children)

--- a/packages/react/test/public-types.test.ts
+++ b/packages/react/test/public-types.test.ts
@@ -1,4 +1,5 @@
-import type { ComponentProps } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
+import type { Unhead } from 'unhead/types'
 import type { Head, HeadProps } from '../src'
 import type { UnheadProvider as ClientUnheadProvider, UnheadProviderProps as ClientUnheadProviderProps } from '../src/client'
 import type { UnheadProvider as ServerUnheadProvider, UnheadProviderProps as ServerUnheadProviderProps } from '../src/server'
@@ -15,4 +16,35 @@ it('exports provider props from each React entry', () => {
   expectTypeOf<ComponentProps<typeof ServerUnheadProvider>>().toEqualTypeOf<ServerUnheadProviderProps>()
   expectTypeOf<ComponentProps<typeof StreamClientUnheadProvider>>().toEqualTypeOf<StreamClientUnheadProviderProps>()
   expectTypeOf<ComponentProps<typeof StreamServerUnheadProvider>>().toEqualTypeOf<StreamServerUnheadProviderProps>()
+})
+
+it('accepts the universal value prop from every provider entry', () => {
+  interface UniversalProps {
+    children: ReactNode
+    value: Unhead
+  }
+
+  expectTypeOf<UniversalProps>().toMatchTypeOf<ClientUnheadProviderProps>()
+  expectTypeOf<ServerUnheadProviderProps>().toEqualTypeOf<UniversalProps>()
+  expectTypeOf<StreamClientUnheadProviderProps>().toEqualTypeOf<UniversalProps>()
+  expectTypeOf<StreamServerUnheadProviderProps>().toEqualTypeOf<UniversalProps>()
+})
+
+it('keeps legacy client props without allowing conflicting instances', () => {
+  interface AutomaticProps {
+    children: ReactNode
+  }
+  interface LegacyProps {
+    children: ReactNode
+    head: Unhead
+  }
+  interface ConflictingProps {
+    children: ReactNode
+    head: Unhead
+    value: Unhead
+  }
+
+  expectTypeOf<AutomaticProps>().toMatchTypeOf<ClientUnheadProviderProps>()
+  expectTypeOf<LegacyProps>().toMatchTypeOf<ClientUnheadProviderProps>()
+  expectTypeOf<ConflictingProps>().not.toMatchTypeOf<ClientUnheadProviderProps>()
 })

--- a/packages/react/test/useHead.test.tsx
+++ b/packages/react/test/useHead.test.tsx
@@ -81,6 +81,31 @@ describe('useHead hook', () => {
     expect(headTags).toContain('<title>Updated Title</title>')
   })
 
+  it('uses the head instance supplied through the universal value prop', () => {
+    const head = createHead()
+
+    render(
+      <UnheadProvider value={head}>
+        <TestComponent />
+      </UnheadProvider>,
+    )
+
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).toContain('<title>Initial Title</title>')
+  })
+
+  it('rejects conflicting value and head props', () => {
+    const value = createHead()
+    const head = createHead()
+
+    expect(() => render(
+      // @ts-expect-error provider instances must be supplied through one prop
+      <UnheadProvider value={value} head={head}>
+        <TestComponent />
+      </UnheadProvider>,
+    )).toThrowError('UnheadProvider received both value and head props')
+  })
+
   it('initializes input value with state', () => {
     const head = createHead()
 


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The browser `UnheadProvider` accepted `head`, while the server and streaming providers accepted `value`; universal wrappers could ignore the supplied browser instance and create another head. All providers now accept `value`, while the browser keeps the deprecated `head` alias and rejects conflicting props.