### PR TITLE
fix(unhead): dedupe scalar Open Graph and Twitter metadata

### DIFF
--- a/docs/head/1.guides/1.core-concepts/6.handling-duplicates.md
+++ b/docs/head/1.guides/1.core-concepts/6.handling-duplicates.md
@@ -119,7 +119,7 @@ useHead({
 ```
 
 ::tip
-This behavior applies to the meta groups that Unhead marks as arrayable, including verification, Open Graph, article, book, profile, Twitter, and author metadata. Other duplicate meta names still resolve to one tag, even within the same entry.
+This behavior applies to the meta groups that Unhead marks as arrayable, including verification, Open Graph, article, book, profile, structured Twitter image, and author metadata. Scalar Twitter metadata such as `twitter:card`, `twitter:title`, and `twitter:description` resolves to one tag, even within the same entry.
 ::
 
 ### Multiple Links with the Same rel and href

--- a/docs/head/1.guides/1.core-concepts/6.handling-duplicates.md
+++ b/docs/head/1.guides/1.core-concepts/6.handling-duplicates.md
@@ -119,7 +119,7 @@ useHead({
 ```
 
 ::tip
-This behavior applies to the meta groups that Unhead marks as arrayable, including verification, Open Graph, article, book, profile, structured Twitter image, and author metadata. Scalar Twitter metadata such as `twitter:card`, `twitter:title`, and `twitter:description` resolves to one tag, even within the same entry.
+Within one entry, Unhead keeps repeated `theme-color`, `google-site-verification`, and `author` tags. It also keeps Open Graph image, audio, video, and alternate locale arrays; article and book author/tag arrays; and deprecated Twitter image arrays. For every other duplicate meta name, the last tag wins.
 ::
 
 ### Multiple Links with the Same rel and href

--- a/packages/unhead/src/utils/const.ts
+++ b/packages/unhead/src/utils/const.ts
@@ -15,12 +15,16 @@ export const UsesMergeStrategy = /* @__PURE__ */ new Set(['templateParams', 'htm
 export const MetaTagsArrayable = /* @__PURE__ */ new Set([
   'theme-color',
   'google-site-verification',
-  'og',
-  'article',
-  'book',
-  'profile',
-  'twitter',
   'author',
+  'og:locale:alternate',
+  'og:image',
+  'og:video',
+  'og:audio',
+  'article:author',
+  'article:tag',
+  'book:author',
+  'book:tag',
+  'twitter:image',
 ])
 
 export const TagPriorityAliases = /* @__PURE__ */ { critical: -8, high: -1, low: 2 } as const

--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -9,7 +9,10 @@ export function isMetaArrayDupeKey(v: string) {
   if (i === -1)
     return false
   const j = v.indexOf(':', i + 1)
-  return MetaTagsArrayable.has(v.slice(i + 1, j === -1 ? v.length : j))
+  const namespace = v.slice(i + 1, j === -1 ? v.length : j)
+  if (namespace === 'twitter')
+    return v === 'meta:twitter:image' || v.startsWith('meta:twitter:image:')
+  return MetaTagsArrayable.has(namespace)
 }
 
 export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {

--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -8,11 +8,12 @@ export function isMetaArrayDupeKey(v: string) {
   const i = v.indexOf(':')
   if (i === -1)
     return false
-  const j = v.indexOf(':', i + 1)
-  const namespace = v.slice(i + 1, j === -1 ? v.length : j)
-  if (namespace === 'twitter')
-    return v === 'meta:twitter:image' || v.startsWith('meta:twitter:image:')
-  return MetaTagsArrayable.has(namespace)
+  const key = v.slice(i + 1)
+  return MetaTagsArrayable.has(key)
+    || key.startsWith('og:image:')
+    || key.startsWith('og:video:')
+    || key.startsWith('og:audio:')
+    || key.startsWith('twitter:image:')
 }
 
 export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {

--- a/packages/unhead/test/unit/client/duplicates.test.ts
+++ b/packages/unhead/test/unit/client/duplicates.test.ts
@@ -3,11 +3,15 @@ import { useSeoMeta } from '../../../src'
 import { getActiveDom, useDOMHead } from '../../util'
 
 describe('dom', () => {
-  it('dedupes scalar Twitter metadata and preserves structured images', async () => {
+  it('dedupes scalar social metadata and preserves structured images', async () => {
     const head = useDOMHead()
 
     head.push({
       meta: [
+        { property: 'og:title', content: 'Old Open Graph title' },
+        { property: 'og:title', content: 'New Open Graph title' },
+        { property: 'og:description', content: 'Old Open Graph description' },
+        { property: 'og:description', content: 'New Open Graph description' },
         { name: 'twitter:card', content: 'summary' },
         { name: 'twitter:card', content: 'summary_large_image' },
         { name: 'twitter:title', content: 'Old title' },
@@ -17,6 +21,10 @@ describe('dom', () => {
       ],
     })
     useSeoMeta(head, {
+      ogImage: [
+        { url: '/first-og.png', alt: 'First Open Graph image' },
+        { url: '/second-og.png', alt: 'Second Open Graph image' },
+      ],
       twitterImage: [
         { url: '/first.png', alt: 'First image' },
         { url: '/second.png', alt: 'Second image' },
@@ -25,15 +33,19 @@ describe('dom', () => {
 
     await new Promise(resolve => setTimeout(resolve, 10))
     const document = head.resolvedOptions.document!
-    const contents = (name: string) =>
-      [...document.querySelectorAll(`meta[name="${name}"]`)]
+    const contents = (attribute: 'name' | 'property', name: string) =>
+      [...document.querySelectorAll(`meta[${attribute}="${name}"]`)]
         .map(tag => tag.getAttribute('content'))
 
-    expect(contents('twitter:card')).toEqual(['summary_large_image'])
-    expect(contents('twitter:title')).toEqual(['New title'])
-    expect(contents('twitter:description')).toEqual(['New description'])
-    expect(contents('twitter:image')).toEqual(['/first.png', '/second.png'])
-    expect(contents('twitter:image:alt')).toEqual(['First image', 'Second image'])
+    expect(contents('property', 'og:title')).toEqual(['New Open Graph title'])
+    expect(contents('property', 'og:description')).toEqual(['New Open Graph description'])
+    expect(contents('property', 'og:image')).toEqual(['/first-og.png', '/second-og.png'])
+    expect(contents('property', 'og:image:alt')).toEqual(['First Open Graph image', 'Second Open Graph image'])
+    expect(contents('name', 'twitter:card')).toEqual(['summary_large_image'])
+    expect(contents('name', 'twitter:title')).toEqual(['New title'])
+    expect(contents('name', 'twitter:description')).toEqual(['New description'])
+    expect(contents('name', 'twitter:image')).toEqual(['/first.png', '/second.png'])
+    expect(contents('name', 'twitter:image:alt')).toEqual(['First image', 'Second image'])
   })
 
   it('basic', async () => {

--- a/packages/unhead/test/unit/client/duplicates.test.ts
+++ b/packages/unhead/test/unit/client/duplicates.test.ts
@@ -1,7 +1,41 @@
 import { describe, expect, it } from 'vitest'
+import { useSeoMeta } from '../../../src'
 import { getActiveDom, useDOMHead } from '../../util'
 
 describe('dom', () => {
+  it('dedupes scalar Twitter metadata and preserves structured images', async () => {
+    const head = useDOMHead()
+
+    head.push({
+      meta: [
+        { name: 'twitter:card', content: 'summary' },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: 'Old title' },
+        { name: 'twitter:title', content: 'New title' },
+        { name: 'twitter:description', content: 'Old description' },
+        { name: 'twitter:description', content: 'New description' },
+      ],
+    })
+    useSeoMeta(head, {
+      twitterImage: [
+        { url: '/first.png', alt: 'First image' },
+        { url: '/second.png', alt: 'Second image' },
+      ],
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+    const document = head.resolvedOptions.document!
+    const contents = (name: string) =>
+      [...document.querySelectorAll(`meta[name="${name}"]`)]
+        .map(tag => tag.getAttribute('content'))
+
+    expect(contents('twitter:card')).toEqual(['summary_large_image'])
+    expect(contents('twitter:title')).toEqual(['New title'])
+    expect(contents('twitter:description')).toEqual(['New description'])
+    expect(contents('twitter:image')).toEqual(['/first.png', '/second.png'])
+    expect(contents('twitter:image:alt')).toEqual(['First image', 'Second image'])
+  })
+
   it('basic', async () => {
     const head = useDOMHead()
 

--- a/packages/unhead/test/unit/dedupe.test.ts
+++ b/packages/unhead/test/unit/dedupe.test.ts
@@ -1,4 +1,14 @@
-import { dedupeKey, hashTag } from '../../src/utils/dedupe'
+import { dedupeKey, hashTag, isMetaArrayDupeKey } from '../../src/utils/dedupe'
+
+describe('isMetaArrayDupeKey', () => {
+  it('only treats structured Twitter images as arrayable', () => {
+    expect(isMetaArrayDupeKey('meta:twitter:card')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:twitter:title')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:twitter:description')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:twitter:image')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:twitter:image:alt')).toBe(true)
+  })
+})
 
 describe('dedupeKey', () => {
   it('uses rel + href for link identity regardless of other props', () => {

--- a/packages/unhead/test/unit/dedupe.test.ts
+++ b/packages/unhead/test/unit/dedupe.test.ts
@@ -1,10 +1,30 @@
 import { dedupeKey, hashTag, isMetaArrayDupeKey } from '../../src/utils/dedupe'
 
 describe('isMetaArrayDupeKey', () => {
-  it('only treats structured Twitter images as arrayable', () => {
+  it('rejects scalar Open Graph and Twitter metadata', () => {
+    expect(isMetaArrayDupeKey('meta:og:title')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:og:description')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:article:section')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:book:isbn')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:profile:username')).toBe(false)
     expect(isMetaArrayDupeKey('meta:twitter:card')).toBe(false)
     expect(isMetaArrayDupeKey('meta:twitter:title')).toBe(false)
     expect(isMetaArrayDupeKey('meta:twitter:description')).toBe(false)
+  })
+
+  it('accepts repeatable metadata', () => {
+    expect(isMetaArrayDupeKey('meta:theme-color')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:google-site-verification')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:author')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:og:locale:alternate')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:og:image')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:og:image:alt')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:og:audio:type')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:og:video:width')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:article:author')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:article:tag')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:book:author')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:book:tag')).toBe(true)
     expect(isMetaArrayDupeKey('meta:twitter:image')).toBe(true)
     expect(isMetaArrayDupeKey('meta:twitter:image:alt')).toBe(true)
   })

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -4,11 +4,15 @@ import { renderSSRHead } from '../../../src/server'
 import { createServerHeadWithContext } from '../../util'
 
 describe('dedupe', () => {
-  it('dedupes scalar Twitter metadata and preserves structured images', () => {
+  it('dedupes scalar social metadata and preserves structured images', () => {
     const head = createServerHeadWithContext()
 
     useHead(head, {
       meta: [
+        { property: 'og:title', content: 'Old Open Graph title' },
+        { property: 'og:title', content: 'New Open Graph title' },
+        { property: 'og:description', content: 'Old Open Graph description' },
+        { property: 'og:description', content: 'New Open Graph description' },
         { name: 'twitter:card', content: 'summary' },
         { name: 'twitter:card', content: 'summary_large_image' },
         { name: 'twitter:title', content: 'Old title' },
@@ -18,6 +22,10 @@ describe('dedupe', () => {
       ],
     })
     useSeoMeta(head, {
+      ogImage: [
+        { url: '/first-og.png', alt: 'First Open Graph image' },
+        { url: '/second-og.png', alt: 'Second Open Graph image' },
+      ],
       twitterImage: [
         { url: '/first.png', alt: 'First image' },
         { url: '/second.png', alt: 'Second image' },
@@ -25,15 +33,19 @@ describe('dedupe', () => {
     })
 
     const { headTags } = renderSSRHead(head)
-    const contents = (name: string) =>
-      [...headTags.matchAll(new RegExp(`<meta name="${name}" content="([^"]+)">`, 'g'))]
+    const contents = (attribute: 'name' | 'property', name: string) =>
+      [...headTags.matchAll(new RegExp(`<meta ${attribute}="${name}" content="([^"]+)">`, 'g'))]
         .map(match => match[1])
 
-    expect(contents('twitter:card')).toEqual(['summary_large_image'])
-    expect(contents('twitter:title')).toEqual(['New title'])
-    expect(contents('twitter:description')).toEqual(['New description'])
-    expect(contents('twitter:image')).toEqual(['/first.png', '/second.png'])
-    expect(contents('twitter:image:alt')).toEqual(['First image', 'Second image'])
+    expect(contents('property', 'og:title')).toEqual(['New Open Graph title'])
+    expect(contents('property', 'og:description')).toEqual(['New Open Graph description'])
+    expect(contents('property', 'og:image')).toEqual(['/first-og.png', '/second-og.png'])
+    expect(contents('property', 'og:image:alt')).toEqual(['First Open Graph image', 'Second Open Graph image'])
+    expect(contents('name', 'twitter:card')).toEqual(['summary_large_image'])
+    expect(contents('name', 'twitter:title')).toEqual(['New title'])
+    expect(contents('name', 'twitter:description')).toEqual(['New description'])
+    expect(contents('name', 'twitter:image')).toEqual(['/first.png', '/second.png'])
+    expect(contents('name', 'twitter:image:alt')).toEqual(['First image', 'Second image'])
   })
 
   it('arrays', async () => {

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -1,9 +1,41 @@
 import { describe, it } from 'vitest'
-import { useHead } from '../../../src'
+import { useHead, useSeoMeta } from '../../../src'
 import { renderSSRHead } from '../../../src/server'
 import { createServerHeadWithContext } from '../../util'
 
 describe('dedupe', () => {
+  it('dedupes scalar Twitter metadata and preserves structured images', () => {
+    const head = createServerHeadWithContext()
+
+    useHead(head, {
+      meta: [
+        { name: 'twitter:card', content: 'summary' },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: 'Old title' },
+        { name: 'twitter:title', content: 'New title' },
+        { name: 'twitter:description', content: 'Old description' },
+        { name: 'twitter:description', content: 'New description' },
+      ],
+    })
+    useSeoMeta(head, {
+      twitterImage: [
+        { url: '/first.png', alt: 'First image' },
+        { url: '/second.png', alt: 'Second image' },
+      ],
+    })
+
+    const { headTags } = renderSSRHead(head)
+    const contents = (name: string) =>
+      [...headTags.matchAll(new RegExp(`<meta name="${name}" content="([^"]+)">`, 'g'))]
+        .map(match => match[1])
+
+    expect(contents('twitter:card')).toEqual(['summary_large_image'])
+    expect(contents('twitter:title')).toEqual(['New title'])
+    expect(contents('twitter:description')).toEqual(['New description'])
+    expect(contents('twitter:image')).toEqual(['/first.png', '/second.png'])
+    expect(contents('twitter:image:alt')).toEqual(['First image', 'Second image'])
+  })
+
   it('arrays', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -39,13 +39,17 @@ describe('dedupe', () => {
 
     expect(contents('property', 'og:title')).toEqual(['New Open Graph title'])
     expect(contents('property', 'og:description')).toEqual(['New Open Graph description'])
-    expect(contents('property', 'og:image')).toEqual(['/first-og.png', '/second-og.png'])
-    expect(contents('property', 'og:image:alt')).toEqual(['First Open Graph image', 'Second Open Graph image'])
+    expect(headTags).toContain(`<meta property="og:image" content="/first-og.png">
+<meta property="og:image:alt" content="First Open Graph image">
+<meta property="og:image" content="/second-og.png">
+<meta property="og:image:alt" content="Second Open Graph image">`)
     expect(contents('name', 'twitter:card')).toEqual(['summary_large_image'])
     expect(contents('name', 'twitter:title')).toEqual(['New title'])
     expect(contents('name', 'twitter:description')).toEqual(['New description'])
-    expect(contents('name', 'twitter:image')).toEqual(['/first.png', '/second.png'])
-    expect(contents('name', 'twitter:image:alt')).toEqual(['First image', 'Second image'])
+    expect(headTags).toContain(`<meta name="twitter:image" content="/first.png">
+<meta name="twitter:image:alt" content="First image">
+<meta name="twitter:image" content="/second.png">
+<meta name="twitter:image:alt" content="Second image">`)
   })
 
   it('arrays', async () => {

--- a/packages/vue/test/unit/e2e/basic.test.ts
+++ b/packages/vue/test/unit/e2e/basic.test.ts
@@ -92,7 +92,6 @@ describe('vue e2e', () => {
       <script src="https://my-app.com/home.js"></script>
       <meta property="og:title" content="My amazing site">
       <meta property="og:description" content="This is my amazing site">
-      <meta property="og:locale" content="en_US">
       <meta property="og:locale" content="en_AU">
       <meta property="og:image" content="https://cdn.example.com/image.jpg">
       <meta property="og:image" content="https://cdn.example.com/image2.jpg">
@@ -132,7 +131,6 @@ describe('vue e2e', () => {
       <script src="https://my-app.com/home.js"></script>
       <meta property="og:title" content="Home">
       <meta property="og:description" content="This is my amazing site">
-      <meta property="og:locale" content="en_US">
       <meta property="og:locale" content="en_AU">
       <meta property="og:image" content="https://cdn.example.com/image.jpg">
       <meta property="og:image" content="https://cdn.example.com/image2.jpg">


### PR DESCRIPTION
### 🔗 Linked issue

Related to #842

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Unhead kept duplicate `og:title`, `article:section`, and other scalar properties because array handling applied to whole namespaces.

Array handling now follows the schema: Open Graph media and alternate locales, article and book authors and tags, and deprecated Twitter image groups remain repeatable. Other duplicates use the existing last-tag-wins rule in SSR and the DOM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved duplicate-handling for Open Graph and Twitter meta tags so scalar values keep only the latest entry.
  - Preserves repeated structured image metadata (including corresponding alt text) in the correct order.
  - Refined which specific repeated fields are treated as multi-value.
- **Documentation**
  - Clarified which metadata fields support multiple values within a single head call, and how other duplicates are resolved.
- **Tests**
  - Expanded unit and SSR/CSR test coverage for the updated deduping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->