### PR TITLE
fix(unhead): reconcile adopted meta identity attributes

### DIFF
--- a/packages/unhead/src/client/renderDOMHead.ts
+++ b/packages/unhead/src/client/renderDOMHead.ts
@@ -7,7 +7,7 @@ import type {
   Unhead,
 } from '../types'
 import { HasElementTags } from '../utils/const'
-import { dedupeKey, hashTag, isMetaArrayDupeKey } from '../utils/dedupe'
+import { dedupeKey, hashTag, isMetaArrayDupeKey, MetaKeyAttrs } from '../utils/dedupe'
 import { normalizeProps } from '../utils/normalize'
 
 /**
@@ -107,6 +107,13 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
     function trackCtx({ id, $el, tag }: DomRenderTagContext) {
       const isAttrTag = tag.tag.endsWith('Attrs')
       state.elMap.set(id, $el)
+      if (tag.tag === 'meta') {
+        for (const k of MetaKeyAttrs) {
+          const value = tag.props[k]
+          if ((value === undefined || value === null) && $el.hasAttribute(k))
+            $el.removeAttribute(k)
+        }
+      }
       if (!isAttrTag) {
         if (tag.textContent && tag.textContent !== $el.textContent) {
           $el.textContent = tag.textContent

--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -1,7 +1,7 @@
 import type { HeadTag } from '../types'
 import { MetaTagsArrayable, TagsWithInnerContent, UniqueTags } from './const'
 
-const allowedMetaProperties = ['name', 'property', 'http-equiv']
+export const MetaKeyAttrs = ['name', 'property', 'http-equiv'] as const
 
 // Standard single-value meta tags that should always deduplicate
 // Tags not included here can be duped by using content: ['one', 'two']
@@ -41,7 +41,7 @@ export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {
     return 'charset'
 
   if (tag.tag === 'meta') {
-    for (const n of allowedMetaProperties) {
+    for (const n of MetaKeyAttrs) {
       // open graph props can have multiple tags with the same property
       if (props[n] !== undefined) {
         const propValue = props[n]

--- a/packages/unhead/test/unit/client/dom.test.ts
+++ b/packages/unhead/test/unit/client/dom.test.ts
@@ -52,4 +52,20 @@ describe('dom', () => {
       </body></html>"
     `)
   })
+
+  it('reconciles identity attributes on an adopted meta tag', async () => {
+    const head = useDOMHead()
+    const document = head.resolvedOptions.document!
+    document.head.innerHTML = '<meta name="og:title" content="Default" data-origin="external">'
+    const adopted = document.head.querySelector('meta')!
+
+    head.push({ meta: [{ property: 'og:title', content: 'Page' }] })
+    await useDelayedSerializedDom()
+
+    const meta = document.head.querySelector('meta[property="og:title"]')!
+    expect(meta).toBe(adopted)
+    expect(meta.getAttribute('name')).toBeNull()
+    expect(meta.getAttribute('content')).toBe('Page')
+    expect(meta.getAttribute('data-origin')).toBe('external')
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Backport of #881.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The v2 renderer left stale meta identity attributes when it reused an adopted element with a different `name`, `property`, or `http-equiv`. This backport removes only the stale identity attributes and preserves the element plus unrelated attributes.