### PR TITLE
fix(v1): harden useHeadSafe input sanitization

### DIFF
--- a/packages/shared/src/safe.ts
+++ b/packages/shared/src/safe.ts
@@ -9,11 +9,31 @@ const WhitelistAttributes = {
   link: ['id', 'color', 'crossorigin', 'fetchpriority', 'href', 'hreflang', 'imagesrcset', 'imagesizes', 'integrity', 'media', 'referrerpolicy', 'rel', 'sizes', 'type'],
 }
 
+const SafeAttrName = /^[a-z][a-z0-9-]*[a-z0-9]$/i
+const HtmlEntityHex = /&#x([0-9a-f]+);?/gi
+const HtmlEntityDec = /&#(\d+);?/g
+
+function safeFromCodePoint(codePoint: number): string {
+  if (codePoint > 0x10FFFF || codePoint < 0 || Number.isNaN(codePoint))
+    return ''
+  return String.fromCodePoint(codePoint)
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(HtmlEntityHex, (_, hex) => safeFromCodePoint(Number.parseInt(hex, 16)))
+    .replace(HtmlEntityDec, (_, decimal) => safeFromCodePoint(Number(decimal)))
+}
+
+function hasDangerousProtocol(value: string): boolean {
+  const normalized = decodeHtmlEntities(value).toLowerCase()
+  return normalized.includes('javascript:') || normalized.includes('data:')
+}
+
 function acceptDataAttrs(value: Record<string, string>) {
   const filtered: Record<string, string> = {}
   // add any data attributes
   Object.keys(value || {})
-    .filter(a => a.startsWith('data-'))
+    .filter(a => a.startsWith('data-') && SafeAttrName.test(a))
     .forEach((a) => {
       filtered[a] = value[a]
     })
@@ -73,7 +93,7 @@ export function whitelistSafeInput(input: Record<string, MaybeArray<Record<strin
                   return
 
                 if (key === 'href') {
-                  if (val.includes('javascript:') || val.includes('data:'))
+                  if (hasDangerousProtocol(val))
                     return
                   link[key] = val
                 }

--- a/test/unhead/ssr/useHeadSafe.test.ts
+++ b/test/unhead/ssr/useHeadSafe.test.ts
@@ -54,6 +54,60 @@ describe('dom useHeadSafe', () => {
     `)
   })
 
+  it('drops malformed data attribute names', async () => {
+    const head = createHead()
+
+    useHeadSafe({
+      meta: [
+        {
+          'name': 'description',
+          'content': 'safe',
+          'data-safe': 'preserved',
+          'data-x onload=alert(1)': 'injected',
+        },
+      ],
+    })
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).toContain('data-safe="preserved"')
+    expect(headTags).not.toContain('injected')
+    expect(headTags).not.toContain('onload')
+  })
+
+  it('blocks mixed-case dangerous link protocols', async () => {
+    const head = createHead()
+
+    useHeadSafe({
+      link: [
+        { rel: 'icon', href: 'JaVaScRiPt:alert(1)' },
+        { rel: 'stylesheet', href: 'DaTa:text/css,body{display:none}' },
+        { rel: 'icon', href: 'https://example.com/favicon.ico' },
+      ],
+    })
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).not.toContain('JaVaScRiPt')
+    expect(headTags).not.toContain('DaTa:')
+    expect(headTags).toContain('href="https://example.com/favicon.ico"')
+  })
+
+  it('blocks entity-obfuscated dangerous link protocols', async () => {
+    const head = createHead()
+
+    useHeadSafe({
+      link: [
+        { rel: 'icon', href: 'javascript&#0000000058;alert(1)' },
+        { rel: 'icon', href: 'data&#x000003A;text/html,unsafe' },
+        { rel: 'icon', href: '/safe-icon.png' },
+      ],
+    })
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).not.toContain('&#0000000058;')
+    expect(headTags).not.toContain('&#x000003A;')
+    expect(headTags).toContain('href="/safe-icon.png"')
+  })
+
   it('meta charset allows safe', async () => {
     const head = createHead()
 


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Unhead v1.11.20 remains vulnerable to three published `useHeadSafe()` sanitization bypasses, and Vue 2 consumers cannot move to v2. This backport validates data attribute names and normalizes encoded URI schemes before filtering unsafe values.