### PR TITLE
fix(unhead): preserve numeric zero head content

### DIFF
--- a/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
@@ -62,14 +62,14 @@ export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
               // @ts-expect-error untyped
               title = title(head._title)
             }
-            ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title || ''
+            ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title ?? ''
             ogTitle.processTemplateParams = true
           }
 
           const description = tagMap.get('meta:description')?.props?.content
           const ogDescription = tagMap.get('meta:og:description')
           if (typeof ogDescription?.props['data-infer'] !== 'undefined') {
-            ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description || ''
+            ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description ?? ''
             ogDescription.processTemplateParams = true
           }
         },

--- a/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
@@ -62,14 +62,15 @@ export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
               // @ts-expect-error untyped
               title = title(head._title)
             }
-            ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title ?? ''
+            title = title?.toString()
+            ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title || ''
             ogTitle.processTemplateParams = true
           }
 
-          const description = tagMap.get('meta:description')?.props?.content
+          const description = tagMap.get('meta:description')?.props?.content?.toString()
           const ogDescription = tagMap.get('meta:og:description')
           if (typeof ogDescription?.props['data-infer'] !== 'undefined') {
-            ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description ?? ''
+            ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description || ''
             ogDescription.processTemplateParams = true
           }
         },

--- a/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
@@ -1,3 +1,4 @@
+import { hasContent } from '../utils/const'
 import { defineHeadPlugin } from './defineHeadPlugin'
 
 export interface InferSeoMetaPluginOptions {
@@ -62,12 +63,13 @@ export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
               // @ts-expect-error untyped
               title = title(head._title)
             }
-            title = title?.toString()
+            title = hasContent(title) ? String(title) : undefined
             ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title || ''
             ogTitle.processTemplateParams = true
           }
 
-          const description = tagMap.get('meta:description')?.props?.content?.toString()
+          const descriptionValue = tagMap.get('meta:description')?.props?.content
+          const description = hasContent(descriptionValue) ? String(descriptionValue) : undefined
           const ogDescription = tagMap.get('meta:og:description')
           if (typeof ogDescription?.props['data-infer'] !== 'undefined') {
             ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description || ''

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -162,8 +162,9 @@ function makeTagSafe(tag: HeadTag): HeadSafe | false {
     // meta is safe, except for http-equiv
     case 'meta':
       WhitelistAttributes.meta.forEach((key) => {
-        if (prev[key]) {
-          next[key] = prev[key]
+        const value = prev[key]
+        if (value || (value as unknown) === 0) {
+          next[key] = value
         }
       })
       break

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -1,5 +1,6 @@
 import type { HeadSafe } from '../types/safeSchema'
 import type { HeadTag } from '../types/tags'
+import { hasContent } from '../utils/const'
 import { isUnsafeKey } from '../utils/unsafeKey'
 import { defineHeadPlugin } from './defineHeadPlugin'
 
@@ -162,9 +163,8 @@ function makeTagSafe(tag: HeadTag): HeadSafe | false {
     // meta is safe, except for http-equiv
     case 'meta':
       WhitelistAttributes.meta.forEach((key) => {
-        const value = prev[key]
-        if (value || (value as unknown) === 0) {
-          next[key] = value
+        if (hasContent(prev[key])) {
+          next[key] = prev[key]
         }
       })
       break

--- a/packages/unhead/src/plugins/validate.ts
+++ b/packages/unhead/src/plugins/validate.ts
@@ -200,7 +200,7 @@ export function ValidatePlugin(options: ValidatePluginOptions = {}) {
                   hasOgTags = true
                 if (key === 'description')
                   hasDescription = true
-                if (key === 'robots' && tag.props.content?.toLowerCase().includes('noindex'))
+                if (key === 'robots' && String(tag.props.content ?? '').toLowerCase().includes('noindex'))
                   isIndexable = false
               }
             }
@@ -264,7 +264,7 @@ export function ValidatePlugin(options: ValidatePluginOptions = {}) {
                 for (const diag of headInputPredicates['no-html-in-title'](titleInput))
                   report(diag.ruleId as ValidationRuleId, diag.message, 'warn', tag)
               }
-              const text = tag.textContent || ''
+              const text = String(tag.textContent ?? '')
               if (TEMPLATE_PARAM_RE.test(text))
                 report('unresolved-template-param', `Unresolved template param in title: "${text}".`, 'warn', tag)
               if (!text.trim())

--- a/packages/unhead/src/server/util/tagToString.ts
+++ b/packages/unhead/src/server/util/tagToString.ts
@@ -24,7 +24,8 @@ export function tagToString<T extends HeadTag>(tag: T) {
     return `${openTag}</${tag.tag}>`
 
   // dangerously using innerHTML, we don't encode this
-  let content = String(tag.textContent || tag.innerHTML || '')
+  const textContent = tag.textContent as unknown
+  let content = String(textContent === 0 ? textContent : tag.textContent || tag.innerHTML || '')
   content = tag.tag === 'title' ? escapeHtml(content) : content.replace(CLOSE_TAG_RE[tag.tag] ||= new RegExp(`<\/${tag.tag}`, 'gi'), `<\\/${tag.tag}`)
   return `${openTag}${content}</${tag.tag}>`
 }

--- a/packages/unhead/src/server/util/tagToString.ts
+++ b/packages/unhead/src/server/util/tagToString.ts
@@ -24,8 +24,7 @@ export function tagToString<T extends HeadTag>(tag: T) {
     return `${openTag}</${tag.tag}>`
 
   // dangerously using innerHTML, we don't encode this
-  const textContent = tag.textContent as unknown
-  let content = String(textContent === 0 ? textContent : tag.textContent || tag.innerHTML || '')
+  let content = String(tag.textContent ?? tag.innerHTML ?? '')
   content = tag.tag === 'title' ? escapeHtml(content) : content.replace(CLOSE_TAG_RE[tag.tag] ||= new RegExp(`<\/${tag.tag}`, 'gi'), `<\\/${tag.tag}`)
   return `${openTag}${content}</${tag.tag}>`
 }

--- a/packages/unhead/src/utils/const.ts
+++ b/packages/unhead/src/utils/const.ts
@@ -25,4 +25,4 @@ export const MetaTagsArrayable = /* @__PURE__ */ new Set([
 
 export const TagPriorityAliases = /* @__PURE__ */ { critical: -8, high: -1, low: 2 } as const
 
-export const hasContent = (value: unknown) => value || Number.isFinite(value)
+export const hasContent = (value: unknown) => typeof value === 'number' ? Number.isFinite(value) : value

--- a/packages/unhead/src/utils/const.ts
+++ b/packages/unhead/src/utils/const.ts
@@ -24,3 +24,5 @@ export const MetaTagsArrayable = /* @__PURE__ */ new Set([
 ])
 
 export const TagPriorityAliases = /* @__PURE__ */ { critical: -8, high: -1, low: 2 } as const
+
+export const hasContent = (value: unknown) => value || Number.isFinite(value)

--- a/packages/unhead/src/utils/index.ts
+++ b/packages/unhead/src/utils/index.ts
@@ -1,4 +1,16 @@
-export * from './const'
+export {
+  DupeableTags,
+  HasElementTags,
+  MetaTagsArrayable,
+  ScriptNetworkEvents,
+  SelfClosingTags,
+  TagConfigKeys,
+  TagPriorityAliases,
+  TagsWithInnerContent,
+  UniqueTags,
+  UsesMergeStrategy,
+  ValidHeadTags,
+} from './const'
 export { dedupeKey, hashTag, isMetaArrayDupeKey } from './dedupe'
 export { resolveMetaKeyType, resolveMetaKeyValue, resolvePackedMetaObjectValue, unpackMeta } from './meta'
 export type { MetaKeyType } from './meta'

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -20,6 +20,10 @@ function isEmptyProps(props: Record<string, any>): boolean {
   return true
 }
 
+function isEmptyContent(value: unknown): boolean {
+  return !value && value !== 0
+}
+
 // matches hooks that receive references to resolved tags and may mutate them in place
 const TAG_MUTATING_HOOK_RE = /^tags:|:render/
 
@@ -136,11 +140,10 @@ function sanitizeTagsInPlace(tags: HeadTag[]): HeadTag[] {
   let w = 0
   for (let t of tags) {
     const { innerHTML, tag, props } = t
-    if (!ValidHeadTags.has(tag) || (isEmptyProps(props) && !innerHTML && !t.textContent))
+    if (!ValidHeadTags.has(tag) || (isEmptyProps(props) && isEmptyContent(innerHTML) && isEmptyContent(t.textContent)))
       continue
     if (tag === 'meta') {
-      const content = props.content as unknown
-      if (!content && content !== 0 && !props['http-equiv'] && !props.charset)
+      if (isEmptyContent(props.content) && !props['http-equiv'] && !props.charset)
         continue
     }
     if (tag === 'script' && (innerHTML || t.textContent)) {

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -138,8 +138,11 @@ function sanitizeTagsInPlace(tags: HeadTag[]): HeadTag[] {
     const { innerHTML, tag, props } = t
     if (!ValidHeadTags.has(tag) || (isEmptyProps(props) && !innerHTML && !t.textContent))
       continue
-    if (tag === 'meta' && !props.content && !props['http-equiv'] && !props.charset)
-      continue
+    if (tag === 'meta') {
+      const content = props.content as unknown
+      if (!content && content !== 0 && !props['http-equiv'] && !props.charset)
+        continue
+    }
     if (tag === 'script' && (innerHTML || t.textContent)) {
       const type = String(props.type)
       const isJsonLike = type.endsWith('json') || type === 'importmap' || type === 'speculationrules'

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -1,5 +1,5 @@
 import type { HeadEntry, HeadTag, Unhead } from '../types'
-import { UsesMergeStrategy, ValidHeadTags } from './const'
+import { hasContent, UsesMergeStrategy, ValidHeadTags } from './const'
 import { dedupeKey, hashTag, isMetaArrayDupeKey } from './dedupe'
 import { callHook } from './hooks'
 import { normalizeEntryToTags } from './normalize'
@@ -18,10 +18,6 @@ function isEmptyProps(props: Record<string, any>): boolean {
   for (const _ in props)
     return false
   return true
-}
-
-function isEmptyContent(value: unknown): boolean {
-  return !value && value !== 0
 }
 
 // matches hooks that receive references to resolved tags and may mutate them in place
@@ -140,10 +136,10 @@ function sanitizeTagsInPlace(tags: HeadTag[]): HeadTag[] {
   let w = 0
   for (let t of tags) {
     const { innerHTML, tag, props } = t
-    if (!ValidHeadTags.has(tag) || (isEmptyProps(props) && isEmptyContent(innerHTML) && isEmptyContent(t.textContent)))
+    if (!ValidHeadTags.has(tag) || (isEmptyProps(props) && !hasContent(innerHTML) && !hasContent(t.textContent)))
       continue
     if (tag === 'meta') {
-      if (isEmptyContent(props.content) && !props['http-equiv'] && !props.charset)
+      if (!hasContent(props.content) && !props['http-equiv'] && !props.charset)
         continue
     }
     if (tag === 'script' && (innerHTML || t.textContent)) {

--- a/packages/unhead/test/unit/client/dom.test.ts
+++ b/packages/unhead/test/unit/client/dom.test.ts
@@ -14,6 +14,16 @@ describe('dom', () => {
     expect(head.resolvedOptions.document?.querySelector('meta[name="numeric-zero"]')?.getAttribute('content')).toBe('0')
   })
 
+  it('renders a numeric zero title', () => {
+    const head = useDOMHead()
+
+    head.push({
+      title: 0,
+    })
+
+    expect(head.resolvedOptions.document?.title).toBe('0')
+  })
+
   it('renders a fresh server head into an explicit document once', () => {
     const document = useDom().window.document
     const head = createServerHeadWithContext()

--- a/packages/unhead/test/unit/client/dom.test.ts
+++ b/packages/unhead/test/unit/client/dom.test.ts
@@ -4,6 +4,16 @@ import { useHead } from '../../../src'
 import { basicSchema, useDelayedSerializedDom, useDOMHead } from '../../util'
 
 describe('dom', () => {
+  it('renders numeric zero meta content', () => {
+    const head = useDOMHead()
+
+    head.push({
+      meta: [{ name: 'numeric-zero', content: 0 }],
+    })
+
+    expect(head.resolvedOptions.document?.querySelector('meta[name="numeric-zero"]')?.getAttribute('content')).toBe('0')
+  })
+
   it('basic', async () => {
     const head = useDOMHead()
 

--- a/packages/unhead/test/unit/client/resolveTags.test.ts
+++ b/packages/unhead/test/unit/client/resolveTags.test.ts
@@ -3,6 +3,30 @@ import { resolveTags } from '../../../src/utils/resolve'
 import { basicSchema, createClientHeadWithContext } from '../../util'
 
 describe('resolveTags', () => {
+  it('preserves numeric zero meta content and drops empty values', () => {
+    const head = createClientHeadWithContext()
+
+    head.push({
+      meta: [
+        { name: 'numeric-zero', content: 0 },
+        { name: 'string-zero', content: '0' },
+        { name: 'value', content: 'value' },
+        { name: 'empty-string', content: '' },
+        { name: 'null', content: null },
+        // @ts-expect-error missing content exercises the runtime sanitizer boundary
+        { name: 'absent' },
+        { name: 'false', content: false },
+        { name: 'nan', content: Number.NaN },
+      ],
+    })
+
+    expect(resolveTags(head).map(tag => tag.props)).toEqual([
+      { name: 'numeric-zero', content: 0 },
+      { name: 'string-zero', content: '0' },
+      { name: 'value', content: 'value' },
+    ])
+  })
+
   it('docs example', async () => {
     const head = createClientHeadWithContext()
 

--- a/packages/unhead/test/unit/client/resolveTags.test.ts
+++ b/packages/unhead/test/unit/client/resolveTags.test.ts
@@ -17,6 +17,8 @@ describe('resolveTags', () => {
         { name: 'absent' },
         { name: 'false', content: false },
         { name: 'nan', content: Number.NaN },
+        { name: 'positive-infinity', content: Number.POSITIVE_INFINITY },
+        { name: 'negative-infinity', content: Number.NEGATIVE_INFINITY },
       ],
     })
 

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -34,6 +34,26 @@ describe('inferSeoMetaPlugin', () => {
       <meta property="og:description" data-infer="" content="My Description">"
     `)
   })
+
+  it('infers numeric zero title and description', () => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin({ twitterCard: false })],
+    })
+
+    head.push({
+      title: 0,
+      meta: [{ name: 'description', content: 0 }],
+    })
+
+    expect(renderSSRHead(head).headTags).toBe([
+      '<title>0</title>',
+      '<meta name="description" content="0">',
+      '<meta property="og:title" data-infer="" content="0">',
+      '<meta property="og:description" data-infer="" content="0">',
+    ].join('\n'))
+  })
+
   it('conflicts', async () => {
     const head = createHead({
       disableDefaults: true,

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -54,6 +54,26 @@ describe('inferSeoMetaPlugin', () => {
     ].join('\n'))
   })
 
+  it('passes numeric zero to custom transformers as strings', () => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin({
+        twitterCard: false,
+        ogTitle: title => title!.trim(),
+        ogDescription: description => description!.trim(),
+      })],
+    })
+
+    head.push({
+      title: 0,
+      meta: [{ name: 'description', content: 0 }],
+    })
+
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).toContain('<meta property="og:title" data-infer="" content="0">')
+    expect(headTags).toContain('<meta property="og:description" data-infer="" content="0">')
+  })
+
   it('conflicts', async () => {
     const head = createHead({
       disableDefaults: true,

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -74,7 +74,7 @@ describe('inferSeoMetaPlugin', () => {
     expect(headTags).toContain('<meta property="og:description" data-infer="" content="0">')
   })
 
-  it.each([false, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])('does not infer invalid content: %s', (content) => {
+  it.each([false, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY] as const)('does not infer invalid content: %s', (content) => {
     const head = createHead({
       disableDefaults: true,
       plugins: [InferSeoMetaPlugin({ twitterCard: false })],

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -74,6 +74,24 @@ describe('inferSeoMetaPlugin', () => {
     expect(headTags).toContain('<meta property="og:description" data-infer="" content="0">')
   })
 
+  it.each([false, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])('does not infer invalid content: %s', (content) => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin({ twitterCard: false })],
+    })
+
+    head.push({
+      title: content,
+      meta: [{ name: 'description', content }],
+    })
+
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).not.toContain('<title')
+    expect(headTags).not.toContain('name="description"')
+    expect(headTags).not.toContain('property="og:title"')
+    expect(headTags).not.toContain('property="og:description"')
+  })
+
   it('conflicts', async () => {
     const head = createHead({
       disableDefaults: true,

--- a/packages/unhead/test/unit/plugins/validate.test.ts
+++ b/packages/unhead/test/unit/plugins/validate.test.ts
@@ -103,6 +103,15 @@ describe('validatePlugin', () => {
       expect(rules.find(r => r.id === 'html-in-title')).toBeFalsy()
     })
 
+    it('accepts a numeric zero title', () => {
+      const { head, rules } = createValidationHead()
+      head.push({ title: 0 })
+
+      expect(renderSSRHead(head).headTags).toBe('<title>0</title>')
+      expect(rules.find(r => r.id === 'empty-title')).toBeFalsy()
+      expect(rules.find(r => r.id === 'missing-title')).toBeFalsy()
+    })
+
     it('warns on unresolved template params in title', () => {
       const { head, rules } = createValidationHead()
       // Push a title that will literally contain %siteName% after resolution
@@ -150,6 +159,14 @@ describe('validatePlugin', () => {
       })
       renderSSRHead(head)
       expect(rules.find(r => r.id === 'missing-description')).toBeFalsy()
+    })
+
+    it('handles numeric zero robots content', async () => {
+      const { head } = createValidationHead()
+      head.push({ meta: [{ name: 'robots', content: 0 }] })
+
+      expect(renderSSRHead(head).headTags).toBe('<meta name="robots" content="0">')
+      await Promise.resolve()
     })
   })
 

--- a/packages/unhead/test/unit/plugins/validate.test.ts
+++ b/packages/unhead/test/unit/plugins/validate.test.ts
@@ -162,11 +162,12 @@ describe('validatePlugin', () => {
     })
 
     it('handles numeric zero robots content', async () => {
-      const { head } = createValidationHead()
+      const { head, rules } = createValidationHead()
       head.push({ meta: [{ name: 'robots', content: 0 }] })
 
       expect(renderSSRHead(head).headTags).toBe('<meta name="robots" content="0">')
       await Promise.resolve()
+      expect(rules.find(r => r.id === 'missing-description')).toBeTruthy()
     })
   })
 

--- a/packages/unhead/test/unit/server/ssr.test.ts
+++ b/packages/unhead/test/unit/server/ssr.test.ts
@@ -5,6 +5,16 @@ import { transformHtmlTemplate } from '../../../src/server/transformHtmlTemplate
 import { basicSchema, createServerHeadWithContext } from '../../util'
 
 describe('ssr', () => {
+  it('renders numeric zero meta content', () => {
+    const head = createServerHeadWithContext()
+
+    head.push({
+      meta: [{ name: 'numeric-zero', content: 0 }],
+    })
+
+    expect(renderSSRHead(head).headTags).toBe('<meta name="numeric-zero" content="0">')
+  })
+
   it('basic', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/ssr.test.ts
+++ b/packages/unhead/test/unit/server/ssr.test.ts
@@ -66,6 +66,16 @@ describe('ssr', () => {
     `)
   })
 
+  it('numeric zero title', () => {
+    const head = createServerHeadWithContext()
+
+    head.push({
+      title: 0,
+    })
+
+    expect(renderSSRHead(head).headTags).toBe('<title>0</title>')
+  })
+
   it('object title', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/useHeadSafe.test.ts
+++ b/packages/unhead/test/unit/server/useHeadSafe.test.ts
@@ -77,6 +77,16 @@ describe('dom useHeadSafe', () => {
     `)
   })
 
+  it('preserves numeric zero meta content', () => {
+    const head = createServerHeadWithContext()
+
+    useHeadSafe(head, {
+      meta: [{ name: 'numeric-zero', content: 0 }],
+    })
+
+    expect(renderSSRHead(head).headTags).toBe('<meta name="numeric-zero" content="0">')
+  })
+
   it('blocks XSS via data-* attribute name injection', async () => {
     const head = createServerHeadWithContext()
 


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Numeric zero was discarded by safe input, title rendering, and inferred SEO metadata; validation also called string methods on numeric content. A private `hasContent` predicate now owns presence checks, while empty, false, null, and non-finite values remain omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved numeric `0` values across title, meta tags, SEO inference (including Open Graph), safe rendering, and validation.
  * Updated sanitization and tag-to-string handling so zero-valued content/attributes are no longer treated as empty or dropped.
  * Improved `robots` meta evaluation to correctly process numeric `0`.

* **Tests**
  * Added/extended unit tests covering numeric `0` behavior across client rendering, SSR serialization, sanitization, SEO inference, validation, and safe head output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->