### PR TITLE
fix(unhead): preserve numeric zero head content

### DIFF
--- a/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
@@ -54,14 +54,14 @@ export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
               // @ts-expect-error untyped
               title = title(head._title)
             }
-            ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title || ''
+            ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title ?? ''
             ogTitle.processTemplateParams = true
           }
 
           const description = tagMap.get('meta:description')?.props?.content
           const ogDescription = tagMap.get('meta:og:description')
           if (typeof ogDescription?.props['data-infer'] !== 'undefined') {
-            ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description || ''
+            ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description ?? ''
             ogDescription.processTemplateParams = true
           }
         },

--- a/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
@@ -1,3 +1,4 @@
+import { hasContent } from '../utils/const'
 import { defineHeadPlugin } from './defineHeadPlugin'
 
 export interface InferSeoMetaPluginOptions {
@@ -54,12 +55,13 @@ export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
               // @ts-expect-error untyped
               title = title(head._title)
             }
-            title = title?.toString()
+            title = hasContent(title) ? String(title) : undefined
             ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title || ''
             ogTitle.processTemplateParams = true
           }
 
-          const description = tagMap.get('meta:description')?.props?.content?.toString()
+          const descriptionValue = tagMap.get('meta:description')?.props?.content
+          const description = hasContent(descriptionValue) ? String(descriptionValue) : undefined
           const ogDescription = tagMap.get('meta:og:description')
           if (typeof ogDescription?.props['data-infer'] !== 'undefined') {
             ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description || ''

--- a/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
+++ b/packages/unhead/src/plugins/inferSeoMetaPlugin.ts
@@ -54,14 +54,15 @@ export function InferSeoMetaPlugin(options: InferSeoMetaPluginOptions = {}) {
               // @ts-expect-error untyped
               title = title(head._title)
             }
-            ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title ?? ''
+            title = title?.toString()
+            ogTitle.props!.content = options.ogTitle ? options.ogTitle(title) : title || ''
             ogTitle.processTemplateParams = true
           }
 
-          const description = tagMap.get('meta:description')?.props?.content
+          const description = tagMap.get('meta:description')?.props?.content?.toString()
           const ogDescription = tagMap.get('meta:og:description')
           if (typeof ogDescription?.props['data-infer'] !== 'undefined') {
-            ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description ?? ''
+            ogDescription.props!.content = options.ogDescription ? options.ogDescription(description) : description || ''
             ogDescription.processTemplateParams = true
           }
         },

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -148,8 +148,9 @@ function makeTagSafe(tag: HeadTag): HeadSafe | false {
     // meta is safe, except for http-equiv
     case 'meta':
       WhitelistAttributes.meta.forEach((key) => {
-        if (prev[key]) {
-          next[key] = prev[key]
+        const value = prev[key]
+        if (value || (value as unknown) === 0) {
+          next[key] = value
         }
       })
       break

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -1,6 +1,7 @@
 import type { HeadSafe } from '../types/safeSchema'
 import type { RawInput } from '../types/schema'
 import type { HeadTag } from '../types/tags'
+import { hasContent } from '../utils/const'
 import { defineHeadPlugin } from './defineHeadPlugin'
 
 const WhitelistAttributes = {
@@ -148,9 +149,8 @@ function makeTagSafe(tag: HeadTag): HeadSafe | false {
     // meta is safe, except for http-equiv
     case 'meta':
       WhitelistAttributes.meta.forEach((key) => {
-        const value = prev[key]
-        if (value || (value as unknown) === 0) {
-          next[key] = value
+        if (hasContent(prev[key])) {
+          next[key] = prev[key]
         }
       })
       break

--- a/packages/unhead/src/server/util/tagToString.ts
+++ b/packages/unhead/src/server/util/tagToString.ts
@@ -33,7 +33,8 @@ export function tagToString<T extends HeadTag>(tag: T) {
     return SelfClosingTags.has(tag.tag) ? openTag : `${openTag}</${tag.tag}>`
 
   // dangerously using innerHTML, we don't encode this
-  let content = String(tag.textContent || tag.innerHTML || '')
+  const textContent = tag.textContent as unknown
+  let content = String(textContent === 0 ? textContent : tag.textContent || tag.innerHTML || '')
   content = tag.tag === 'title' ? escapeHtml(content) : content.replace(new RegExp(`<\/${tag.tag}`, 'gi'), `<\\/${tag.tag}`)
   return SelfClosingTags.has(tag.tag) ? openTag : `${openTag}${content}</${tag.tag}>`
 }

--- a/packages/unhead/src/server/util/tagToString.ts
+++ b/packages/unhead/src/server/util/tagToString.ts
@@ -33,8 +33,7 @@ export function tagToString<T extends HeadTag>(tag: T) {
     return SelfClosingTags.has(tag.tag) ? openTag : `${openTag}</${tag.tag}>`
 
   // dangerously using innerHTML, we don't encode this
-  const textContent = tag.textContent as unknown
-  let content = String(textContent === 0 ? textContent : tag.textContent || tag.innerHTML || '')
+  let content = String(tag.textContent ?? tag.innerHTML ?? '')
   content = tag.tag === 'title' ? escapeHtml(content) : content.replace(new RegExp(`<\/${tag.tag}`, 'gi'), `<\\/${tag.tag}`)
   return SelfClosingTags.has(tag.tag) ? openTag : `${openTag}${content}</${tag.tag}>`
 }

--- a/packages/unhead/src/unhead.ts
+++ b/packages/unhead/src/unhead.ts
@@ -15,6 +15,10 @@ import { isMetaArrayDupeKey, sortTags, tagWeight, UsesMergeStrategy, ValidHeadTa
 import { dedupeKey, hashTag } from './utils/dedupe'
 import { normalizeEntryToTags } from './utils/normalize'
 
+function isEmptyContent(value: unknown): boolean {
+  return !value && value !== 0
+}
+
 function registerPlugin(head: Unhead<any>, p: HeadPluginInput) {
   const plugin = (typeof p === 'function' ? p(head) : p)
   // key is required in types but we avoid breaking changes
@@ -193,12 +197,11 @@ export function createUnhead<T = ResolvableHead>(resolvedOptions: CreateHeadOpti
           continue
         }
         // avoid rendering empty tags
-        if (Object.keys(props).length === 0 && !t.innerHTML && !t.textContent) {
+        if (Object.keys(props).length === 0 && isEmptyContent(t.innerHTML) && isEmptyContent(t.textContent)) {
           continue
         }
         if (tag === 'meta') {
-          const content = props.content as unknown
-          if (!content && content !== 0 && !props['http-equiv'] && !props.charset) {
+          if (isEmptyContent(props.content) && !props['http-equiv'] && !props.charset) {
             continue
           }
         }

--- a/packages/unhead/src/unhead.ts
+++ b/packages/unhead/src/unhead.ts
@@ -12,12 +12,9 @@ import type {
 } from './types'
 import { createHooks } from 'hookable'
 import { isMetaArrayDupeKey, sortTags, tagWeight, UsesMergeStrategy, ValidHeadTags } from './utils'
+import { hasContent } from './utils/const'
 import { dedupeKey, hashTag } from './utils/dedupe'
 import { normalizeEntryToTags } from './utils/normalize'
-
-function isEmptyContent(value: unknown): boolean {
-  return !value && value !== 0
-}
 
 function registerPlugin(head: Unhead<any>, p: HeadPluginInput) {
   const plugin = (typeof p === 'function' ? p(head) : p)
@@ -197,11 +194,11 @@ export function createUnhead<T = ResolvableHead>(resolvedOptions: CreateHeadOpti
           continue
         }
         // avoid rendering empty tags
-        if (Object.keys(props).length === 0 && isEmptyContent(t.innerHTML) && isEmptyContent(t.textContent)) {
+        if (Object.keys(props).length === 0 && !hasContent(t.innerHTML) && !hasContent(t.textContent)) {
           continue
         }
         if (tag === 'meta') {
-          if (isEmptyContent(props.content) && !props['http-equiv'] && !props.charset) {
+          if (!hasContent(props.content) && !props['http-equiv'] && !props.charset) {
             continue
           }
         }

--- a/packages/unhead/src/unhead.ts
+++ b/packages/unhead/src/unhead.ts
@@ -196,8 +196,11 @@ export function createUnhead<T = ResolvableHead>(resolvedOptions: CreateHeadOpti
         if (Object.keys(props).length === 0 && !t.innerHTML && !t.textContent) {
           continue
         }
-        if (tag === 'meta' && !props.content && !props['http-equiv'] && !props.charset) {
-          continue
+        if (tag === 'meta') {
+          const content = props.content as unknown
+          if (!content && content !== 0 && !props['http-equiv'] && !props.charset) {
+            continue
+          }
         }
         // final XSS
         if (tag === 'script' && innerHTML) {

--- a/packages/unhead/src/utils/const.ts
+++ b/packages/unhead/src/utils/const.ts
@@ -40,4 +40,4 @@ export const MetaTagsArrayable = /* @__PURE__ */ new Set([
   'author',
 ])
 
-export const hasContent = (value: unknown) => value || Number.isFinite(value)
+export const hasContent = (value: unknown) => typeof value === 'number' ? Number.isFinite(value) : value

--- a/packages/unhead/src/utils/const.ts
+++ b/packages/unhead/src/utils/const.ts
@@ -39,3 +39,5 @@ export const MetaTagsArrayable = /* @__PURE__ */ new Set([
   'twitter',
   'author',
 ])
+
+export const hasContent = (value: unknown) => value || Number.isFinite(value)

--- a/packages/unhead/src/utils/index.ts
+++ b/packages/unhead/src/utils/index.ts
@@ -1,4 +1,15 @@
-export * from './const'
+export {
+  DupeableTags,
+  HasElementTags,
+  MetaTagsArrayable,
+  ScriptNetworkEvents,
+  SelfClosingTags,
+  TagConfigKeys,
+  TagsWithInnerContent,
+  UniqueTags,
+  UsesMergeStrategy,
+  ValidHeadTags,
+} from './const'
 export { dedupeKey, hashTag, isMetaArrayDupeKey } from './dedupe'
 export { resolveMetaKeyType, resolveMetaKeyValue, resolvePackedMetaObjectValue, unpackMeta } from './meta'
 export { normalizeEntryToTags, normalizeProps } from './normalize'

--- a/packages/unhead/test/unit/client/dom.test.ts
+++ b/packages/unhead/test/unit/client/dom.test.ts
@@ -3,6 +3,16 @@ import { useHead } from '../../../src'
 import { basicSchema, useDelayedSerializedDom, useDOMHead } from '../../util'
 
 describe('dom', () => {
+  it('renders numeric zero meta content', async () => {
+    const head = useDOMHead()
+
+    head.push({
+      meta: [{ name: 'numeric-zero', content: 0 }],
+    })
+
+    expect(await useDelayedSerializedDom()).toContain('<meta name="numeric-zero" content="0">')
+  })
+
   it('basic', async () => {
     const head = useDOMHead()
 

--- a/packages/unhead/test/unit/client/dom.test.ts
+++ b/packages/unhead/test/unit/client/dom.test.ts
@@ -13,6 +13,17 @@ describe('dom', () => {
     expect(await useDelayedSerializedDom()).toContain('<meta name="numeric-zero" content="0">')
   })
 
+  it('renders a numeric zero title', async () => {
+    const head = useDOMHead()
+
+    head.push({
+      title: 0,
+    })
+
+    await useDelayedSerializedDom()
+    expect(head.resolvedOptions.document?.title).toBe('0')
+  })
+
   it('basic', async () => {
     const head = useDOMHead()
 

--- a/packages/unhead/test/unit/client/resolveTags.test.ts
+++ b/packages/unhead/test/unit/client/resolveTags.test.ts
@@ -2,6 +2,29 @@ import { describe, it } from 'vitest'
 import { basicSchema, createClientHeadWithContext } from '../../util'
 
 describe('resolveTags', () => {
+  it('preserves numeric zero meta content and drops empty values', async () => {
+    const head = createClientHeadWithContext()
+
+    head.push({
+      meta: [
+        { name: 'numeric-zero', content: 0 },
+        { name: 'string-zero', content: '0' },
+        { name: 'value', content: 'value' },
+        { name: 'empty-string', content: '' },
+        { name: 'null', content: null },
+        { name: 'absent' },
+        { name: 'false', content: false },
+        { name: 'nan', content: Number.NaN },
+      ],
+    })
+
+    expect((await head.resolveTags()).map(tag => tag.props)).toEqual([
+      { name: 'numeric-zero', content: 0 },
+      { name: 'string-zero', content: '0' },
+      { name: 'value', content: 'value' },
+    ])
+  })
+
   it('docs example', async () => {
     const head = createClientHeadWithContext()
 

--- a/packages/unhead/test/unit/client/resolveTags.test.ts
+++ b/packages/unhead/test/unit/client/resolveTags.test.ts
@@ -15,6 +15,8 @@ describe('resolveTags', () => {
         { name: 'absent' },
         { name: 'false', content: false },
         { name: 'nan', content: Number.NaN },
+        { name: 'positive-infinity', content: Number.POSITIVE_INFINITY },
+        { name: 'negative-infinity', content: Number.NEGATIVE_INFINITY },
       ],
     })
 

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -73,7 +73,7 @@ describe('inferSeoMetaPlugin', () => {
     expect(headTags).toContain('<meta property="og:description" data-infer="" content="0">')
   })
 
-  it.each([false, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])('does not infer invalid content: %s', async (content) => {
+  it.each([false, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY] as const)('does not infer invalid content: %s', async (content) => {
     const head = createHead({
       disableDefaults: true,
       plugins: [InferSeoMetaPlugin({ twitterCard: false })],

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -33,6 +33,27 @@ describe('inferSeoMetaPlugin', () => {
       <meta property="og:description" data-infer="" content="My Description">"
     `)
   })
+
+  it('infers numeric zero title and description', async () => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin()],
+    })
+
+    head.push({
+      title: 0,
+      meta: [{ name: 'description', content: 0 }],
+    })
+
+    expect((await renderSSRHead(head)).headTags).toBe([
+      '<title>0</title>',
+      '<meta name="description" content="0">',
+      '<meta name="twitter:card" content="summary_large_image">',
+      '<meta property="og:title" data-infer="" content="0">',
+      '<meta property="og:description" data-infer="" content="0">',
+    ].join('\n'))
+  })
+
   it('conflicts', async () => {
     const head = createHead({
       disableDefaults: true,

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -54,6 +54,25 @@ describe('inferSeoMetaPlugin', () => {
     ].join('\n'))
   })
 
+  it('passes numeric zero to custom transformers as strings', async () => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin({
+        ogTitle: title => title!.trim(),
+        ogDescription: description => description!.trim(),
+      })],
+    })
+
+    head.push({
+      title: 0,
+      meta: [{ name: 'description', content: 0 }],
+    })
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).toContain('<meta property="og:title" data-infer="" content="0">')
+    expect(headTags).toContain('<meta property="og:description" data-infer="" content="0">')
+  })
+
   it('conflicts', async () => {
     const head = createHead({
       disableDefaults: true,

--- a/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
+++ b/packages/unhead/test/unit/plugins/infer-seo-meta.test.ts
@@ -73,6 +73,24 @@ describe('inferSeoMetaPlugin', () => {
     expect(headTags).toContain('<meta property="og:description" data-infer="" content="0">')
   })
 
+  it.each([false, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])('does not infer invalid content: %s', async (content) => {
+    const head = createHead({
+      disableDefaults: true,
+      plugins: [InferSeoMetaPlugin({ twitterCard: false })],
+    })
+
+    head.push({
+      title: content,
+      meta: [{ name: 'description', content }],
+    })
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).not.toContain('<title')
+    expect(headTags).not.toContain('name="description"')
+    expect(headTags).not.toContain('property="og:title"')
+    expect(headTags).not.toContain('property="og:description"')
+  })
+
   it('conflicts', async () => {
     const head = createHead({
       disableDefaults: true,

--- a/packages/unhead/test/unit/server/ssr.test.ts
+++ b/packages/unhead/test/unit/server/ssr.test.ts
@@ -67,6 +67,16 @@ describe('ssr', () => {
     `)
   })
 
+  it('numeric zero title', async () => {
+    const head = createServerHeadWithContext()
+
+    head.push({
+      title: 0,
+    })
+
+    expect((await renderSSRHead(head)).headTags).toBe('<title>0</title>')
+  })
+
   it('object title', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/ssr.test.ts
+++ b/packages/unhead/test/unit/server/ssr.test.ts
@@ -6,6 +6,16 @@ import { transformHtmlTemplate } from '../../../src/server/transformHtmlTemplate
 import { basicSchema, createServerHeadWithContext } from '../../util'
 
 describe('ssr', () => {
+  it('renders numeric zero meta content', async () => {
+    const head = createServerHeadWithContext()
+
+    head.push({
+      meta: [{ name: 'numeric-zero', content: 0 }],
+    })
+
+    expect((await renderSSRHead(head)).headTags).toBe('<meta name="numeric-zero" content="0">')
+  })
+
   it('basic', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/useHeadSafe.test.ts
+++ b/packages/unhead/test/unit/server/useHeadSafe.test.ts
@@ -77,6 +77,16 @@ describe('dom useHeadSafe', () => {
     `)
   })
 
+  it('preserves numeric zero meta content', async () => {
+    const head = createServerHeadWithContext()
+
+    useHeadSafe(head, {
+      meta: [{ name: 'numeric-zero', content: 0 }],
+    })
+
+    expect((await renderSSRHead(head)).headTags).toBe('<meta name="numeric-zero" content="0">')
+  })
+
   it('blocks XSS via data-* attribute name injection', async () => {
     const head = createServerHeadWithContext()
 


### PR DESCRIPTION
### 🔗 Linked issue

Backport of #885.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Unhead v2 discarded numeric zero in safe input, title rendering, and inferred SEO metadata. A private `hasContent` predicate now owns presence checks, while empty, false, null, and non-finite values remain omitted.