### PR TITLE
fix(ssr): escape ampersands in attributes

### DIFF
--- a/packages/unhead/src/server/util/propsToString.ts
+++ b/packages/unhead/src/server/util/propsToString.ts
@@ -1,11 +1,14 @@
 import { INVALID_ATTR_NAME_RE } from '../../utils/attrs'
 
+const AMPERSAND_RE = /&/g
 const DOUBLE_QUOTE_RE = /"/g
 
 /* @__PURE__ */
 function encodeAttribute(value: string) {
   const s = typeof value === 'string' ? value : String(value)
-  return s.includes('"') ? s.replace(DOUBLE_QUOTE_RE, '&quot;') : s
+  return s.includes('&') || s.includes('"')
+    ? s.replace(AMPERSAND_RE, '&amp;').replace(DOUBLE_QUOTE_RE, '&quot;')
+    : s
 }
 
 /* @__PURE__ */

--- a/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
+++ b/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
@@ -380,13 +380,13 @@ describe('useHeadSafe edge cases', () => {
       expect(ctx.headTags).not.toContain('Content-Security-Policy')
     })
 
-    it('escapes quotes in attribute values', async () => {
+    it('escapes quotes and ampersands in attribute values', async () => {
       const ctx = await safeRender({
         meta: [{ name: 'description', content: 'He said "hello" & <goodbye>' }],
       })
       expect(ctx.headTags).toContain('&quot;')
       // < and > are not escaped in attribute values (safe inside double quotes)
-      expect(ctx.headTags).toContain('content="He said &quot;hello&quot; & <goodbye>"')
+      expect(ctx.headTags).toContain('content="He said &quot;hello&quot; &amp; <goodbye>"')
     })
   })
 

--- a/packages/unhead/test/unit/server/util.test.ts
+++ b/packages/unhead/test/unit/server/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { propsToString } from '../../../src/server'
+import { propsToString, tagToString } from '../../../src/server'
 
 describe('propsToString', () => {
   it('prepends a space only when there are props', async () => {
@@ -7,6 +7,42 @@ describe('propsToString', () => {
       a: 'b',
     })).toStrictEqual(' a="b"')
     expect(propsToString({})).toStrictEqual('')
+  })
+  it('escapes ampersands in URL attributes', () => {
+    expect(tagToString({
+      tag: 'link',
+      props: {
+        rel: 'preload',
+        as: 'image',
+        href: '/_ipx/w_200&q_10/image.png',
+        imagesrcset: '/_ipx/w_200&q_10/image.png 1x, /_ipx/w_400&q_10/image.png 2x',
+      },
+    })).toStrictEqual('<link rel="preload" as="image" href="/_ipx/w_200&amp;q_10/image.png" imagesrcset="/_ipx/w_200&amp;q_10/image.png 1x, /_ipx/w_400&amp;q_10/image.png 2x">')
+  })
+  it('escapes ampersands in metadata content', () => {
+    expect(tagToString({
+      tag: 'meta',
+      props: {
+        name: 'description',
+        content: 'Research & Development',
+      },
+    })).toStrictEqual('<meta name="description" content="Research &amp; Development">')
+    expect(tagToString({
+      tag: 'meta',
+      props: {
+        name: 'description',
+        content: 'a&copy;b',
+      },
+    })).toStrictEqual('<meta name="description" content="a&amp;copy;b">')
+  })
+  it('treats already encoded attributes as literal input', () => {
+    expect(tagToString({
+      tag: 'meta',
+      props: {
+        name: 'description',
+        content: 'a&amp;b &quot;quoted&quot;',
+      },
+    })).toStrictEqual('<meta name="description" content="a&amp;amp;b &amp;quot;quoted&amp;quot;">')
   })
   it ('class / style strings', () => {
     expect(propsToString({

--- a/packages/unhead/test/unit/server/xss.test.ts
+++ b/packages/unhead/test/unit/server/xss.test.ts
@@ -381,7 +381,7 @@ describe('xss', () => {
     const ctx = renderSSRHead(head)
     expect(ctx.headTags).toMatchInlineSnapshot(`
       "<link rel="stylesheet" href="//evil.com/xss.js">
-      <link rel="stylesheet" href="javascript&#58;alert(1)">
+      <link rel="stylesheet" href="javascript&amp;#58;alert(1)">
       <link rel="stylesheet" href="vbscript:alert(1)">"
     `)
   })


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

SSR attribute serialization escaped quotes but left ampersands raw, allowing entity-like values and query-string URLs to change when parsed. The serializer now escapes ampersands first and tests raw, encoded, safe-head, and responsive image inputs.