### PR TITLE
fix(types): narrow unpackMeta return type

### DIFF
--- a/packages/unhead/src/plugins/flatMeta.ts
+++ b/packages/unhead/src/plugins/flatMeta.ts
@@ -15,7 +15,6 @@ export const FlatMetaPlugin = /* @__PURE__ */ defineHeadPlugin({
           continue
         }
         hasFlatMeta = true
-        // @ts-expect-error untyped
         for (const props of unpackMeta(t.props))
           tagsToAdd.push({ ...t, tag: 'meta', props })
       }

--- a/packages/unhead/src/utils/meta.ts
+++ b/packages/unhead/src/utils/meta.ts
@@ -1,4 +1,4 @@
-import type { MetaFlat, MetaGeneric, ResolvableHead, UnheadMeta } from '../types'
+import type { MetaFlat, MetaGeneric, UnheadMeta } from '../types'
 import { MetaTagsArrayable } from './const'
 
 export type MetaKeyType = 'name' | 'property' | 'http-equiv'
@@ -137,7 +137,7 @@ function handleObjectEntry(key: string, value: Record<string, any>): UnheadMeta[
     Object.entries(sanitizedValue)
       .map(([k, v]) => [`${key}${k === 'url' ? '' : `${k[0].toUpperCase()}${k.slice(1)}`}`, v]),
   )
-  return (unpackMeta(input || {}) as UnheadMeta[])
+  return unpackMeta(input || {})
     .sort((a: any, b: any) => ((a[attr]?.length || 0) - (b[attr]?.length || 0)))
 }
 
@@ -171,7 +171,7 @@ export function resolvePackedMetaObjectValue(value: any, key: string): string {
   })
 }
 
-export function unpackMeta<T extends MetaFlat>(input: T): Required<ResolvableHead>['meta'] {
+export function unpackMeta<T extends MetaFlat>(input: T): UnheadMeta[] {
   const extras: UnheadMeta[] = []
   const primitives: Record<string, any> = {}
 
@@ -193,14 +193,14 @@ export function unpackMeta<T extends MetaFlat>(input: T): Required<ResolvableHea
 
           for (const [propKey, propValue] of Object.entries(v)) {
             const metaKey = `${key}${propKey === 'url' ? '' : `:${propKey}`}`
-            const meta = unpackMeta({ [metaKey]: propValue }) as UnheadMeta[]
+            const meta = unpackMeta({ [metaKey]: propValue })
             ;(propKey === 'url' ? urlProps : otherProps).push(...meta)
           }
           extras.push(...urlProps, ...otherProps)
         }
         else {
           extras.push(...(typeof v === 'string'
-            ? unpackMeta({ [key]: v }) as UnheadMeta[]
+            ? unpackMeta({ [key]: v })
             : handleObjectEntry(key, v)))
         }
       }
@@ -272,5 +272,5 @@ export function unpackMeta<T extends MetaFlat>(input: T): Required<ResolvableHea
       : m.content === '_null'
         ? { ...m, content: null }
         : m,
-  ) as Required<ResolvableHead>['meta']
+  )
 }

--- a/packages/unhead/test/unit/types.test.ts
+++ b/packages/unhead/test/unit/types.test.ts
@@ -1,9 +1,10 @@
-import type { HeadEntry, HeadEntryOptions, Link, PreloadLink, Script, SerializableHead } from '../../src/types'
+import type { HeadEntry, HeadEntryOptions, Link, PreloadLink, Script, SerializableHead, UnheadMeta } from '../../src/types'
 import type { MetaKeyType, ResolveTagsOptions } from '../../src/utils'
 import { expectTypeOf } from 'vitest'
 import { useHead, useHeadSafe, useSeoMeta } from '../../src/composables'
 import { defineLink, defineScript } from '../../src/define'
 import { createHead } from '../../src/server'
+import { unpackMeta } from '../../src/utils'
 
 describe('types', () => {
   it('exports extension types without narrowing existing entries', () => {
@@ -11,6 +12,10 @@ describe('types', () => {
     expectTypeOf<ResolveTagsOptions>().toHaveProperty('tagWeight')
     expectTypeOf<NonNullable<HeadEntry<unknown>['options']>>()
       .toEqualTypeOf<Omit<HeadEntryOptions, 'head' | 'onRendered'>>()
+  })
+  it('types unpackMeta output as concrete meta tags', () => {
+    const meta = unpackMeta({ description: 'Page description' })
+    expectTypeOf(meta).toEqualTypeOf<UnheadMeta[]>()
   })
   it('preserves properties validated by define helpers', () => {
     const preload = defineLink({


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`unpackMeta()` always returns a concrete meta array, but its public type exposed a resolvable union and forced consumers to cast the result. The return type is now `UnheadMeta[]`, with internal casts removed and an exact public type regression.