### PR TITLE
fix(types): narrow unpackMeta return type

### DIFF
--- a/packages/unhead/src/utils/meta.ts
+++ b/packages/unhead/src/utils/meta.ts
@@ -1,4 +1,4 @@
-import type { MetaFlat, ResolvableHead, UnheadMeta } from '../types'
+import type { MetaFlat, UnheadMeta } from '../types'
 import { MetaTagsArrayable } from './const'
 
 export const NAMESPACES = /* @__PURE__ */ {
@@ -130,10 +130,8 @@ function handleObjectEntry(key: string, value: Record<string, any>): UnheadMeta[
     Object.entries(sanitizedValue)
       .map(([k, v]) => [`${key}${k === 'url' ? '' : `${k[0].toUpperCase()}${k.slice(1)}`}`, v]),
   )
-  // @ts-expect-error untyped
   return unpackMeta(input || {})
-    // @ts-expect-error untyped
-    .sort((a, b) => ((a[attr]?.length || 0) - (b[attr]?.length || 0))) as UnheadMeta[]
+    .sort((a: any, b: any) => ((a[attr]?.length || 0) - (b[attr]?.length || 0)))
 }
 
 export function resolveMetaKeyType(key: string): keyof UnheadMeta {
@@ -170,7 +168,7 @@ export function resolvePackedMetaObjectValue(value: string, key: string): string
   })
 }
 
-export function unpackMeta<T extends MetaFlat>(input: T): Required<ResolvableHead>['meta'] {
+export function unpackMeta<T extends MetaFlat>(input: T): UnheadMeta[] {
   const extras: UnheadMeta[] = []
   const primitives: Record<string, any> = {}
 
@@ -194,7 +192,7 @@ export function unpackMeta<T extends MetaFlat>(input: T): Required<ResolvableHea
 
           for (const [propKey, propValue] of Object.entries(v)) {
             const metaKey = `${key}${propKey === 'url' ? '' : `:${propKey}`}`
-            const meta = unpackMeta({ [metaKey]: propValue }) as UnheadMeta[]
+            const meta = unpackMeta({ [metaKey]: propValue })
             // @ts-expect-error untyped
             ;(propKey === 'url' ? urlProps : otherProps).push(...meta)
           }
@@ -203,7 +201,7 @@ export function unpackMeta<T extends MetaFlat>(input: T): Required<ResolvableHea
         }
         else {
           extras.push(...(typeof v === 'string'
-            ? unpackMeta({ [key]: v }) as UnheadMeta[]
+            ? unpackMeta({ [key]: v })
             : handleObjectEntry(key, v)))
         }
       }
@@ -276,5 +274,5 @@ export function unpackMeta<T extends MetaFlat>(input: T): Required<ResolvableHea
       : m.content === '_null'
         ? { ...m, content: null }
         : m,
-  ) as Required<ResolvableHead>['meta']
+  )
 }

--- a/packages/unhead/test/unit/types.test.ts
+++ b/packages/unhead/test/unit/types.test.ts
@@ -1,8 +1,14 @@
-import type { SerializableHead } from '../../src/types'
+import type { SerializableHead, UnheadMeta } from '../../src/types'
+import { expectTypeOf } from 'vitest'
 import { useHead, useHeadSafe, useSeoMeta } from '../../src/composables'
 import { createHead } from '../../src/server'
+import { unpackMeta } from '../../src/utils'
 
 describe('types', () => {
+  it('types unpackMeta output as concrete meta tags', () => {
+    const meta = unpackMeta({ description: 'Page description' })
+    expectTypeOf(meta).toEqualTypeOf<UnheadMeta[]>()
+  })
   it('types useHead', () => {
     const unhead = createHead()
     useHead(unhead, {


### PR DESCRIPTION
### 🔗 Linked issue

Backport of #889.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The v2 `unpackMeta()` type exposed a resolvable union even though the utility always returns a concrete meta array. This backport returns `UnheadMeta[]`, removes the resulting casts, and adds an exact public type regression.