### PR TITLE
fix: support browsers without Object.hasOwn

### DIFF
--- a/packages/schema-org/src/core/util.ts
+++ b/packages/schema-org/src/core/util.ts
@@ -1,3 +1,5 @@
+import { hasOwn } from 'unhead/utils'
+
 type MergeValue<T, U> = U extends undefined
   ? T
   : T extends readonly (infer TargetItem)[]
@@ -22,7 +24,7 @@ export function merge(target: any, source: any): any {
     return target
 
   for (const key in source) {
-    if (!Object.hasOwn(source, key) || key === '__proto__' || key === 'constructor' || key === 'prototype')
+    if (!hasOwn(source, key) || key === '__proto__' || key === 'constructor' || key === 'prototype')
       continue
 
     const value = source[key]

--- a/packages/schema-org/src/plugin.ts
+++ b/packages/schema-org/src/plugin.ts
@@ -2,7 +2,7 @@ import type { HeadPlugin, HeadTag, Unhead } from 'unhead/types'
 import type { SchemaOrgGraph } from './core/graph'
 import type { MetaInput, ResolvedMeta } from './types'
 import { defineHeadPlugin, TemplateParamsPlugin } from 'unhead/plugins'
-import { processTemplateParams } from 'unhead/utils'
+import { hasOwn, processTemplateParams } from 'unhead/utils'
 import {
   createSchemaOrgGraph,
 } from './core/graph'
@@ -12,7 +12,7 @@ import { resolveMeta } from './core/resolve'
 function mergeObjects(target: any, source: any): any {
   const result = { ...target }
   for (const key in source) {
-    if (!Object.hasOwn(source, key) || source[key] === undefined || key === '__proto__' || key === 'constructor' || key === 'prototype')
+    if (!hasOwn(source, key) || source[key] === undefined || key === '__proto__' || key === 'constructor' || key === 'prototype')
       continue
 
     const isNestedObject = result[key]

--- a/packages/schema-org/src/utils/index.ts
+++ b/packages/schema-org/src/utils/index.ts
@@ -3,6 +3,7 @@ import type {
   Id,
   Thing,
 } from '../types'
+import { hasOwn } from 'unhead/utils'
 
 const PROTOCOL_RE = /^[\s\w\0+.-]{2,}:(?:[/\\]{2})?/
 const JOIN_LEADING_SLASH_RE = /^\.?\//
@@ -177,7 +178,7 @@ export function resolveAsGraphKey(key?: Id | string) {
  */
 export function stripEmptyProperties(obj: any) {
   for (const k in obj) {
-    if (!Object.hasOwn(obj, k))
+    if (!hasOwn(obj, k))
       continue
 
     const v = obj[k]
@@ -215,7 +216,7 @@ export function stripNullProperties(obj: any) {
   }
 
   for (const k in obj) {
-    if (!Object.hasOwn(obj, k))
+    if (!hasOwn(obj, k))
       continue
 
     const v = obj[k]

--- a/packages/schema-org/test/ssr/browser-compatibility.test.ts
+++ b/packages/schema-org/test/ssr/browser-compatibility.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { withoutObjectHasOwn } from '../../../unhead/test/fixtures'
+import { merge } from '../../src/core/util'
+import { stripEmptyProperties, stripNullProperties } from '../../src/utils'
+
+describe('schema.org browser compatibility', () => {
+  it('processes schema data without Object.hasOwn', () => {
+    const result = withoutObjectHasOwn(() => {
+      return {
+        merged: merge({
+          nested: {
+            first: true,
+          },
+        }, {
+          nested: {
+            second: true,
+          },
+        }),
+        noEmpty: stripEmptyProperties({
+          empty: '',
+          name: 'Compatible',
+        }),
+        noNull: stripNullProperties({
+          name: 'Compatible',
+          nullable: null,
+        }),
+      }
+    })
+
+    expect(result.noEmpty).toEqual({
+      name: 'Compatible',
+    })
+    expect(result.noNull).toEqual({
+      name: 'Compatible',
+    })
+    expect(result.merged).toEqual({
+      nested: {
+        first: true,
+        second: true,
+      },
+    })
+  })
+})

--- a/packages/unhead/src/composables.ts
+++ b/packages/unhead/src/composables.ts
@@ -8,6 +8,7 @@ import type {
 } from './types'
 import { FlatMetaPlugin } from './plugins/flatMeta'
 import { SafeInputPlugin } from './plugins/safe'
+import { hasOwn } from './utils/hasOwn'
 
 export function useHead<T extends Unhead<any>, I = ResolvableHead>(unhead: T, input?: ResolvableHead, options: HeadEntryOptions = {}): ActiveHeadEntry<I> {
   return unhead.push((input || {}) as I, options) as ActiveHeadEntry<I>
@@ -27,7 +28,7 @@ export function useSeoMeta<T extends Unhead<any>>(unhead: T, input: UseSeoMetaIn
     }
     const meta: Record<string, any> = {}
     for (const key in input) {
-      if (!Object.hasOwn(input, key) || key === 'title' || key === 'titleTemplate')
+      if (!hasOwn(input, key) || key === 'title' || key === 'titleTemplate')
         continue
       meta[key] = input[key as keyof UseSeoMetaInput]
     }

--- a/packages/unhead/src/parser/index.ts
+++ b/packages/unhead/src/parser/index.ts
@@ -1,4 +1,5 @@
 import type { SerializableHead } from '../types'
+import { hasOwn } from '../utils/hasOwn'
 
 const TAG_HTML = 0
 const TAG_HEAD = 1
@@ -186,7 +187,7 @@ export function parseAttributes(attrStr: string): Record<string, string> {
   const setAttr = (attrName: string, value: string) => {
     // Browsers keep the first duplicate attribute. Preserve that behavior so
     // template extraction cannot rewrite inert tags into active ones.
-    if (!Object.hasOwn(result, attrName))
+    if (!hasOwn(result, attrName))
       result[attrName] = value
   }
   const len = attrStr.length

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -16,6 +16,7 @@ import type {
   UseScriptScopeReturn,
   WarmupStrategy,
 } from './types'
+import { hasOwn } from '../utils/hasOwn'
 import { callHook } from '../utils/hooks'
 import { createForwardingProxy, createNoopedRecordingProxy, replayProxyRecordings } from './proxy'
 import { createScriptScope } from './scope'
@@ -57,7 +58,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
   } = _options || {}
   const id = input.key || input.src || (typeof input.innerHTML === 'string' ? input.innerHTML : '')
   const scripts = head._scripts || (head._scripts = Object.create(null))
-  const prevScript = Object.hasOwn(scripts, id)
+  const prevScript = hasOwn(scripts, id)
     ? scripts[id] as undefined | UseScriptContext<UseFunctionType<UseScriptOptions<T>, T>>
     : undefined
   if (prevScript) {

--- a/packages/unhead/src/utils/hasOwn.ts
+++ b/packages/unhead/src/utils/hasOwn.ts
@@ -1,0 +1,5 @@
+const hasOwnProperty = Object.prototype.hasOwnProperty
+
+export function hasOwn(object: object, key: PropertyKey): boolean {
+  return hasOwnProperty.call(object, key)
+}

--- a/packages/unhead/src/utils/index.ts
+++ b/packages/unhead/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './const'
 export { dedupeKey, hashTag, isMetaArrayDupeKey } from './dedupe'
+export { hasOwn } from './hasOwn'
 export { resolveMetaKeyType, resolveMetaKeyValue, resolvePackedMetaObjectValue, unpackMeta } from './meta'
 export type { MetaKeyType } from './meta'
 export { normalizeEntryToTags, normalizeProps } from './normalize'

--- a/packages/unhead/test/fixtures.ts
+++ b/packages/unhead/test/fixtures.ts
@@ -13,7 +13,10 @@ export function withoutObjectHasOwn<T>(fn: () => T): T {
     return fn()
   }
   finally {
-    Object.defineProperty(Object, 'hasOwn', descriptor!)
+    if (descriptor)
+      Object.defineProperty(Object, 'hasOwn', descriptor)
+    else
+      Reflect.deleteProperty(Object, 'hasOwn')
   }
 }
 

--- a/packages/unhead/test/fixtures.ts
+++ b/packages/unhead/test/fixtures.ts
@@ -2,6 +2,21 @@ import type { SSRHeadPayload } from '@unhead/ssr'
 import type { ResolvableHead } from '../src/types'
 import { JSDOM } from 'jsdom'
 
+export function withoutObjectHasOwn<T>(fn: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(Object, 'hasOwn')
+  Object.defineProperty(Object, 'hasOwn', {
+    configurable: true,
+    value: undefined,
+    writable: true,
+  })
+  try {
+    return fn()
+  }
+  finally {
+    Object.defineProperty(Object, 'hasOwn', descriptor!)
+  }
+}
+
 export function useDom(payload?: Partial<SSRHeadPayload>, extra?: Partial<SSRHeadPayload>) {
   if (typeof window !== 'undefined') {
     // reset all window.document.documentElement attributes

--- a/packages/unhead/test/unit/browser-compatibility.test.ts
+++ b/packages/unhead/test/unit/browser-compatibility.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { useSeoMeta } from '../../src/composables'
+import { parseAttributes } from '../../src/parser'
+import { useScript } from '../../src/scripts'
+import { createHead } from '../../src/server'
+import { resolveTags } from '../../src/utils'
+import { withoutObjectHasOwn } from '../fixtures'
+
+describe('browser compatibility', () => {
+  it('normalizes SEO meta without Object.hasOwn', () => {
+    const head = createHead()
+    withoutObjectHasOwn(() => {
+      useSeoMeta(head, { description: 'Compatible' })
+    })
+
+    expect(resolveTags(head)).toContainEqual(expect.objectContaining({
+      props: {
+        content: 'Compatible',
+        name: 'description',
+      },
+      tag: 'meta',
+    }))
+  })
+
+  it('parses attributes without Object.hasOwn', () => {
+    const attributes = withoutObjectHasOwn(() => {
+      return parseAttributes('name="description" content="Compatible"')
+    })
+
+    expect(attributes).toEqual({
+      content: 'Compatible',
+      name: 'description',
+    })
+  })
+
+  it('deduplicates scripts without Object.hasOwn', () => {
+    const head = createHead()
+    const [first, second] = withoutObjectHasOwn(() => {
+      return [
+        useScript(head, '/compatible.js', { trigger: 'manual' }),
+        useScript(head, '/compatible.js', { trigger: 'manual' }),
+      ] as const
+    })
+
+    expect(first).toBe(second)
+  })
+})

--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -6,7 +6,7 @@ import type {
   UseSeoMetaInput,
 } from './types'
 import { FlatMetaPlugin, SafeInputPlugin } from 'unhead/plugins'
-import { walkResolver } from 'unhead/utils'
+import { hasOwn, walkResolver } from 'unhead/utils'
 import {
   getCurrentInstance,
   getCurrentScope,
@@ -84,7 +84,7 @@ function normalizeSeoMetaInput(input: UseSeoMetaInput) {
 
   const meta: Record<string, any> = {}
   for (const key in input) {
-    if (!Object.hasOwn(input, key) || key === 'title' || key === 'titleTemplate')
+    if (!hasOwn(input, key) || key === 'title' || key === 'titleTemplate')
       continue
     meta[key] = input[key as keyof UseSeoMetaInput]
   }

--- a/packages/vue/test/unit/e2e/useSeoMeta.test.ts
+++ b/packages/vue/test/unit/e2e/useSeoMeta.test.ts
@@ -3,11 +3,23 @@
 import { renderDOMHead } from '@unhead/dom'
 import { renderSSRHead } from '@unhead/ssr'
 import { useSeoMeta } from '@unhead/vue'
+import { createHead } from '@unhead/vue/client'
 import { describe, it } from 'vitest'
-import { useDom } from '../../../../unhead/test/fixtures'
+import { useDom, withoutObjectHasOwn } from '../../../../unhead/test/fixtures'
 import { csrVueAppWithUnhead, ssrVueAppWithUnhead } from '../../util'
 
 describe('unhead vue e2e useSeoMeta', () => {
+  it('normalizes flat meta without Object.hasOwn', () => {
+    const dom = useDom()
+    const head = createHead()
+    withoutObjectHasOwn(() => {
+      useSeoMeta({ description: 'Compatible' }, { head })
+    })
+    renderDOMHead(head, { document: dom.window.document })
+
+    expect(dom.window.document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Compatible')
+  })
+
   it('normalizes flat meta patches', async () => {
     const dom = useDom()
     let entry: ReturnType<typeof useSeoMeta> | undefined

--- a/test/exports/react.yaml
+++ b/test/exports/react.yaml
@@ -57,6 +57,7 @@
   DupeableTags: object
   HasElementTags: object
   hashTag: function
+  hasOwn: function
   isMetaArrayDupeKey: function
   MetaTagsArrayable: object
   normalizeEntryToTags: function

--- a/test/exports/solid-js.yaml
+++ b/test/exports/solid-js.yaml
@@ -54,6 +54,7 @@
   DupeableTags: object
   HasElementTags: object
   hashTag: function
+  hasOwn: function
   isMetaArrayDupeKey: function
   MetaTagsArrayable: object
   normalizeEntryToTags: function

--- a/test/exports/svelte.yaml
+++ b/test/exports/svelte.yaml
@@ -55,6 +55,7 @@
   DupeableTags: object
   HasElementTags: object
   hashTag: function
+  hasOwn: function
   isMetaArrayDupeKey: function
   MetaTagsArrayable: object
   normalizeEntryToTags: function

--- a/test/exports/unhead.yaml
+++ b/test/exports/unhead.yaml
@@ -93,6 +93,7 @@
   DupeableTags: object
   HasElementTags: object
   hashTag: function
+  hasOwn: function
   isMetaArrayDupeKey: function
   MetaTagsArrayable: object
   normalizeEntryToTags: function

--- a/test/exports/vue.yaml
+++ b/test/exports/vue.yaml
@@ -77,6 +77,7 @@
   DupeableTags: object
   HasElementTags: object
   hashTag: function
+  hasOwn: function
   isMetaArrayDupeKey: function
   MetaTagsArrayable: object
   normalizeEntryToTags: function


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Browser-reachable code used `Object.hasOwn()`, which fails in Safari 14 and other environments without that API. A shared `hasOwnProperty.call` helper now covers core, Vue, and Schema.org client paths while the server-only serializer keeps `Object.hasOwn()`.