### PR TITLE
fix(react): support Fragment children in Head

### DIFF
--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -9,12 +9,27 @@ export interface HeadProps {
   titleTemplate?: string
 }
 
+function flattenHeadElements(children: ReactNode): React.ReactElement[] {
+  const elements: React.ReactElement[] = []
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child))
+      return
+
+    if (child.type === React.Fragment) {
+      elements.push(...flattenHeadElements((child.props as { children?: ReactNode }).children))
+      return
+    }
+
+    elements.push(child)
+  })
+  return elements
+}
+
 const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
   const head = useUnhead()
 
   // Process children only when they change
-  const processedElements = useMemo(() =>
-    React.Children.toArray(children).filter(React.isValidElement), [children])
+  const processedElements = useMemo(() => flattenHeadElements(children), [children])
 
   const getHeadChanges = useCallback(() => {
     const input: UseHeadInput = {

--- a/packages/react/test/SimpleHead.test.tsx
+++ b/packages/react/test/SimpleHead.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react'
 // @vitest-environment jsdom
 import React from 'react'
 import { describe, expect, it } from 'vitest'
+import { Head } from '../src'
 import { createHead, UnheadProvider } from '../src/client'
 import { renderSSRHead } from '../src/server'
 import { SimpleHead } from './fixtures/SimpleHead'
@@ -49,5 +50,33 @@ describe('simpleHead component', () => {
 
     const { headTags } = renderSSRHead(head)
     expect(headTags).toBe('')
+  })
+
+  it('renders nested fragment children', async () => {
+    const head = createHead()
+
+    render(
+      <UnheadProvider head={head}>
+        <Head>
+          <>
+            {[
+              <meta key="meta" name="fragment-meta" content="nested" />,
+              <React.Fragment key="script">
+                {null}
+                <meta name="fragment-meta-2" content="nested-2" />
+                <script>window.__FRAGMENT_TEST__ = true</script>
+              </React.Fragment>,
+            ]}
+          </>
+        </Head>
+      </UnheadProvider>,
+    )
+
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).toMatchInlineSnapshot(`
+      "<script>window.__FRAGMENT_TEST__ = true</script>
+      <meta name="fragment-meta" content="nested">
+      <meta name="fragment-meta-2" content="nested-2">"
+    `)
   })
 })

--- a/packages/react/test/SimpleHeadSSR.test.tsx
+++ b/packages/react/test/SimpleHeadSSR.test.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { renderToString } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { Head } from '../src'
 import { UnheadProvider } from '../src/client'
 import { createHead, renderSSRHead, transformHtmlTemplate } from '../src/server'
 import { SimpleHead } from './fixtures/SimpleHead'
@@ -71,6 +72,34 @@ describe('simpleHead component in ssr', () => {
       <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
       <link rel="icon" href="favicon.ico">
       <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Example","url":"https://www.example.com"}</script>"
+    `)
+  })
+
+  it('renders nested fragment children', async () => {
+    const head = createHead({ disableDefaults: true })
+
+    renderToString(
+      <UnheadProvider head={head}>
+        <Head>
+          <>
+            {[
+              <meta key="meta" name="fragment-meta" content="nested" />,
+              <React.Fragment key="script">
+                {false}
+                <meta name="fragment-meta-2" content="nested-2" />
+                <script>window.__FRAGMENT_TEST__ = true</script>
+              </React.Fragment>,
+            ]}
+          </>
+        </Head>
+      </UnheadProvider>,
+    )
+
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).toMatchInlineSnapshot(`
+      "<script>window.__FRAGMENT_TEST__ = true</script>
+      <meta name="fragment-meta" content="nested">
+      <meta name="fragment-meta-2" content="nested-2">"
     `)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

React's `<Head>` adapter drops tags nested inside Fragments, so integrations such as Zudoku need to flatten children themselves. Recursively flatten Fragment children in client and SSR paths while preserving element order and conditional children.