### PR TITLE
fix(react): normalize Head JSX props

### DIFF
--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -9,6 +9,23 @@ export interface HeadProps {
   titleTemplate?: string
 }
 
+function normalizeReactPropAliases(props: unknown): Record<string, any> {
+  if (!props || typeof props !== 'object')
+    return {}
+
+  const normalized: Record<string, any> = {}
+  for (const [prop, value] of Object.entries(props)) {
+    if (prop === 'ref' || prop === 'suppressContentEditableWarning' || prop === 'suppressHydrationWarning')
+      continue
+
+    const name = prop === 'className'
+      ? 'class'
+      : prop === 'httpEquiv' ? 'http-equiv' : prop
+    normalized[name] = value
+  }
+  return normalized
+}
+
 const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
   const head = useUnhead()
 
@@ -30,7 +47,7 @@ const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
         continue
       }
 
-      const data: Record<string, any> = { ...(typeof props === 'object' ? props : {}) }
+      const data = normalizeReactPropAliases(props)
 
       if (TagsWithInnerContent.has(tagName) && data.children) {
         const contentKey = tagName === 'script' ? 'innerHTML' : 'textContent'

--- a/packages/react/test/SimpleHead.test.tsx
+++ b/packages/react/test/SimpleHead.test.tsx
@@ -1,8 +1,9 @@
 import { render } from '@testing-library/react'
 // @vitest-environment jsdom
 import React from 'react'
-import { describe, expect, it } from 'vitest'
-import { createHead, UnheadProvider } from '../src/client'
+import { describe, expect, it, vi } from 'vitest'
+import { Head } from '../src'
+import { createHead, renderDOMHead, UnheadProvider } from '../src/client'
 import { renderSSRHead } from '../src/server'
 import { SimpleHead } from './fixtures/SimpleHead'
 
@@ -49,5 +50,76 @@ describe('simpleHead component', () => {
 
     const { headTags } = renderSSRHead(head)
     expect(headTags).toBe('')
+  })
+
+  it('normalizes React head prop names in the DOM', async () => {
+    const head = createHead()
+    const onLoad = vi.fn()
+
+    render(
+      <UnheadProvider head={head}>
+        <Head>
+          <meta
+            ref={React.createRef<HTMLMetaElement>()}
+            httpEquiv="refresh"
+            content="0;url=/next"
+            className="refresh metadata"
+            style={{ color: 'red' }}
+            itemProp="refresh"
+            suppressContentEditableWarning
+            suppressHydrationWarning
+          />
+          <link
+            rel="preload"
+            href="/hero.png"
+            as="image"
+            crossOrigin="anonymous"
+            fetchPriority="high"
+            hrefLang="en"
+            imageSrcSet="/hero.png 1x, /hero-2x.png 2x"
+            imageSizes="100vw"
+            referrerPolicy="no-referrer"
+          />
+          <script
+            src="/legacy.js"
+            charSet="utf-8"
+            crossOrigin="use-credentials"
+            fetchPriority="low"
+            noModule
+            referrerPolicy="origin"
+            onLoad={onLoad}
+          />
+        </Head>
+      </UnheadProvider>,
+    )
+
+    await renderDOMHead(head, { document })
+
+    const meta = document.head.querySelector('meta[http-equiv="refresh"]')
+    expect(meta).not.toBeNull()
+    expect(meta?.getAttribute('httpequiv')).toBeNull()
+    expect(meta?.className).toBe('refresh metadata')
+    expect((meta as HTMLElement).style.color).toBe('red')
+    expect(meta?.getAttribute('itemprop')).toBe('refresh')
+    expect(meta?.hasAttribute('ref')).toBe(false)
+    expect(meta?.hasAttribute('suppresscontenteditablewarning')).toBe(false)
+    expect(meta?.hasAttribute('suppresshydrationwarning')).toBe(false)
+
+    const link = document.head.querySelector('link[href="/hero.png"]')
+    expect(link?.getAttribute('crossorigin')).toBe('anonymous')
+    expect(link?.getAttribute('fetchpriority')).toBe('high')
+    expect(link?.getAttribute('hreflang')).toBe('en')
+    expect(link?.getAttribute('imagesrcset')).toBe('/hero.png 1x, /hero-2x.png 2x')
+    expect(link?.getAttribute('imagesizes')).toBe('100vw')
+    expect(link?.getAttribute('referrerpolicy')).toBe('no-referrer')
+
+    const script = document.head.querySelector('script[src="/legacy.js"]')
+    expect(script?.getAttribute('charset')).toBe('utf-8')
+    expect(script?.getAttribute('crossorigin')).toBe('use-credentials')
+    expect(script?.getAttribute('fetchpriority')).toBe('low')
+    expect(script?.hasAttribute('nomodule')).toBe(true)
+    expect(script?.getAttribute('referrerpolicy')).toBe('origin')
+    script?.dispatchEvent(new Event('load'))
+    expect(onLoad).toHaveBeenCalledOnce()
   })
 })

--- a/packages/react/test/SimpleHeadSSR.test.tsx
+++ b/packages/react/test/SimpleHeadSSR.test.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { renderToString } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { Head } from '../src'
 import { UnheadProvider } from '../src/client'
 import { createHead, renderSSRHead, transformHtmlTemplate } from '../src/server'
 import { SimpleHead } from './fixtures/SimpleHead'
@@ -72,5 +73,66 @@ describe('simpleHead component in ssr', () => {
       <link rel="icon" href="favicon.ico">
       <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Example","url":"https://www.example.com"}</script>"
     `)
+  })
+
+  it('normalizes React head prop names during SSR', async () => {
+    const head = createHead({ disableDefaults: true })
+
+    renderToString(
+      <UnheadProvider head={head}>
+        <Head>
+          <meta
+            ref={React.createRef<HTMLMetaElement>()}
+            httpEquiv="refresh"
+            content="0;url=/next"
+            className="refresh metadata"
+            style={{ color: 'red' }}
+            itemProp="refresh"
+            suppressContentEditableWarning
+            suppressHydrationWarning
+          />
+          <link
+            rel="preload"
+            href="/hero.png"
+            as="image"
+            crossOrigin="anonymous"
+            fetchPriority="high"
+            hrefLang="en"
+            imageSrcSet="/hero.png 1x, /hero-2x.png 2x"
+            imageSizes="100vw"
+            referrerPolicy="no-referrer"
+          />
+          <script
+            src="/legacy.js"
+            charSet="utf-8"
+            crossOrigin="use-credentials"
+            fetchPriority="low"
+            noModule
+            referrerPolicy="origin"
+          />
+        </Head>
+      </UnheadProvider>,
+    )
+
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).toContain('http-equiv="refresh"')
+    expect(headTags).not.toContain('httpequiv=')
+    expect(headTags).toContain('class="refresh metadata"')
+    expect(headTags).toContain('style="color:red"')
+    expect(headTags).toContain('itemprop="refresh"')
+    expect(headTags).not.toContain(' ref=')
+    expect(headTags).not.toContain('suppresscontenteditablewarning')
+    expect(headTags).not.toContain('suppresshydrationwarning')
+    expect(headTags).toContain('crossorigin="anonymous"')
+    expect(headTags).toContain('fetchpriority="high"')
+    expect(headTags).toContain('hreflang="en"')
+    expect(headTags).toContain('imagesrcset="/hero.png 1x, /hero-2x.png 2x"')
+    expect(headTags).toContain('imagesizes="100vw"')
+    expect(headTags).toContain('referrerpolicy="no-referrer"')
+    expect(headTags).toContain('charset="utf-8"')
+    expect(headTags).toContain('crossorigin="use-credentials"')
+    expect(headTags).toContain('fetchpriority="low"')
+    expect(headTags).toContain('nomodule')
+    expect(headTags).toContain('referrerpolicy="origin"')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

React JSX aliases such as `className` and `httpEquiv` currently serialize to the wrong HTML attributes, and React control props can leak into head tags. Normalize those aliases and omit control props before passing each element to Unhead in both client and SSR rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * React head elements now correctly normalize React-style property names to standard HTML attributes.
  * React-only properties are excluded from rendered head markup.
  * Normalized attributes now work consistently in both browser and server-rendered output.
  * Script load handlers continue to fire correctly after rendering. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->