### PR TITLE
fix(react): support raw content in Head

### DIFF
--- a/docs/0.react/head/guides/1.core-concepts/1.components.md
+++ b/docs/0.react/head/guides/1.core-concepts/1.components.md
@@ -80,6 +80,24 @@ Google does not set a fixed meta-description length; search snippets are truncat
 </Head>
 ```
 
+### Raw HTML
+
+`<Head>` supports React's `dangerouslySetInnerHTML` prop on `<title>`, `<script>`, `<style>`, and `<noscript>`. It cannot be combined with children.
+
+Use a string child for ordinary inline scripts and styles. Use `dangerouslySetInnerHTML` when the content must be parsed as raw markup, such as an HTML fallback inside `<noscript>`:
+
+```tsx
+const trustedFallback = {
+  __html: '<img src="/pixel.gif" alt="">'
+}
+
+<Head>
+  <noscript dangerouslySetInnerHTML={trustedFallback} />
+</Head>
+```
+
+Only pass trusted or sanitized content. Untrusted HTML can introduce an XSS vulnerability. See [React's `dangerouslySetInnerHTML` guidance](https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html).
+
 ### Open Graph
 
 ```tsx

--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -9,6 +9,28 @@ export interface HeadProps {
   titleTemplate?: string
 }
 
+function normalizeRawContent(tagName: string, data: Record<string, any>) {
+  const rawContent = data.dangerouslySetInnerHTML
+  delete data.dangerouslySetInnerHTML
+
+  if (rawContent == null)
+    return
+
+  if (!TagsWithInnerContent.has(tagName)) {
+    throw new Error(`${tagName} is a self-closing tag and must neither have \`children\` nor use \`dangerouslySetInnerHTML\`.`)
+  }
+  if (typeof rawContent !== 'object' || !('__html' in rawContent)) {
+    throw new Error('`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`.')
+  }
+  if (data.children != null) {
+    throw new Error('Can only set one of `children` or `props.dangerouslySetInnerHTML`.')
+  }
+
+  const content = rawContent.__html
+  if (content != null)
+    data[tagName === 'title' ? 'textContent' : 'innerHTML'] = String(content)
+}
+
 const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
   const head = useUnhead()
 
@@ -31,6 +53,7 @@ const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
       }
 
       const data: Record<string, any> = { ...(typeof props === 'object' ? props : {}) }
+      normalizeRawContent(tagName, data)
 
       if (TagsWithInnerContent.has(tagName) && data.children) {
         const contentKey = tagName === 'script' ? 'innerHTML' : 'textContent'

--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -87,7 +87,7 @@ const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
       const data = normalizeReactPropAliases(props)
       normalizeRawContent(tagName, data)
 
-      if (TagsWithInnerContent.has(tagName) && data.children) {
+      if (TagsWithInnerContent.has(tagName) && data.children != null) {
         const contentKey = tagName === 'script' ? 'innerHTML' : 'textContent'
         data[contentKey] = Array.isArray(data.children)
           ? data.children.map(String).join('')

--- a/packages/react/test/HeadRawContent.test.tsx
+++ b/packages/react/test/HeadRawContent.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Head } from '../src'
+import { createHead, renderDOMHead, UnheadProvider } from '../src/client'
+
+describe('head raw content in the DOM', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''
+  })
+
+  it('maps dangerouslySetInnerHTML to supported head tag content', async () => {
+    const head = createHead()
+    const script = '<span data-value="script">& raw</span>'
+    const style = 'body::before { content: "<unsafe>"; }'
+    const noscript = '<img src="pixel.gif" alt="pixel">'
+    const title = '<b>Title</b> & value'
+
+    render(
+      <UnheadProvider head={head}>
+        <Head>
+          <script data-test="script" type="text/plain" dangerouslySetInnerHTML={{ __html: script }} />
+          <style data-test="style" dangerouslySetInnerHTML={{ __html: style }} />
+          <noscript data-test="noscript" dangerouslySetInnerHTML={{ __html: noscript }} />
+          <title dangerouslySetInnerHTML={{ __html: title }} />
+        </Head>
+      </UnheadProvider>,
+    )
+
+    await renderDOMHead(head, { document })
+
+    expect(document.head.querySelector('[data-test="script"]')?.textContent).toBe(script)
+    expect(document.head.querySelector('[data-test="style"]')?.textContent).toBe(style)
+    expect(document.head.querySelector('[data-test="noscript"]')?.textContent).toBe(noscript)
+    expect(document.title).toBe(title)
+    expect(document.head.querySelector('[dangerouslysetinnerhtml]')).toBeNull()
+  })
+})

--- a/packages/react/test/HeadRawContentSSR.test.tsx
+++ b/packages/react/test/HeadRawContentSSR.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { Head } from '../src'
+import { createHead, renderSSRHead, UnheadProvider } from '../src/server'
+
+describe('head raw content in SSR', () => {
+  it('renders raw content without serializing the React control prop', () => {
+    const head = createHead({ disableDefaults: true })
+
+    renderToString(
+      <UnheadProvider value={head}>
+        <Head>
+          <script
+            type="application/javascript"
+            dangerouslySetInnerHTML={{ __html: 'window.payload = "</script><script>evil()</script>"' }}
+          />
+          <style dangerouslySetInnerHTML={{ __html: 'body::before { content: "</style><script>evil()</script>"; }' }} />
+          <noscript dangerouslySetInnerHTML={{ __html: '<img src="pixel.gif" alt="pixel">' }} />
+          <title dangerouslySetInnerHTML={{ __html: '<b>Title</b> & value' }} />
+        </Head>
+      </UnheadProvider>,
+    )
+
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).toContain('<script type="application/javascript">window.payload = "<\\/script><script>evil()<\\/script>"</script>')
+    expect(headTags).toContain('<style>body::before { content: "<\\/style><script>evil()</script>"; }</style>')
+    expect(headTags).toContain('<noscript><img src="pixel.gif" alt="pixel"></noscript>')
+    expect(headTags).toContain('<title>&lt;b&gt;Title&lt;&#x2F;b&gt; &amp; value</title>')
+    expect(headTags.toLowerCase()).not.toContain('dangerouslysetinnerhtml')
+  })
+
+  it.each(['title', 'script', 'style', 'noscript'])(
+    'rejects children combined with dangerouslySetInnerHTML on <%s>',
+    (tagName) => {
+      const head = createHead({ disableDefaults: true })
+      const rawElement = React.createElement(tagName, {
+        dangerouslySetInnerHTML: { __html: 'raw' },
+      }, 'child')
+
+      expect(() => renderToString(
+        <UnheadProvider value={head}>
+          <Head>{rawElement}</Head>
+        </UnheadProvider>,
+      )).toThrow('Can only set one of `children` or `props.dangerouslySetInnerHTML`.')
+    },
+  )
+
+  it('rejects malformed dangerouslySetInnerHTML values', () => {
+    const head = createHead({ disableDefaults: true })
+    const rawElement = React.createElement('script', {
+      dangerouslySetInnerHTML: {} as { __html: string },
+    })
+
+    expect(() => renderToString(
+      <UnheadProvider value={head}>
+        <Head>{rawElement}</Head>
+      </UnheadProvider>,
+    )).toThrow('`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`.')
+  })
+
+  it.each(['base', 'link', 'meta'])(
+    'rejects dangerouslySetInnerHTML on self-closing <%s>',
+    (tagName) => {
+      const head = createHead({ disableDefaults: true })
+      const rawElement = React.createElement(tagName, {
+        dangerouslySetInnerHTML: { __html: 'raw' },
+      })
+
+      expect(() => renderToString(
+        <UnheadProvider value={head}>
+          <Head>{rawElement}</Head>
+        </UnheadProvider>,
+      )).toThrow(`${tagName} is a self-closing tag and must neither have \`children\` nor use \`dangerouslySetInnerHTML\`.`)
+    },
+  )
+})

--- a/packages/react/test/SimpleHeadSSR.test.tsx
+++ b/packages/react/test/SimpleHeadSSR.test.tsx
@@ -163,4 +163,25 @@ describe('simpleHead component in ssr', () => {
       <meta name="fragment-meta-2" content="nested-2">"
     `)
   })
+
+  it('preserves numeric zero children', () => {
+    const head = createHead({ disableDefaults: true })
+
+    renderToString(
+      <UnheadProvider head={head}>
+        <Head>
+          <title>{0}</title>
+          <script type="text/plain">{0}</script>
+          <style>{0}</style>
+          <noscript>{0}</noscript>
+        </Head>
+      </UnheadProvider>,
+    )
+
+    const { headTags } = renderSSRHead(head)
+    expect(headTags).toContain('<title>0</title>')
+    expect(headTags).toContain('<script type="text/plain">0</script>')
+    expect(headTags).toContain('<style>0</style>')
+    expect(headTags).toContain('<noscript>0</noscript>')
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [x] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`dangerouslySetInnerHTML` was emitted as an attribute by the React `<Head>` adapter, leaving raw content empty. Map valid raw content to Unhead content fields, reject conflicting shapes, preserve numeric zero children, document trusted input, and retain SSR breakout protection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for raw HTML in `<Head>` for `<script>`, `<style>`, `<noscript>`, and `<title>`.
  * Raw head content now renders correctly in both client and server output, including correct handling of `0` values.

* **Bug Fixes**
  * Prevented internal raw-content props from being emitted as DOM/HTML attributes.
  * Added stricter validation for unsupported or invalid `dangerouslySetInnerHTML` usage (including invalid combinations and malformed values).

* **Documentation**
  * Documented the “Raw HTML” capability, usage rules, and XSS considerations for `<Head>`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
