### PR TITLE
fix(validate): warn on too many prefetch's

### DIFF
--- a/docs/0.typescript/head/guides/2.tooling/2.validate-plugin.md
+++ b/docs/0.typescript/head/guides/2.tooling/2.validate-plugin.md
@@ -39,6 +39,7 @@ ValidatePlugin({
   rules: {
     'missing-description': 'off',
     'too-many-preloads': ['warn', { max: 10 }],
+    'too-many-prefetches': ['info', { max: 100 }],
     'inline-style-size': ['info', { maxKB: 20 }],
   },
   // Replace the default console.warn dispatch.
@@ -63,7 +64,10 @@ A small set of rules accept a `[severity, options]` tuple to tune their threshol
 | `meta-beyond-1mb` | `maxBytes` | 1_048_576 |
 | `too-many-fetchpriority-high` | `max` | 2 |
 | `too-many-preloads` | `max` | 6 |
+| `too-many-prefetches` | `max` | 50 |
 | `too-many-preconnects` | `max` | 4 |
+
+The `too-many-prefetches` default is an advisory guardrail for speculative bandwidth and cache use, not a browser or standards limit.
 
 ## Rule IDs
 

--- a/docs/head/1.guides/plugins/validate.md
+++ b/docs/head/1.guides/plugins/validate.md
@@ -153,6 +153,7 @@ These rules encode conservative heuristics rather than universal browser limits.
 | `preconnect-missing-crossorigin` | `warn` | `<link rel="preconnect">` is missing `crossorigin` but CORS resources are loaded from that origin, causing a separate connection |
 | `preload-fetchpriority-conflict` | `warn` | A non-script preload has `fetchpriority="low"`; script preloads are exempt because `useScript()` uses that combination for warmup |
 | `too-many-preloads` | `warn` | More than 6 `<link rel="preload">` tags compete for bandwidth and hurt performance |
+| `too-many-prefetches` | `info` | More than 50 `<link rel="prefetch">` tags may consume speculative bandwidth and cache capacity. This advisory guardrail is not a browser or standards limit |
 | `too-many-preconnects` | `warn` | More than 4 `<link rel="preconnect">` tags; each starts connection work that can compete with critical resources |
 | `redundant-dns-prefetch` | `info` | Same origin has both `<link rel="preconnect">` and `<link rel="dns-prefetch">`; preconnect already includes DNS resolution |
 | `preload-async-defer-conflict` | `warn` | A preloaded script also has `async` or `defer` and the preload is not marked `fetchpriority="low"`. Browsers allow this combination; the warning is the plugin's priority heuristic |
@@ -187,6 +188,7 @@ Some rules accept an options object as an ESLint-style `[severity, options]` tup
 ValidatePlugin({
   rules: {
     'too-many-preloads': ['warn', { max: 10 }],
+    'too-many-prefetches': ['info', { max: 100 }],
     'too-many-preconnects': ['warn', { max: 6 }],
     'too-many-fetchpriority-high': ['warn', { max: 3 }],
     'charset-not-early': ['warn', { maxPosition: 5 }],

--- a/packages/cli/test/validate.test.ts
+++ b/packages/cli/test/validate.test.ts
@@ -51,4 +51,20 @@ describe('validateHtml', () => {
     expect(ids).toContain('non-absolute-canonical')
     expect(ids).toContain('canonical-og-url-mismatch')
   })
+
+  it('surfaces excessive prefetches as an advisory info finding', () => {
+    const prefetches = Array.from(
+      { length: 51 },
+      (_, i) => `<link rel="prefetch" href="/future-resource-${i}.js" />`,
+    ).join('\n')
+    const html = `<!doctype html><html><head>
+      <title>x</title>
+      <meta name="description" content="d" />
+      ${prefetches}
+    </head></html>`
+
+    const rule = validateHtml(html, 'inline').rules.find(r => r.id === 'too-many-prefetches')
+    expect(rule?.severity).toBe('info')
+    expect(rule?.message).toContain('advisory guardrail, not a standards limit')
+  })
 })

--- a/packages/unhead/src/plugins/validate.ts
+++ b/packages/unhead/src/plugins/validate.ts
@@ -40,6 +40,7 @@ export interface ValidatePluginOptions {
    * rules: {
    *   'missing-description': 'off',
    *   'too-many-preloads': ['warn', { max: 10 }],
+   *   'too-many-prefetches': ['info', { max: 100 }],
    *   'inline-style-size': ['info', { maxKB: 20 }],
    * }
    * ```
@@ -340,6 +341,12 @@ export function ValidatePlugin(options: ValidatePluginOptions = {}) {
           const preloadCount = tags.filter((t: HeadTag) => t.tag === 'link' && t.props.rel === 'preload').length
           if (preloadCount > maxPreloads)
             report('too-many-preloads', `Found ${preloadCount} preload links — more than ${maxPreloads} preloads compete for bandwidth and can hurt performance.`, 'warn')
+
+          // Large prefetch sets may consume speculative bandwidth and cache capacity
+          const { max: maxPrefetches } = resolveOptions(ruleConfig, 'too-many-prefetches', { max: 50 })
+          const prefetchCount = tags.filter((t: HeadTag) => t.tag === 'link' && t.props.rel === 'prefetch').length
+          if (prefetchCount > maxPrefetches)
+            report('too-many-prefetches', `Found ${prefetchCount} prefetch links. The configured maximum of ${maxPrefetches} is an advisory guardrail, not a standards limit. Large speculative fetch sets can consume bandwidth and cache capacity.`, 'info')
 
           // Too many preconnects waste connections
           const { max: maxPreconnects } = resolveOptions(ruleConfig, 'too-many-preconnects', { max: 4 })

--- a/packages/unhead/src/validate/rules.ts
+++ b/packages/unhead/src/validate/rules.ts
@@ -45,6 +45,7 @@ export const VALIDATION_RULE_IDS = /* @__PURE__ */ [
   'script-src-with-content',
   'too-many-fetchpriority-high',
   'too-many-preconnects',
+  'too-many-prefetches',
   'too-many-preloads',
   'twitter-handle-missing-at',
   'unresolved-template-param',
@@ -59,6 +60,7 @@ export interface ValidationRuleOptions {
   'inline-style-size': { maxKB: number }
   'meta-beyond-1mb': { maxBytes: number }
   'too-many-fetchpriority-high': { max: number }
+  'too-many-prefetches': { max: number }
   'too-many-preloads': { max: number }
   'too-many-preconnects': { max: number }
 }

--- a/packages/unhead/test/unit/plugins/validate.test.ts
+++ b/packages/unhead/test/unit/plugins/validate.test.ts
@@ -668,6 +668,32 @@ describe('validatePlugin', () => {
       expect(rules.find(r => r.id === 'too-many-preloads')).toBeFalsy()
     })
 
+    it('reports more than 50 prefetches as an advisory info finding', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: Array.from({ length: 51 }, (_, i) => ({
+          rel: 'prefetch' as const,
+          href: `/future-resource-${i}.js`,
+        })),
+      })
+      renderSSRHead(head)
+      const rule = rules.find(r => r.id === 'too-many-prefetches')
+      expect(rule?.severity).toBe('info')
+      expect(rule?.message).toContain('advisory guardrail, not a standards limit')
+    })
+
+    it('does not report 50 or fewer prefetches', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        link: Array.from({ length: 50 }, (_, i) => ({
+          rel: 'prefetch' as const,
+          href: `/future-resource-${i}.js`,
+        })),
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'too-many-prefetches')).toBeFalsy()
+    })
+
     it('warns on redundant dns-prefetch when preconnect exists', () => {
       const { head, rules } = createValidationHead()
       head.push({
@@ -839,6 +865,18 @@ describe('validatePlugin', () => {
       })
       renderSSRHead(head)
       expect(rules.find(r => r.id === 'too-many-preloads')).toBeTruthy()
+    })
+
+    it('respects custom max and severity for too-many-prefetches', () => {
+      const { head, rules } = createValidationHead({ rules: { 'too-many-prefetches': ['warn', { max: 2 }] } })
+      head.push({
+        link: Array.from({ length: 3 }, (_, i) => ({
+          rel: 'prefetch' as const,
+          href: `/future-resource-${i}.js`,
+        })),
+      })
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'too-many-prefetches')?.severity).toBe('warn')
     })
 
     it('respects custom max for too-many-preconnects', () => {


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Unhead validation warns about excessive preloads but stays silent when an application creates hundreds of prefetch links. Add a configurable informational guardrail for prefetch counts to runtime and CLI validation, with a default threshold of 50.