### PR TITLE
fix(v2): align React Head JSX behavior

### DIFF
--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -9,12 +9,66 @@ interface HeadProps {
   titleTemplate?: string
 }
 
+function flattenHeadElements(children: ReactNode): React.ReactElement[] {
+  const elements: React.ReactElement[] = []
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child))
+      return
+
+    if (child.type === React.Fragment) {
+      elements.push(...flattenHeadElements((child.props as { children?: ReactNode }).children))
+      return
+    }
+
+    elements.push(child)
+  })
+  return elements
+}
+
+function normalizeReactPropAliases(props: unknown): Record<string, any> {
+  if (!props || typeof props !== 'object')
+    return {}
+
+  const normalized: Record<string, any> = {}
+  for (const [prop, value] of Object.entries(props)) {
+    if (prop === 'ref' || prop === 'suppressContentEditableWarning' || prop === 'suppressHydrationWarning')
+      continue
+
+    const name = prop === 'className'
+      ? 'class'
+      : prop === 'httpEquiv' ? 'http-equiv' : prop
+    normalized[name] = value
+  }
+  return normalized
+}
+
+function normalizeRawContent(tagName: string, data: Record<string, any>) {
+  const rawContent = data.dangerouslySetInnerHTML
+  delete data.dangerouslySetInnerHTML
+
+  if (rawContent == null)
+    return
+
+  if (!TagsWithInnerContent.has(tagName)) {
+    throw new Error(`${tagName} is a self-closing tag and must neither have \`children\` nor use \`dangerouslySetInnerHTML\`.`)
+  }
+  if (typeof rawContent !== 'object' || !('__html' in rawContent)) {
+    throw new Error('`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`.')
+  }
+  if (data.children != null) {
+    throw new Error('Can only set one of `children` or `props.dangerouslySetInnerHTML`.')
+  }
+
+  const content = rawContent.__html
+  if (content != null)
+    data[tagName === 'title' ? 'textContent' : 'innerHTML'] = String(content)
+}
+
 const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
   const head = useUnhead()
 
   // Process children only when they change
-  const processedElements = useMemo(() =>
-    React.Children.toArray(children).filter(React.isValidElement), [children])
+  const processedElements = useMemo(() => flattenHeadElements(children), [children])
 
   const getHeadChanges = useCallback(() => {
     const input: UseHeadInput = {
@@ -30,7 +84,8 @@ const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
         continue
       }
 
-      const data: Record<string, any> = { ...(typeof props === 'object' ? props : {}) }
+      const data = normalizeReactPropAliases(props)
+      normalizeRawContent(tagName, data)
 
       if (TagsWithInnerContent.has(tagName) && data.children) {
         const contentKey = tagName === 'script' ? 'innerHTML' : 'textContent'

--- a/packages/react/test/HeadRawContent.test.tsx
+++ b/packages/react/test/HeadRawContent.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Head } from '../src'
+import { createHead, renderDOMHead, UnheadProvider } from '../src/client'
+
+describe('head raw content in the DOM', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''
+  })
+
+  it('maps dangerouslySetInnerHTML to supported head tag content', async () => {
+    const head = createHead()
+    const script = '<span data-value="script">& raw</span>'
+    const style = 'body::before { content: "<unsafe>"; }'
+    const noscript = '<img src="pixel.gif" alt="pixel">'
+    const title = '<b>Title</b> & value'
+
+    render(
+      <UnheadProvider head={head}>
+        <Head>
+          <script data-test="script" type="text/plain" dangerouslySetInnerHTML={{ __html: script }} />
+          <style data-test="style" dangerouslySetInnerHTML={{ __html: style }} />
+          <noscript data-test="noscript" dangerouslySetInnerHTML={{ __html: noscript }} />
+          <title dangerouslySetInnerHTML={{ __html: title }} />
+        </Head>
+      </UnheadProvider>,
+    )
+
+    await renderDOMHead(head, { document })
+
+    expect(document.head.querySelector('[data-test="script"]')?.textContent).toBe(script)
+    expect(document.head.querySelector('[data-test="style"]')?.textContent).toBe(style)
+    expect(document.head.querySelector('[data-test="noscript"]')?.textContent).toBe(noscript)
+    expect(document.title).toBe(title)
+    expect(document.head.querySelector('[dangerouslysetinnerhtml]')).toBeNull()
+  })
+})

--- a/packages/react/test/HeadRawContentSSR.test.tsx
+++ b/packages/react/test/HeadRawContentSSR.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { Head } from '../src'
+import { createHead, renderSSRHead, UnheadProvider } from '../src/server'
+
+describe('head raw content in SSR', () => {
+  it('renders raw content without serializing the React control prop', async () => {
+    const head = createHead({ disableDefaults: true })
+
+    renderToString(
+      <UnheadProvider value={head}>
+        <Head>
+          <script
+            type="application/javascript"
+            dangerouslySetInnerHTML={{ __html: 'window.payload = "</script><script>evil()</script>"' }}
+          />
+          <style dangerouslySetInnerHTML={{ __html: 'body::before { content: "</style><script>evil()</script>"; }' }} />
+          <noscript dangerouslySetInnerHTML={{ __html: '<img src="pixel.gif" alt="pixel">' }} />
+          <title dangerouslySetInnerHTML={{ __html: '<b>Title</b> & value' }} />
+        </Head>
+      </UnheadProvider>,
+    )
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).toContain('<script type="application/javascript">window.payload = "<\\/script><script>evil()<\\/script>"</script>')
+    expect(headTags).toContain('<style>body::before { content: "<\\/style><script>evil()</script>"; }</style>')
+    expect(headTags).toContain('<noscript><img src="pixel.gif" alt="pixel"></noscript>')
+    expect(headTags).toContain('<title>&lt;b&gt;Title&lt;&#x2F;b&gt; &amp; value</title>')
+    expect(headTags.toLowerCase()).not.toContain('dangerouslysetinnerhtml')
+  })
+
+  it.each(['title', 'script', 'style', 'noscript'])(
+    'rejects children combined with dangerouslySetInnerHTML on <%s>',
+    (tagName) => {
+      const head = createHead({ disableDefaults: true })
+      const rawElement = React.createElement(tagName, {
+        dangerouslySetInnerHTML: { __html: 'raw' },
+      }, 'child')
+
+      expect(() => renderToString(
+        <UnheadProvider value={head}>
+          <Head>{rawElement}</Head>
+        </UnheadProvider>,
+      )).toThrow('Can only set one of `children` or `props.dangerouslySetInnerHTML`.')
+    },
+  )
+
+  it('rejects malformed dangerouslySetInnerHTML values', () => {
+    const head = createHead({ disableDefaults: true })
+    const rawElement = React.createElement('script', {
+      dangerouslySetInnerHTML: {} as { __html: string },
+    })
+
+    expect(() => renderToString(
+      <UnheadProvider value={head}>
+        <Head>{rawElement}</Head>
+      </UnheadProvider>,
+    )).toThrow('`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`.')
+  })
+
+  it.each(['base', 'link', 'meta'])(
+    'rejects dangerouslySetInnerHTML on self-closing <%s>',
+    (tagName) => {
+      const head = createHead({ disableDefaults: true })
+      const rawElement = React.createElement(tagName, {
+        dangerouslySetInnerHTML: { __html: 'raw' },
+      })
+
+      expect(() => renderToString(
+        <UnheadProvider value={head}>
+          <Head>{rawElement}</Head>
+        </UnheadProvider>,
+      )).toThrow(`${tagName} is a self-closing tag and must neither have \`children\` nor use \`dangerouslySetInnerHTML\`.`)
+    },
+  )
+})

--- a/packages/react/test/SimpleHead.test.tsx
+++ b/packages/react/test/SimpleHead.test.tsx
@@ -1,8 +1,9 @@
 import { render } from '@testing-library/react'
 // @vitest-environment jsdom
 import React from 'react'
-import { describe, expect, it } from 'vitest'
-import { createHead, UnheadProvider } from '../src/client'
+import { describe, expect, it, vi } from 'vitest'
+import { Head } from '../src'
+import { createHead, renderDOMHead, UnheadProvider } from '../src/client'
 import { renderSSRHead } from '../src/server'
 import { SimpleHead } from './fixtures/SimpleHead'
 
@@ -49,5 +50,104 @@ describe('simpleHead component', () => {
 
     const { headTags } = await renderSSRHead(head)
     expect(headTags).toBe('')
+  })
+
+  it('renders nested fragment children', async () => {
+    const head = createHead()
+
+    render(
+      <UnheadProvider head={head}>
+        <Head>
+          <>
+            {[
+              <meta key="meta" name="fragment-meta" content="nested" />,
+              <React.Fragment key="script">
+                {null}
+                <meta name="fragment-meta-2" content="nested-2" />
+                <script>window.__FRAGMENT_TEST__ = true</script>
+              </React.Fragment>,
+            ]}
+          </>
+        </Head>
+      </UnheadProvider>,
+    )
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).toMatchInlineSnapshot(`
+      "<script>window.__FRAGMENT_TEST__ = true</script>
+      <meta name="fragment-meta" content="nested">
+      <meta name="fragment-meta-2" content="nested-2">"
+    `)
+  })
+
+  it('normalizes React head prop names in the DOM', async () => {
+    const head = createHead()
+    const onLoad = vi.fn()
+
+    render(
+      <UnheadProvider head={head}>
+        <Head>
+          <meta
+            ref={React.createRef<HTMLMetaElement>()}
+            httpEquiv="refresh"
+            content="0;url=/next"
+            className="refresh metadata"
+            style={{ color: 'red' }}
+            itemProp="refresh"
+            suppressContentEditableWarning
+            suppressHydrationWarning
+          />
+          <link
+            rel="preload"
+            href="/hero.png"
+            as="image"
+            crossOrigin="anonymous"
+            fetchPriority="high"
+            hrefLang="en"
+            imageSrcSet="/hero.png 1x, /hero-2x.png 2x"
+            imageSizes="100vw"
+            referrerPolicy="no-referrer"
+          />
+          <script
+            src="/legacy.js"
+            charSet="utf-8"
+            crossOrigin="use-credentials"
+            fetchPriority="low"
+            noModule
+            referrerPolicy="origin"
+            onLoad={onLoad}
+          />
+        </Head>
+      </UnheadProvider>,
+    )
+
+    await renderDOMHead(head, { document })
+
+    const meta = document.head.querySelector('meta[http-equiv="refresh"]')
+    expect(meta).not.toBeNull()
+    expect(meta?.getAttribute('httpequiv')).toBeNull()
+    expect(meta?.className).toBe('refresh metadata')
+    expect((meta as HTMLElement).style.color).toBe('red')
+    expect(meta?.getAttribute('itemprop')).toBe('refresh')
+    expect(meta?.hasAttribute('ref')).toBe(false)
+    expect(meta?.hasAttribute('suppresscontenteditablewarning')).toBe(false)
+    expect(meta?.hasAttribute('suppresshydrationwarning')).toBe(false)
+
+    const link = document.head.querySelector('link[href="/hero.png"]')
+    expect(link?.getAttribute('crossorigin')).toBe('anonymous')
+    expect(link?.getAttribute('fetchpriority')).toBe('high')
+    expect(link?.getAttribute('hreflang')).toBe('en')
+    expect(link?.getAttribute('imagesrcset')).toBe('/hero.png 1x, /hero-2x.png 2x')
+    expect(link?.getAttribute('imagesizes')).toBe('100vw')
+    expect(link?.getAttribute('referrerpolicy')).toBe('no-referrer')
+
+    const script = document.head.querySelector('script[src="/legacy.js"]')
+    expect(script?.getAttribute('charset')).toBe('utf-8')
+    expect(script?.getAttribute('crossorigin')).toBe('use-credentials')
+    expect(script?.getAttribute('fetchpriority')).toBe('low')
+    expect(script?.hasAttribute('nomodule')).toBe(true)
+    expect(script?.getAttribute('referrerpolicy')).toBe('origin')
+    script?.dispatchEvent(new Event('load'))
+    expect(onLoad).toHaveBeenCalledOnce()
   })
 })

--- a/packages/react/test/SimpleHeadSSR.test.tsx
+++ b/packages/react/test/SimpleHeadSSR.test.tsx
@@ -2,8 +2,9 @@
 import React from 'react'
 import { renderToString } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { Head } from '../src'
 import { UnheadProvider } from '../src/client'
-import { createHead, renderSSRHead, transformHtmlTemplate } from '../src/server'
+import { createHead, renderSSRHead, UnheadProvider as ServerUnheadProvider, transformHtmlTemplate } from '../src/server'
 import { SimpleHead } from './fixtures/SimpleHead'
 
 describe('simpleHead component in ssr', () => {
@@ -72,5 +73,94 @@ describe('simpleHead component in ssr', () => {
       <link rel="icon" href="favicon.ico">
       <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Example","url":"https://www.example.com"}</script>"
     `)
+  })
+
+  it('renders nested fragment children', async () => {
+    const head = createHead({ disableDefaults: true })
+
+    renderToString(
+      <ServerUnheadProvider value={head}>
+        <Head>
+          <>
+            {[
+              <meta key="meta" name="fragment-meta" content="nested" />,
+              <React.Fragment key="script">
+                {false}
+                <meta name="fragment-meta-2" content="nested-2" />
+                <script>window.__FRAGMENT_TEST__ = true</script>
+              </React.Fragment>,
+            ]}
+          </>
+        </Head>
+      </ServerUnheadProvider>,
+    )
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).toMatchInlineSnapshot(`
+      "<script>window.__FRAGMENT_TEST__ = true</script>
+      <meta name="fragment-meta" content="nested">
+      <meta name="fragment-meta-2" content="nested-2">"
+    `)
+  })
+
+  it('normalizes React head prop names during SSR', async () => {
+    const head = createHead({ disableDefaults: true })
+
+    renderToString(
+      <ServerUnheadProvider value={head}>
+        <Head>
+          <meta
+            ref={React.createRef<HTMLMetaElement>()}
+            httpEquiv="refresh"
+            content="0;url=/next"
+            className="refresh metadata"
+            style={{ color: 'red' }}
+            itemProp="refresh"
+            suppressContentEditableWarning
+            suppressHydrationWarning
+          />
+          <link
+            rel="preload"
+            href="/hero.png"
+            as="image"
+            crossOrigin="anonymous"
+            fetchPriority="high"
+            hrefLang="en"
+            imageSrcSet="/hero.png 1x, /hero-2x.png 2x"
+            imageSizes="100vw"
+            referrerPolicy="no-referrer"
+          />
+          <script
+            src="/legacy.js"
+            charSet="utf-8"
+            crossOrigin="use-credentials"
+            fetchPriority="low"
+            noModule
+            referrerPolicy="origin"
+          />
+        </Head>
+      </ServerUnheadProvider>,
+    )
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).toContain('http-equiv="refresh"')
+    expect(headTags).not.toContain('httpequiv=')
+    expect(headTags).toContain('class="refresh metadata"')
+    expect(headTags).toContain('style="color:red"')
+    expect(headTags).toContain('itemprop="refresh"')
+    expect(headTags).not.toContain(' ref=')
+    expect(headTags).not.toContain('suppresscontenteditablewarning')
+    expect(headTags).not.toContain('suppresshydrationwarning')
+    expect(headTags).toContain('crossorigin="anonymous"')
+    expect(headTags).toContain('fetchpriority="high"')
+    expect(headTags).toContain('hreflang="en"')
+    expect(headTags).toContain('imagesrcset="/hero.png 1x, /hero-2x.png 2x"')
+    expect(headTags).toContain('imagesizes="100vw"')
+    expect(headTags).toContain('referrerpolicy="no-referrer"')
+    expect(headTags).toContain('charset="utf-8"')
+    expect(headTags).toContain('crossorigin="use-credentials"')
+    expect(headTags).toContain('fetchpriority="low"')
+    expect(headTags).toContain('nomodule')
+    expect(headTags).toContain('referrerpolicy="origin"')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Backports #892, #893, and #894.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Unhead v2 drops nested React Fragment tags, serializes JSX aliases incorrectly, and cannot map `dangerouslySetInnerHTML` into head content. Backport the three focused React adapter fixes while retaining v2 lifecycle, async SSR, and escaping behavior.