### PR TITLE
docs: clarify SPA metadata visibility

### DIFF
--- a/docs/0.react/head/guides/0.get-started/1.installation.md
+++ b/docs/0.react/head/guides/0.get-started/1.installation.md
@@ -50,7 +50,7 @@ hydrateRoot(
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-add-head-tags) this step.
+Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
 ::
 
 For SSR, create a fresh instance from `@unhead/react/server`{lang="bash"} for each request and return it with the rendered app.

--- a/docs/0.solid-js/head/guides/0.get-started/1.installation.md
+++ b/docs/0.solid-js/head/guides/0.get-started/1.installation.md
@@ -37,7 +37,7 @@ hydrate(() => {
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-add-head-tags) this step.
+Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
 ::
 
 For SSR, create a fresh instance from `@unhead/solid-js/server`{lang="bash"} for each request and return it with the rendered app.

--- a/docs/0.svelte/head/guides/0.get-started/1.installation.md
+++ b/docs/0.svelte/head/guides/0.get-started/1.installation.md
@@ -75,7 +75,7 @@ export default app
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-add-head-tags) this step.
+Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
 ::
 
 For SSR, create a fresh instance from `@unhead/svelte/server`{lang="bash"} for each request and return it with Svelte's render result.

--- a/docs/0.typescript/head/guides/0.get-started/1.installation.md
+++ b/docs/0.typescript/head/guides/0.get-started/1.installation.md
@@ -51,7 +51,7 @@ Follow the [Wrapping Composables](/docs/typescript/head/guides/core-concepts/wra
 ## Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#add-head-tags) this step.
+Serving your app as an SPA? You can [skip](#add-head-tags) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
 ::
 
 Somewhere in your server entry, create a server head instance.

--- a/docs/0.vue/head/guides/0.get-started/1.installation.md
+++ b/docs/0.vue/head/guides/0.get-started/1.installation.md
@@ -55,7 +55,7 @@ app.mount('#app')
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-server-defaults) this step.
+Serving your app as an SPA? You can [skip](#4-server-defaults) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
 ::
 
 For SSR, create a fresh instance from `@unhead/vue/server`{lang="bash"} for each request and return it with the rendered app.


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Client-only head changes are missing from response HTML, so most social preview crawlers cannot read route metadata in an SPA. The TypeScript, Vue, React, Solid, and Svelte installation guides now show when to use SSR, prerendering, or static tags.