### PR TITLE
docs: clarify v2 head setup and package imports

### DIFF
--- a/docs/0.vue/head/guides/0.get-started/1.migration.md
+++ b/docs/0.vue/head/guides/0.get-started/1.migration.md
@@ -223,6 +223,31 @@ const app = createApp()
 app.use(head)
 ```
 
+Create the client head once in the browser. On the server, create a fresh server head for every request. Do not reuse a head from `@unhead/vue/client` in a shared application factory during SSR. The server constructor installs server defaults, Vue server resolvers, and payload support that the client constructor omits.
+
+### Remove Legacy Instance Annotations
+
+V1 examples sometimes annotated the instance with `VueHeadClient<MergeHead>`. These types no longer describe the v2 factory. Remove the annotation and let `createHead()` infer its result:
+
+```diff
+-import type { MergeHead, VueHeadClient } from '@unhead/vue'
+ import { createHead } from '@unhead/vue/client'
+
+-const head = createHead() as unknown as VueHeadClient<MergeHead>
++const head = createHead()
+```
+
+### Replace Legacy Alias Packages
+
+Move direct imports from the compatibility packages to their v2 entry points:
+
+| V1 package | V2 entry point |
+| --- | --- |
+| `@unhead/ssr` | `unhead/server` |
+| `@unhead/dom` | `unhead/client` |
+| `@unhead/shared` | `unhead/utils` |
+| `@unhead/schema` | `unhead/types` |
+
 ### Removed Implicit Context
 
 🚦 Impact Level: Critical

--- a/docs/6.migration-guide/2.v2.md
+++ b/docs/6.migration-guide/2.v2.md
@@ -38,6 +38,19 @@ createHead()
 +createHead()
 ```
 
+Create the browser head once. Create a fresh server head for every request; do not reuse a client instance during SSR.
+
+### Replace Legacy Alias Packages
+
+Move direct imports from the compatibility packages to their v2 entry points:
+
+| V1 package | V2 entry point |
+| --- | --- |
+| `@unhead/ssr` | `unhead/server` |
+| `@unhead/dom` | `unhead/client` |
+| `@unhead/shared` | `unhead/utils` |
+| `@unhead/schema` | `unhead/types` |
+
 ---
 
 ## Removed Implicit Context


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

V1 migrations can accidentally reuse a browser head during SSR or retain obsolete type casts and alias imports. The v2 guides now show request-scoped server heads, inferred `createHead()` types, and the current package entry points.