### PR TITLE
fix(unhead): force client mode during SSR

### DIFF
--- a/packages/react/test/client-createHead-ssr.test.tsx
+++ b/packages/react/test/client-createHead-ssr.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { createHead, UnheadProvider } from '../src/client'
+import { useHead } from '../src/composables'
+
+describe('client createHead during SSR', () => {
+  it('does not retain entries across server renders', () => {
+    const head = createHead()
+
+    function Page() {
+      useHead({ title: 'Client head' })
+      return <div>Page</div>
+    }
+
+    const render = () => renderToString(
+      <UnheadProvider head={head}>
+        <Page />
+      </UnheadProvider>,
+    )
+
+    const entryCounts = [head.entries.size]
+    render()
+    entryCounts.push(head.entries.size)
+    render()
+    entryCounts.push(head.entries.size)
+
+    expect(entryCounts).toEqual([0, 0, 0])
+    expect(head.ssr).toBe(false)
+  })
+})

--- a/packages/unhead/src/client/createHead.ts
+++ b/packages/unhead/src/client/createHead.ts
@@ -7,7 +7,7 @@ export function createHead<T = ResolvableHead>(options: CreateClientHeadOptions 
   options.document = options.document || (typeof window !== 'undefined' ? document : undefined)
   const initialPayload = options.document?.head.querySelector('script[id="unhead:payload"]')?.innerHTML || false
   // restore initial entry from payload (titleTemplate and templateParams)
-  return createUnhead<T>({
+  const head = createUnhead<T>({
     ...options,
     plugins: [
       ...(options.plugins || []),
@@ -23,4 +23,6 @@ export function createHead<T = ResolvableHead>(options: CreateClientHeadOptions 
       ...(options.init || []),
     ],
   })
+  head.ssr = false
+  return head
 }


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`unhead/client` can infer SSR mode when created without a DOM, causing module-global React client heads to retain entries across server renders. Force client mode in the v2 client constructor and cover repeated `renderToString()` calls.