### PR TITLE
docs(vue): clarify reactive translated titles

### DIFF
--- a/docs/0.vue/head/guides/1.core-concepts/0.reactivity-and-context.md
+++ b/docs/0.vue/head/guides/1.core-concepts/0.reactivity-and-context.md
@@ -276,7 +276,7 @@ Calling `t()` before `useHead()` stores only its current result:
 useHead({ title: t('pages.login.title') })
 ```
 
-Keep a functional `titleTemplate` as a function. Wrapping it in `computed()` turns it into a Vue computed getter, so its callback parameter follows Vue's computed contract instead of receiving the page title from Unhead:
+Pass a functional `titleTemplate` directly. If you wrap it in `computed()`, Vue treats its parameter as the previous computed value rather than the page title from Unhead:
 
 ```ts
 // The callback parameter is not the page title
@@ -285,7 +285,7 @@ useHead({
 })
 ```
 
-Do not mix `document.title` assignments with a reactive Unhead entry. The next Unhead render will reconcile the managed title. Express every title update through the entry instead.
+Once Unhead owns the title, avoid writing to `document.title` directly. Unhead will overwrite that value on its next render.
 
 ### Avoid Creating Entries in Watchers
 

--- a/docs/0.vue/head/guides/1.core-concepts/0.reactivity-and-context.md
+++ b/docs/0.vue/head/guides/1.core-concepts/0.reactivity-and-context.md
@@ -251,6 +251,42 @@ useHead({
 })
 ```
 
+### Translated Titles
+
+Call translation functions inside getters so locale changes update the existing head entry:
+
+```ts
+const { locale, t } = useI18n()
+
+useHead({
+  htmlAttrs: {
+    lang: () => locale.value,
+  },
+  title: () => t('pages.login.title'),
+  titleTemplate: title => title
+    ? `${title} | ${t('brand.name')}`
+    : t('brand.name'),
+})
+```
+
+Calling `t()` before `useHead()` stores only its current result:
+
+```ts
+// Does not update when the locale changes
+useHead({ title: t('pages.login.title') })
+```
+
+Keep a functional `titleTemplate` as a function. Wrapping it in `computed()` turns it into a Vue computed getter, so its callback parameter follows Vue's computed contract instead of receiving the page title from Unhead:
+
+```ts
+// The callback parameter is not the page title
+useHead({
+  titleTemplate: computed(title => `${title} | ${t('brand.name')}`),
+})
+```
+
+Do not mix `document.title` assignments with a reactive Unhead entry. The next Unhead render will reconcile the managed title. Express every title update through the entry instead.
+
 ### Avoid Creating Entries in Watchers
 
 Avoid `useHead()`{lang="ts"} calls in watchers, as this creates new entries on each update:


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`useHead({ title: t(...) })` captures one translation, while the parameter in `computed(title => ...)` is Vue's previous computed value rather than Unhead's page title. The reactivity guide now shows reactive title and `lang` getters, then explains why direct `document.title` writes get overwritten.