### PR TITLE
fix(react): support value in v2 client provider

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -45,12 +45,14 @@ const head = createHead({ /* config */ })
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <UnheadProvider head={head}>
+    <UnheadProvider value={head}>
       <App />
     </UnheadProvider>
   </StrictMode>
 )
 ```
+
+Use the `value` prop with client and server providers. The client provider still accepts the deprecated `head` prop for compatibility.
 
 #### Server-side (SSR)
 
@@ -86,7 +88,7 @@ const head = createHead({ /* config */ })
 hydrateRoot(
   document.getElementById('root'),
   <StrictMode>
-    <UnheadProvider head={head}>
+    <UnheadProvider value={head}>
       <App />
     </UnheadProvider>
   </StrictMode>

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -16,8 +16,28 @@ export function createHead(options: CreateClientHeadOptions = {}): Unhead {
   return head
 }
 
-export function UnheadProvider({ children, head }: { children: ReactNode, head?: ReturnType<typeof createHead> }) {
-  return createElement(UnheadContext.Provider, { value: head || createHead() }, children)
+interface LegacyUnheadProviderProps {
+  children: ReactNode
+  value?: never
+  /**
+   * @deprecated Use `value` for a consistent provider API across client and server entries.
+   */
+  head?: Unhead
+}
+
+interface UniversalUnheadProviderProps {
+  children: ReactNode
+  value: Unhead
+  head?: never
+}
+
+export type UnheadProviderProps = LegacyUnheadProviderProps | UniversalUnheadProviderProps
+
+export function UnheadProvider({ children, value, head }: UnheadProviderProps) {
+  if (value !== undefined && head !== undefined)
+    throw new TypeError('UnheadProvider received both value and head props')
+
+  return createElement(UnheadContext.Provider, { value: value ?? head ?? createHead() }, children)
 }
 
 export type {

--- a/packages/react/test/useHead.test.tsx
+++ b/packages/react/test/useHead.test.tsx
@@ -73,6 +73,31 @@ describe('useHead hook', () => {
     expect(headTags).toContain('<title>Updated Title</title>')
   })
 
+  it('uses the head instance supplied through the value prop', async () => {
+    const head = createHead()
+
+    render(
+      <UnheadProvider value={head}>
+        <TestComponent />
+      </UnheadProvider>,
+    )
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).toContain('<title>Initial Title</title>')
+  })
+
+  it('rejects conflicting value and head props', () => {
+    const value = createHead()
+    const head = createHead()
+
+    expect(() => render(
+      // @ts-expect-error provider instances must be supplied through one prop
+      <UnheadProvider value={value} head={head}>
+        <TestComponent />
+      </UnheadProvider>,
+    )).toThrowError('UnheadProvider received both value and head props')
+  })
+
   it('initializes input value with state', () => {
     const head = createHead()
 


### PR DESCRIPTION
### 🔗 Linked issue

Backport of #879.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The v2 React client provider ignores the universal `value` prop, so an SSR tree can hydrate with a different head instance. Accept `value`, retain the deprecated `head` alias, and reject calls that provide both.