### PR TITLE
fix(unhead): dedupe scalar Twitter meta tags

### DIFF
--- a/docs/head/1.guides/1.core-concepts/6.handling-duplicates.md
+++ b/docs/head/1.guides/1.core-concepts/6.handling-duplicates.md
@@ -120,7 +120,7 @@ useHead({
 ```
 
 ::tip
-This behavior is specifically designed for verification tags and similar use cases where multiple tags with the same name are valid and necessary.
+Unhead also preserves arrayable metadata groups such as Open Graph and structured Twitter images. Scalar Twitter metadata such as `twitter:card`, `twitter:title`, and `twitter:description` resolves to one tag.
 ::
 
 ## How Do I Use Custom Keys for Deduplication?

--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -13,10 +13,14 @@ const StandardSingleMetaTags = new Set([
 ])
 
 export function isMetaArrayDupeKey(v: string) {
-  const parts = v.split(':')
-  if (!parts.length)
+  const i = v.indexOf(':')
+  if (i === -1)
     return false
-  return MetaTagsArrayable.has(parts[1])
+  const j = v.indexOf(':', i + 1)
+  const namespace = v.slice(i + 1, j === -1 ? v.length : j)
+  if (namespace === 'twitter')
+    return v === 'meta:twitter:image' || v.startsWith('meta:twitter:image:')
+  return MetaTagsArrayable.has(namespace)
 }
 
 export function dedupeKey<T extends HeadTag>(tag: T): string | undefined {

--- a/packages/unhead/test/unit/client/duplicates.test.ts
+++ b/packages/unhead/test/unit/client/duplicates.test.ts
@@ -1,7 +1,41 @@
 import { describe, expect, it } from 'vitest'
+import { useSeoMeta } from '../../../src'
 import { useDelayedSerializedDom, useDOMHead } from '../../util'
 
 describe('dom', () => {
+  it('dedupes scalar Twitter metadata and preserves structured images', async () => {
+    const head = useDOMHead()
+
+    head.push({
+      meta: [
+        { name: 'twitter:card', content: 'summary' },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: 'Old title' },
+        { name: 'twitter:title', content: 'New title' },
+        { name: 'twitter:description', content: 'Old description' },
+        { name: 'twitter:description', content: 'New description' },
+      ],
+    })
+    useSeoMeta(head, {
+      twitterImage: [
+        { url: '/first.png', alt: 'First image' },
+        { url: '/second.png', alt: 'Second image' },
+      ],
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+    const document = head.resolvedOptions.document!
+    const contents = (name: string) =>
+      [...document.querySelectorAll(`meta[name="${name}"]`)]
+        .map(tag => tag.getAttribute('content'))
+
+    expect(contents('twitter:card')).toEqual(['summary_large_image'])
+    expect(contents('twitter:title')).toEqual(['New title'])
+    expect(contents('twitter:description')).toEqual(['New description'])
+    expect(contents('twitter:image')).toEqual(['/first.png', '/second.png'])
+    expect(contents('twitter:image:alt')).toEqual(['First image', 'Second image'])
+  })
+
   it('basic', async () => {
     const head = useDOMHead()
 

--- a/packages/unhead/test/unit/dedupe.test.ts
+++ b/packages/unhead/test/unit/dedupe.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { isMetaArrayDupeKey } from '../../src/utils/dedupe'
+
+describe('isMetaArrayDupeKey', () => {
+  it('only treats structured Twitter images as arrayable', () => {
+    expect(isMetaArrayDupeKey('meta:twitter:card')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:twitter:title')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:twitter:description')).toBe(false)
+    expect(isMetaArrayDupeKey('meta:twitter:image')).toBe(true)
+    expect(isMetaArrayDupeKey('meta:twitter:image:alt')).toBe(true)
+  })
+})

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -1,10 +1,42 @@
-import { describe, it } from 'vitest'
-import { useHead } from '../../../src'
+import { describe, expect, it } from 'vitest'
+import { useHead, useSeoMeta } from '../../../src'
 import { DeprecationsPlugin } from '../../../src/plugins'
 import { renderSSRHead } from '../../../src/server'
 import { createServerHeadWithContext } from '../../util'
 
 describe('dedupe', () => {
+  it('dedupes scalar Twitter metadata and preserves structured images', async () => {
+    const head = createServerHeadWithContext()
+
+    useHead(head, {
+      meta: [
+        { name: 'twitter:card', content: 'summary' },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: 'Old title' },
+        { name: 'twitter:title', content: 'New title' },
+        { name: 'twitter:description', content: 'Old description' },
+        { name: 'twitter:description', content: 'New description' },
+      ],
+    })
+    useSeoMeta(head, {
+      twitterImage: [
+        { url: '/first.png', alt: 'First image' },
+        { url: '/second.png', alt: 'Second image' },
+      ],
+    })
+
+    const { headTags } = await renderSSRHead(head)
+    const contents = (name: string) =>
+      [...headTags.matchAll(new RegExp(`<meta name="${name}" content="([^"]+)">`, 'g'))]
+        .map(match => match[1])
+
+    expect(contents('twitter:card')).toEqual(['summary_large_image'])
+    expect(contents('twitter:title')).toEqual(['New title'])
+    expect(contents('twitter:description')).toEqual(['New description'])
+    expect(contents('twitter:image')).toEqual(['/first.png', '/second.png'])
+    expect(contents('twitter:image:alt')).toEqual(['First image', 'Second image'])
+  })
+
   it('arrays', async () => {
     const head = createServerHeadWithContext()
 


### PR DESCRIPTION
### 🔗 Linked issue

Backport of #880.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Unhead v2 treats every `twitter:*` key as arrayable, so scalar card, title, and description tags accumulate across head layers. Restore last-entry precedence for scalar Twitter metadata while preserving structured image groups.