### PR TITLE
fix(scripts): preserve vendor method receivers

### DIFF
--- a/packages/unhead/src/scripts/proxy.ts
+++ b/packages/unhead/src/scripts/proxy.ts
@@ -31,22 +31,62 @@ export function createNoopedRecordingProxy<T extends Record<string, any>>(instan
 }
 
 export function createForwardingProxy<T extends Record<string, any>>(target: T): AsVoidFunctions<T> {
-  const handler: ProxyHandler<T> = {
-    get(_, prop, receiver) {
-      const v = Reflect.get(_, prop, receiver)
-      if (typeof v === 'object') {
-        return new Proxy(v, handler)
-      }
-      return v
-    },
-    apply(_, __, args) {
-      // does not return the apply output for consistency
-      // @ts-expect-error untyped
-      Reflect.apply(_, __, args)
-      return undefined
-    },
+  type Method = (...args: any[]) => any
+
+  const proxyCache = new WeakMap<object, object>()
+  const methodCache = new WeakMap<object, WeakMap<Method, Method>>()
+
+  function createMethodProxy(owner: object, method: Method): Method {
+    let ownerMethods = methodCache.get(owner)
+    if (!ownerMethods) {
+      ownerMethods = new WeakMap()
+      methodCache.set(owner, ownerMethods)
+    }
+    const cached = ownerMethods.get(method)
+    if (cached) {
+      return cached
+    }
+    const proxy = new Proxy(method, {
+      apply(_, __, args) {
+        Reflect.apply(_, owner, args)
+        return undefined
+      },
+    })
+    ownerMethods.set(method, proxy)
+    return proxy
   }
-  return new Proxy(target, handler) as AsVoidFunctions<T>
+
+  function createProxy<V extends object>(value: V): V {
+    const cached = proxyCache.get(value)
+    if (cached) {
+      return cached as V
+    }
+    const proxy = new Proxy(value, {
+      get(_, prop) {
+        const v = Reflect.get(_, prop, _)
+        if (typeof v === 'function') {
+          return createMethodProxy(_, v as Method)
+        }
+        if (v !== null && typeof v === 'object') {
+          return createProxy(v)
+        }
+        return v
+      },
+      set(_, prop, value) {
+        return Reflect.set(_, prop, value, _)
+      },
+      apply(_, __, args) {
+        // does not return the apply output for consistency
+        // @ts-expect-error untyped
+        Reflect.apply(_, __, args)
+        return undefined
+      },
+    })
+    proxyCache.set(value, proxy)
+    return proxy
+  }
+
+  return createProxy(target) as AsVoidFunctions<T>
 }
 
 export function replayProxyRecordings<T extends object>(target: T, stack: RecordingEntry[][]) {

--- a/packages/unhead/test/unit/scripts/proxy.test.ts
+++ b/packages/unhead/test/unit/scripts/proxy.test.ts
@@ -147,6 +147,29 @@ describe('proxy chain', () => {
     expect(consoleMock).toHaveBeenCalledWith('hello-world')
   })
 
+  it('preserves the receiver for nested vendor methods', () => {
+    const brandedCanvas = new WeakSet<object>()
+    const canvas = {
+      getBoundingClientRect() {
+        if (!brandedCanvas.has(this)) {
+          throw new TypeError('Illegal invocation')
+        }
+        return { width: 120 }
+      },
+    }
+    brandedCanvas.add(canvas)
+    const api = {
+      canvas,
+      addConfetti() {
+        return this.canvas.getBoundingClientRect().width
+      },
+    }
+
+    const proxy = createForwardingProxy(api)
+
+    expect(() => proxy.addConfetti()).not.toThrow()
+  })
+
   it('replays calls after async use() resolves', async () => {
     const head = createHead()
     const { promise, resolve } = Promise.withResolvers<{ greet: (foo: string) => string }>()


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue. Found through Sentry issue NUXTSEO-SITE-17.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Forwarded vendor methods received the proxy as `this`, which broke native receiver checks in Firefox. Method wrappers now call their owning raw object and cache nested proxies while retaining the existing void return contract.
