### PR TITLE
docs: add SPA guide 

### DIFF
--- a/docs/0.angular/head/guides/0.get-started/1.installation.md
+++ b/docs/0.angular/head/guides/0.get-started/1.installation.md
@@ -51,7 +51,7 @@ bootstrapApplication(AppComponent, config)
 ### 3. Add Server-Side Rendering (Optional)
 
 ::note
-Not using Server-Side Rendering? You can skip this step.
+Not using Server-Side Rendering? You can skip this step. See the [SPA guide](/docs/head/guides/get-started/single-page-applications) for template defaults, crawler limits, and route prerendering.
 ::
 
 For Angular Universal or other SSR setups, configure Unhead for the server:

--- a/docs/0.react/head/guides/0.get-started/1.installation.md
+++ b/docs/0.react/head/guides/0.get-started/1.installation.md
@@ -50,7 +50,7 @@ hydrateRoot(
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
 ::
 
 For SSR, create a fresh instance from `@unhead/react/server`{lang="bash"} for each request and return it with the rendered app.

--- a/docs/0.react/head/guides/0.get-started/1.installation.md
+++ b/docs/0.react/head/guides/0.get-started/1.installation.md
@@ -50,7 +50,7 @@ hydrateRoot(
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. See the [SPA guide](/docs/head/guides/get-started/single-page-applications) for template defaults, crawler limits, and route prerendering.
 ::
 
 For SSR, create a fresh instance from `@unhead/react/server`{lang="bash"} for each request and return it with the rendered app.

--- a/docs/0.solid-js/head/guides/0.get-started/1.installation.md
+++ b/docs/0.solid-js/head/guides/0.get-started/1.installation.md
@@ -37,7 +37,7 @@ hydrate(() => {
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
 ::
 
 For SSR, create a fresh instance from `@unhead/solid-js/server`{lang="bash"} for each request and return it with the rendered app.

--- a/docs/0.solid-js/head/guides/0.get-started/1.installation.md
+++ b/docs/0.solid-js/head/guides/0.get-started/1.installation.md
@@ -37,7 +37,7 @@ hydrate(() => {
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. See the [SPA guide](/docs/head/guides/get-started/single-page-applications) for template defaults, crawler limits, and route prerendering.
 ::
 
 For SSR, create a fresh instance from `@unhead/solid-js/server`{lang="bash"} for each request and return it with the rendered app.

--- a/docs/0.svelte/head/guides/0.get-started/1.installation.md
+++ b/docs/0.svelte/head/guides/0.get-started/1.installation.md
@@ -75,7 +75,7 @@ export default app
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
 ::
 
 For SSR, create a fresh instance from `@unhead/svelte/server`{lang="bash"} for each request and return it with Svelte's render result.

--- a/docs/0.svelte/head/guides/0.get-started/1.installation.md
+++ b/docs/0.svelte/head/guides/0.get-started/1.installation.md
@@ -75,7 +75,7 @@ export default app
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#4-add-head-tags) this step. See the [SPA guide](/docs/head/guides/get-started/single-page-applications) for template defaults, crawler limits, and route prerendering.
 ::
 
 For SSR, create a fresh instance from `@unhead/svelte/server`{lang="bash"} for each request and return it with Svelte's render result.

--- a/docs/0.typescript/head/guides/0.get-started/1.installation.md
+++ b/docs/0.typescript/head/guides/0.get-started/1.installation.md
@@ -51,7 +51,7 @@ Follow the [Wrapping Composables](/docs/typescript/head/guides/core-concepts/wra
 ## Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#add-head-tags) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#add-head-tags) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
 ::
 
 Somewhere in your server entry, create a server head instance.

--- a/docs/0.typescript/head/guides/0.get-started/1.installation.md
+++ b/docs/0.typescript/head/guides/0.get-started/1.installation.md
@@ -51,7 +51,7 @@ Follow the [Wrapping Composables](/docs/typescript/head/guides/core-concepts/wra
 ## Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#add-head-tags) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#add-head-tags) this step. See the [SPA guide](/docs/head/guides/get-started/single-page-applications) for template defaults, crawler limits, and route prerendering.
 ::
 
 Somewhere in your server entry, create a server head instance.

--- a/docs/0.vue/head/guides/0.get-started/1.installation.md
+++ b/docs/0.vue/head/guides/0.get-started/1.installation.md
@@ -55,7 +55,7 @@ app.mount('#app')
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-server-defaults) this step. Client-side head changes are not included in the response HTML, so social preview crawlers generally will not see them. Use SSR or prerendering for crawler-visible per-route titles, descriptions, canonicals, robots directives, and social metadata. Put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#4-server-defaults) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
 ::
 
 For SSR, create a fresh instance from `@unhead/vue/server`{lang="bash"} for each request and return it with the rendered app.

--- a/docs/0.vue/head/guides/0.get-started/1.installation.md
+++ b/docs/0.vue/head/guides/0.get-started/1.installation.md
@@ -55,7 +55,7 @@ app.mount('#app')
 ### 3. Set Up Server-Side Rendering
 
 ::note
-Serving your app as an SPA? You can [skip](#4-server-defaults) this step. Client-side head changes are missing from the response HTML, which most social preview crawlers read without running JavaScript. Use SSR or prerendering for route-specific titles, descriptions, canonical URLs, robots directives, and social tags. For an SPA, put critical static tags in `index.html`.
+Serving your app as an SPA? You can [skip](#4-server-defaults) this step. See the [SPA guide](/docs/head/guides/get-started/single-page-applications) for template defaults, crawler limits, and route prerendering.
 ::
 
 For SSR, create a fresh instance from `@unhead/vue/server`{lang="bash"} for each request and return it with the rendered app.

--- a/docs/0.vue/head/guides/0.get-started/1.migration.md
+++ b/docs/0.vue/head/guides/0.get-started/1.migration.md
@@ -223,7 +223,7 @@ const app = createApp()
 app.use(head)
 ```
 
-Create the client head once in the browser. On the server, create a fresh server head for every request. Do not reuse a head from `@unhead/vue/client` in a shared application factory during SSR. The server constructor installs server defaults, Vue server resolvers, and payload support that the client constructor omits.
+Create one client head in the browser, but a fresh server head for every request. A shared SSR application factory must not reuse a head from `@unhead/vue/client`; that constructor omits server defaults, Vue server resolvers, and payload support.
 
 ### Remove Legacy Instance Annotations
 

--- a/docs/6.migration-guide/2.v2.md
+++ b/docs/6.migration-guide/2.v2.md
@@ -38,7 +38,7 @@ createHead()
 +createHead()
 ```
 
-Create the browser head once. Create a fresh server head for every request; do not reuse a client instance during SSR.
+Create the browser head once. For SSR, create a fresh server head for each request rather than reusing the browser instance.
 
 ### Replace Legacy Alias Packages
 

--- a/docs/head/1.guides/0.get-started/0.overview.md
+++ b/docs/head/1.guides/0.get-started/0.overview.md
@@ -19,6 +19,8 @@ Choose your framework below. The examples on this site will update to use its Un
 
 :UPageCard{title="Intro to Unhead" description="See how Unhead manages tags during server and client rendering" to="/docs/head/guides/get-started/intro-to-unhead" icon="i-heroicons-information-circle" spotlight spotlight-color="primary"}
 
+:UPageCard{title="Single Page Applications" description="Add template defaults and prerender public SPA routes" to="/docs/head/guides/get-started/single-page-applications" icon="i-heroicons-window" spotlight spotlight-color="primary"}
+
 :UPageCard{title="Starter Recipes" description="Examples for common head-management scenarios" to="/docs/head/guides/get-started/starter-recipes" icon="i-heroicons-bookmark" spotlight spotlight-color="primary"}
 
 ::

--- a/docs/head/1.guides/0.get-started/3.single-page-applications.md
+++ b/docs/head/1.guides/0.get-started/3.single-page-applications.md
@@ -1,0 +1,209 @@
+---
+title: "Using Unhead in a Single Page Application"
+description: "Ship useful fallback head tags from an SPA, then prerender public routes so crawlers receive route-specific metadata."
+navigation:
+  title: "Single Page Applications"
+---
+
+Unhead updates the document after your SPA starts in the browser. Those updates do not change the HTML response from your server or CDN.
+
+This distinction matters for public pages. Google can render JavaScript, but rendering may be delayed, and [not every crawler runs JavaScript](https://developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics). Social preview crawlers commonly read the response HTML and stop there.
+
+Start with site-wide metadata in the SPA's HTML template. If public routes need their own metadata, prerender them.
+
+Private dashboards and other authenticated apps rarely need prerendering. Template defaults are usually enough for them.
+
+## Add Metadata to the SPA Template
+
+Start with useful defaults in the `index.html` file that your host serves for SPA routes:
+
+```html [index.html]
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>Acme</title>
+    <meta name="description" content="Plan and publish your work with Acme.">
+
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Acme">
+    <meta property="og:description" content="Plan and publish your work with Acme.">
+    <meta property="og:image" content="https://example.com/social-card.png">
+    <meta property="og:image:alt" content="Acme">
+    <meta name="twitter:card" content="summary_large_image">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>
+```
+
+Keep the charset near the start of `<head>`. Use an absolute URL for the social image.
+
+These values must make sense for every route that receives this file. If the same `index.html` serves `/`, `/about`, and `/pricing`, do not put a homepage canonical URL in the shared template. Add route-specific canonical and Open Graph URLs through Unhead, then prerender those routes.
+
+## Set Route Metadata with Unhead
+
+Continue to use Unhead for navigation inside the app:
+
+```ts
+import { useHead } from '@unhead/dynamic-import'
+
+useHead({
+  title: 'Pricing | Acme',
+  meta: [
+    {
+      name: 'description',
+      content: 'Compare Acme plans and pricing.'
+    },
+    { property: 'og:title', content: 'Pricing | Acme' },
+    {
+      property: 'og:description',
+      content: 'Compare Acme plans and pricing.'
+    },
+    { property: 'og:url', content: 'https://example.com/pricing' }
+  ],
+  link: [
+    { rel: 'canonical', href: 'https://example.com/pricing' }
+  ]
+}, {
+  onRendered() {
+    document.documentElement.dataset.prerenderReady = window.location.pathname
+  }
+})
+```
+
+The `onRendered` callback runs after Unhead has patched the DOM. The marker gives a prerender script a reliable point to capture the page.
+
+For an async route, expose the marker only after its content and head data are ready. A build that captures the loading title is still a broken build.
+
+## Prerender Routes with JavaScript
+
+If your framework already has static generation, use it. The script below is for an existing Vite SPA: [Playwright](https://playwright.dev/) runs the built app, waits for Unhead, and saves the rendered HTML.
+
+Install Playwright and its Chromium binary:
+
+```bash
+pnpm add -D playwright
+pnpm exec playwright install chromium
+```
+
+Add a script:
+
+```js [scripts/prerender.mjs]
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { chromium } from 'playwright'
+import { preview } from 'vite'
+
+const routes = ['/', '/about', '/pricing']
+const port = 4173
+const origin = `http://127.0.0.1:${port}`
+
+function outputFile(route) {
+  return route === '/'
+    ? resolve('dist/index.html')
+    : resolve('dist', route.slice(1), 'index.html')
+}
+
+function closeServer(server) {
+  return new Promise((resolveClose, rejectClose) => {
+    server.httpServer.close((error) => {
+      if (error)
+        rejectClose(error)
+      else
+        resolveClose()
+    })
+  })
+}
+
+async function renderRoute(browser, route) {
+  const page = await browser.newPage()
+
+  await page.goto(new URL(route, origin).href, {
+    waitUntil: 'networkidle',
+  })
+  await page.waitForFunction(
+    expectedRoute =>
+      document.documentElement.dataset.prerenderReady === expectedRoute,
+    route,
+  )
+
+  await page.evaluate(() => {
+    document.documentElement.removeAttribute('data-prerender-ready')
+  })
+
+  const file = outputFile(route)
+  await mkdir(dirname(file), { recursive: true })
+  await writeFile(file, await page.content())
+  await page.close()
+}
+
+const server = await preview({
+  preview: {
+    host: '127.0.0.1',
+    port,
+    strictPort: true,
+  },
+})
+
+await chromium.launch()
+  .then(browser =>
+    Promise.all(routes.map(route => renderRoute(browser, route)))
+      .finally(() => browser.close()),
+  )
+  .finally(() => closeServer(server))
+```
+
+Run it after Vite builds the SPA:
+
+```json [package.json]
+{
+  "scripts": {
+    "build": "vite build && pnpm prerender",
+    "prerender": "node scripts/prerender.mjs"
+  }
+}
+```
+
+The output contains one document per route:
+
+```text
+dist/
+├── index.html
+├── about/
+│   └── index.html
+└── pricing/
+    └── index.html
+```
+
+Configure your host to serve these files before its SPA fallback. An unconditional rewrite from every URL to `/index.html` bypasses the prerendered documents.
+
+Keep the route list in sync with your router or generate it from the same route data. Prerendering is a poor fit when routes change on every request, depend on a signed-in user, or number in the tens of thousands. Use SSR for those pages.
+
+## Check the Response HTML
+
+Build the app, then inspect the generated file without opening a browser:
+
+```bash
+pnpm build
+rg '<title>|description|canonical|og:' dist/pricing/index.html
+```
+
+After deployment, check the response too:
+
+```bash
+curl -s https://example.com/pricing \
+  | rg '<title>|description|canonical|og:'
+```
+
+You can also run the [Unhead CLI](/docs/typescript/head/guides/tooling/cli) over every generated page:
+
+```bash
+pnpm dlx @unhead/cli validate-html 'dist/**/*.html'
+```
+
+View Source is the final check. DevTools shows the live DOM after Unhead runs, which can hide a missing prerender step.


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

PRs #897 and #898 added crawler visibility and v2 migration guidance. This follow-up moves the SPA advice into a dedicated guide covering `index.html` defaults, route metadata, and Playwright prerendering. It also shortens the installation notes and clarifies that each SSR request needs a fresh server head.