### PR TITLE
feat(validate): warn on deprecated Twitter metadata

### DIFF
--- a/docs/0.typescript/head/guides/2.tooling/2.validate-plugin.md
+++ b/docs/0.typescript/head/guides/2.tooling/2.validate-plugin.md
@@ -81,6 +81,8 @@ console.log(VALIDATION_RULE_IDS) // ['canonical-og-url-mismatch', 'charset-not-e
 
 `unhead/validate` also exports the `KNOWN_META_NAMES`, `KNOWN_META_PROPERTIES`, and `URL_META_KEYS` allowlists used for typo detection. These exports are available to other tooling.
 
+`deprecated-twitter-meta` reports non-Slack `twitter:*` metadata and recommends Open Graph metadata. The Slack unfurl fields `twitter:label1`, `twitter:label2`, `twitter:data1`, and `twitter:data2` are excluded.
+
 ## Integration with DevTools
 
 When the Unhead Vite plugin is active, reports from `ValidatePlugin` appear in the DevTools **Tags** and **Audit** panels. Each row links to the file and line that pushed the tag through Vite's open-in-editor endpoint.

--- a/docs/head/1.guides/plugins/validate.md
+++ b/docs/head/1.guides/plugins/validate.md
@@ -105,9 +105,12 @@ Google recommends [absolute canonical URLs](https://developers.google.com/search
 | `deprecated-prop-body` | Removed `body: true` tag property |
 | `deprecated-prop-children` | Removed `children` content property |
 | `deprecated-prop-hid-vmid` | Removed `hid` or `vmid` keys |
+| `deprecated-twitter-meta` | Non-Slack `twitter:*` metadata; use Open Graph metadata instead |
 | `missing-alias-sorting-plugin` | A `before:` or `after:` priority is used without `AliasSortingPlugin` |
 | `missing-template-params-plugin` | `templateParams` is used without `TemplateParamsPlugin` |
 | `numeric-tag-priority` | A numeric `tagPriority` is used instead of a named priority |
+
+`twitter:label1`, `twitter:label2`, `twitter:data1`, and `twitter:data2` remain supported for Slack link unfurls.
 
 ### Missing Companion Tags
 

--- a/packages/unhead/src/plugins/validate.ts
+++ b/packages/unhead/src/plugins/validate.ts
@@ -54,6 +54,12 @@ export interface ValidatePluginOptions {
 
 const TEMPLATE_PARAM_RE = /%\w+(?:\.\w+)?%/
 const AT_PREFIX_RE = /^at\s+/
+const SLACK_TWITTER_META_NAMES = new Set([
+  'twitter:data1',
+  'twitter:data2',
+  'twitter:label1',
+  'twitter:label2',
+])
 
 /**
  * Per-rule severity used by the runtime ValidatePlugin path that runs through
@@ -237,6 +243,12 @@ export function ValidatePlugin(options: ValidatePluginOptions = {}) {
             if (tagInput) {
               for (const predicate of Object.values(tagPredicates))
                 emitFromPredicates(predicate(tagInput), tag)
+            }
+
+            if (tag.tag === 'meta' && typeof metaKey === 'string') {
+              const normalizedMetaKey = metaKey.toLowerCase()
+              if (normalizedMetaKey.startsWith('twitter:') && !SLACK_TWITTER_META_NAMES.has(normalizedMetaKey))
+                report('deprecated-twitter-meta', `${normalizedMetaKey} is deprecated. Use Open Graph metadata instead.`, 'warn', tag)
             }
 
             // === URL Validity (runtime-only: depends on URL_META_KEYS lookup) ===

--- a/packages/unhead/src/validate/rules.ts
+++ b/packages/unhead/src/validate/rules.ts
@@ -13,6 +13,7 @@ export const VALIDATION_RULE_IDS = /* @__PURE__ */ [
   'deprecated-prop-body',
   'deprecated-prop-children',
   'deprecated-prop-hid-vmid',
+  'deprecated-twitter-meta',
   'duplicate-resource-hint',
   'empty-meta-content',
   'empty-title',

--- a/packages/unhead/test/unit/plugins/validate.test.ts
+++ b/packages/unhead/test/unit/plugins/validate.test.ts
@@ -322,6 +322,44 @@ describe('validatePlugin', () => {
     })
   })
 
+  describe('deprecated Twitter metadata', () => {
+    it('warns on non-Slack twitter metadata without removing it', () => {
+      const { head, rules } = createValidationHead()
+      head.push({ meta: [{ name: 'twitter:title', content: 'Title' }] })
+
+      expect(renderSSRHead(head).headTags).toContain('name="twitter:title"')
+      expect(rules.find(r => r.id === 'deprecated-twitter-meta')).toMatchObject({
+        message: 'twitter:title is deprecated. Use Open Graph metadata instead.',
+        severity: 'warn',
+      })
+    })
+
+    it('allows Twitter metadata used by Slack unfurls', () => {
+      const { head, rules } = createValidationHead()
+      head.push({
+        meta: [
+          { name: 'twitter:label1', content: 'Price' },
+          { name: 'twitter:data1', content: '$9.99' },
+          { name: 'twitter:label2', content: 'Availability' },
+          { name: 'twitter:data2', content: 'In stock' },
+        ],
+      })
+
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'deprecated-twitter-meta')).toBeFalsy()
+    })
+
+    it('respects the deprecated-twitter-meta rule config', () => {
+      const { head, rules } = createValidationHead({
+        rules: { 'deprecated-twitter-meta': 'off' },
+      })
+      head.push({ meta: [{ name: 'twitter:description', content: 'Description' }] })
+
+      renderSSRHead(head)
+      expect(rules.find(r => r.id === 'deprecated-twitter-meta')).toBeFalsy()
+    })
+  })
+
   describe('typo detection', () => {
     it('suggests correction for og:titl typo', () => {
       const { head, rules } = createValidationHead()


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #842

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`ValidatePlugin` now reports `deprecated-twitter-meta` for non-Slack `twitter:*` metadata while preserving the rendered tags. `twitter:label1`, `twitter:label2`, `twitter:data1`, and `twitter:data2` remain exempt because Slack uses them for classic unfurls; the rule can be disabled through `rules`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation warnings for deprecated, non-Slack `twitter:*` metadata.
  * Recommends using Open Graph metadata instead.
  * Preserves support for Slack link-unfurl fields.

* **Documentation**
  * Documented the new `deprecated-twitter-meta` validation rule, its exceptions, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->