### PR TITLE
fix(bundler): make Vite DevTools kit optional

### DIFF
--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -80,6 +80,7 @@
   },
   "peerDependencies": {
     "@unhead/cli": "workspace:^",
+    "@vitejs/devtools-kit": "^0.4.1",
     "esbuild": ">=0.17.0",
     "lightningcss": ">=1.20.0",
     "rolldown": ">=1.0.0-beta.0",
@@ -89,6 +90,9 @@
   },
   "peerDependenciesMeta": {
     "@unhead/cli": {
+      "optional": true
+    },
+    "@vitejs/devtools-kit": {
       "optional": true
     },
     "esbuild": {
@@ -108,7 +112,6 @@
     }
   },
   "dependencies": {
-    "@vitejs/devtools-kit": "catalog:",
     "magic-string": "catalog:",
     "oxc-parser": "catalog:",
     "oxc-walker": "catalog:",
@@ -116,6 +119,7 @@
     "unplugin": "catalog:"
   },
   "devDependencies": {
+    "@vitejs/devtools-kit": "catalog:",
     "rollup": "catalog:",
     "unhead": "workspace:*",
     "vite": "catalog:"

--- a/packages/bundler/test/package.test.ts
+++ b/packages/bundler/test/package.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+interface PackageJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>
+}
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf8'),
+) as PackageJson
+
+describe('@unhead/bundler package', () => {
+  it('keeps Vite DevTools packages optional', () => {
+    const runtimeDependencies = {
+      ...packageJson.dependencies,
+      ...packageJson.optionalDependencies,
+    }
+
+    expect(Object.keys(runtimeDependencies).filter(name => name.startsWith('@vitejs/devtools'))).toEqual([])
+    expect(packageJson.peerDependencies?.['@vitejs/devtools-kit']).toBeDefined()
+    expect(packageJson.peerDependenciesMeta?.['@vitejs/devtools-kit']).toEqual({ optional: true })
+    expect(packageJson.devDependencies?.['@vitejs/devtools-kit']).toBeDefined()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,9 +836,6 @@ importers:
       '@unhead/cli':
         specifier: workspace:^
         version: link:../cli
-      '@vitejs/devtools-kit':
-        specifier: 'catalog:'
-        version: 0.4.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.2))(srvx@0.11.22)(typescript@7.0.2)(vite@8.1.5)
       esbuild:
         specifier: '>=0.17.0'
         version: 0.28.1
@@ -867,6 +864,9 @@ importers:
         specifier: '>=5.0.0'
         version: 5.105.2(esbuild@0.28.1)
     devDependencies:
+      '@vitejs/devtools-kit':
+        specifier: 'catalog:'
+        version: 0.4.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.2))(srvx@0.11.22)(typescript@7.0.2)(vite@8.1.5)
       rollup:
         specifier: 'catalog:'
         version: 4.62.2


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@unhead/vue` installs `@unhead/bundler`, whose runtime dependencies included the full `@vitejs/devtools-kit` graph. Move the kit to an optional peer so normal framework installs skip it, while retaining a dev dependency for local builds. The package test locks that manifest shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package integration for the optional Vite DevTools Kit peer dependency.
  * Kept the DevTools Kit out of runtime dependencies while retaining it for development and testing.

* **Tests**
  * Added coverage to verify dependency classification and optional peer dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->