### PR TITLE
ci: report runtime dependency size

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -36,12 +36,14 @@ jobs:
           # the PR's perf harness may not exist on the base ref; keep a copy so we can
           # measure the base build with the same script (same runner cancels variance)
           cp bench/perf-ci.mjs /tmp/perf-ci.mjs
+          cp bench/bundle/dependency-analyze.mjs /tmp/dependency-analyze.mjs
           # runner setup (pnpm store probing) can leave the lockfile dirty; nothing
           # in this fresh checkout is precious, so surface the diff and discard it
           git status --porcelain
           git diff --stat
           git checkout -f ${{ github.base_ref }}
           pnpm install
+          node /tmp/dependency-analyze.mjs > /tmp/base-dependencies.json
           pnpm build
           # the base ref may predate some bundle configs (react, full, schema-org);
           # tolerate their absence so the other baselines are still produced and the
@@ -62,6 +64,7 @@ jobs:
       - name: Build PR bundles
         run: |
           pnpm install
+          node bench/bundle/dependency-analyze.mjs > /tmp/pr-dependencies.json
           pnpm build
           pnpm test:bundle-size
           pnpm test:vue-bundle-size
@@ -81,7 +84,9 @@ jobs:
         id: analyze
         env:
           BASE_DIST: /tmp/base-dist
+          BASE_DEPENDENCIES: /tmp/base-dependencies.json
           BASE_PERF: /tmp/base-perf.json
+          PR_DEPENDENCIES: /tmp/pr-dependencies.json
           PR_PERF: /tmp/pr-perf.json
         run: |
           output=$(bun bench/bundle/report.ts)

--- a/bench/bundle/dependency-analyze.mjs
+++ b/bench/bundle/dependency-analyze.mjs
@@ -1,0 +1,120 @@
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+
+const root = process.cwd()
+const packagesDir = resolve(root, 'packages')
+
+function readManifest(packageDir) {
+  return JSON.parse(readFileSync(resolve(packageDir, 'package.json'), 'utf8'))
+}
+
+function collectWorkspacePackages() {
+  return new Map(
+    readdirSync(packagesDir, { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .map(entry => resolve(packagesDir, entry.name))
+      .filter(packageDir => existsSync(resolve(packageDir, 'package.json')))
+      .map(packageDir => {
+        const manifest = readManifest(packageDir)
+        return [manifest.name, { dir: packageDir, manifest }]
+      }),
+  )
+}
+
+function packageSize(packageDir) {
+  return readdirSync(packageDir, { withFileTypes: true }).reduce((total, entry) => {
+    if (entry.name === 'node_modules')
+      return total
+    const path = resolve(packageDir, entry.name)
+    if (entry.isDirectory())
+      return total + packageSize(path)
+    if (entry.isFile())
+      return total + lstatSync(path).size
+    return total
+  }, 0)
+}
+
+function productionDependencies(manifest) {
+  const dependencies = new Map(
+    Object.keys(manifest.dependencies || {}).map(name => [name, { name, optional: false }]),
+  )
+  for (const name of Object.keys(manifest.optionalDependencies || {}))
+    dependencies.set(name, { name, optional: true })
+  return [...dependencies.values()]
+}
+
+function resolveInstalledPackage(name, fromDir) {
+  const require = createRequire(resolve(fromDir, 'package.json'))
+  const packageJson = require.resolve.paths(name)
+    ?.map(nodeModulesDir => resolve(nodeModulesDir, name, 'package.json'))
+    .find(existsSync)
+  if (!packageJson)
+    return null
+  const dir = realpathSync(dirname(packageJson))
+  return { dir, manifest: readManifest(dir) }
+}
+
+function analyzePackage(rootPackage, workspacePackages) {
+  const visitedWorkspacePackages = new Set()
+  const externalPackages = new Map()
+  const skippedOptionalDependencies = []
+
+  function visitPackage(packageDir, manifest, isWorkspace) {
+    if (isWorkspace) {
+      if (visitedWorkspacePackages.has(manifest.name))
+        return
+      visitedWorkspacePackages.add(manifest.name)
+    }
+
+    for (const dependency of productionDependencies(manifest)) {
+      const workspaceDependency = isWorkspace ? workspacePackages.get(dependency.name) : null
+      if (workspaceDependency) {
+        visitPackage(workspaceDependency.dir, workspaceDependency.manifest, true)
+        continue
+      }
+
+      const installed = resolveInstalledPackage(dependency.name, packageDir)
+      if (!installed) {
+        if (dependency.optional) {
+          // Platform-specific optional packages can be absent from this runner.
+          skippedOptionalDependencies.push(`${manifest.name} -> ${dependency.name}`)
+          continue
+        }
+        throw new Error(`Cannot resolve production dependency ${manifest.name} -> ${dependency.name}`)
+      }
+
+      const key = `${installed.manifest.name}@${installed.manifest.version}`
+      if (externalPackages.has(key))
+        continue
+
+      externalPackages.set(key, {
+        name: installed.manifest.name,
+        version: installed.manifest.version,
+        size: packageSize(installed.dir),
+      })
+      visitPackage(installed.dir, installed.manifest, false)
+    }
+  }
+
+  visitPackage(rootPackage.dir, rootPackage.manifest, true)
+  const dependencies = [...externalPackages.values()]
+    .sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version))
+
+  return {
+    name: rootPackage.manifest.name,
+    dependencyCount: dependencies.length,
+    dependencySize: dependencies.reduce((total, dependency) => total + dependency.size, 0),
+    dependencies,
+    skippedOptionalDependencies: skippedOptionalDependencies.sort(),
+  }
+}
+
+const workspacePackages = collectWorkspacePackages()
+const packages = [...workspacePackages.values()]
+  .filter(pkg => pkg.manifest.private !== true)
+  .map(pkg => analyzePackage(pkg, workspacePackages))
+  .sort((a, b) => a.name.localeCompare(b.name))
+
+process.stdout.write(`${JSON.stringify({ packages }, null, 2)}\n`)

--- a/bench/bundle/dependency-report.test.ts
+++ b/bench/bundle/dependency-report.test.ts
@@ -10,6 +10,7 @@ const base = {
       dependencies: [
         { name: 'vite', version: '8.1.5', size: 4_000_000 },
       ],
+      skippedOptionalDependencies: [],
     },
   ],
 }
@@ -25,6 +26,7 @@ describe('runtime dependency report', () => {
           dependencies: [
             { name: 'vue', version: '3.5.40', size: 2_000_000 },
           ],
+          skippedOptionalDependencies: [],
         },
       ],
     }
@@ -40,13 +42,13 @@ describe('runtime dependency report', () => {
 
       <details><summary>All packages (1)</summary>
 
-      | Package | External deps | Install size | Largest dependency |
-      |---|---|---|---|
-      | @unhead/vue | 18 | 29 MB | vue 2 MB |
+      | Package | External deps | Install size | Largest dependency | Skipped optional |
+      |---|---|---|---|---|
+      | @unhead/vue | 18 | 29 MB | vue 2 MB | 0 |
 
       </details>
 
-      <sub>Production dependencies only. Peer dependencies and Unhead workspace packages are excluded.</sub>"
+      <sub>Production dependencies only. Peer dependencies and Unhead workspace packages are excluded. Skipped optional dependencies are unavailable on the CI platform.</sub>"
     `)
   })
 
@@ -63,5 +65,37 @@ describe('runtime dependency report', () => {
     }
 
     expect(renderDependencyReport(base, current)).toContain('🔴 +1 dependency')
+  })
+
+  it('renders a neutral net dependency count when package changes cancel out', () => {
+    const balancingBase = {
+      packages: [
+        { ...base.packages[0], name: 'a', dependencyCount: 1 },
+        { ...base.packages[0], name: 'b', dependencyCount: 2 },
+      ],
+    }
+    const current = {
+      packages: [
+        { ...balancingBase.packages[0], dependencyCount: 2 },
+        { ...balancingBase.packages[1], dependencyCount: 1 },
+      ],
+    }
+
+    expect(renderDependencyReport(balancingBase, current)).toContain('net 0 dependencies')
+  })
+
+  it('surfaces skipped optional dependencies by package', () => {
+    const current = {
+      packages: [{
+        ...base.packages[0],
+        skippedOptionalDependencies: [
+          'oxc-parser -> @oxc-parser/binding-darwin-arm64',
+        ],
+      }],
+    }
+    const report = renderDependencyReport(null, current)
+
+    expect(report).toContain('| @unhead/vue | 42 | 58 MB | vite 4 MB | 1 |')
+    expect(report).toContain('@unhead/vue: `oxc-parser -> @oxc-parser/binding-darwin-arm64`')
   })
 })

--- a/bench/bundle/dependency-report.test.ts
+++ b/bench/bundle/dependency-report.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { renderDependencyReport } from './dependency-report'
+
+const base = {
+  packages: [
+    {
+      name: '@unhead/vue',
+      dependencyCount: 42,
+      dependencySize: 58_000_000,
+      dependencies: [
+        { name: 'vite', version: '8.1.5', size: 4_000_000 },
+      ],
+    },
+  ],
+}
+
+describe('runtime dependency report', () => {
+  it('surfaces dependency size and count changes', () => {
+    const current = {
+      packages: [
+        {
+          name: '@unhead/vue',
+          dependencyCount: 18,
+          dependencySize: 29_000_000,
+          dependencies: [
+            { name: 'vue', version: '3.5.40', size: 2_000_000 },
+          ],
+        },
+      ],
+    }
+
+    expect(renderDependencyReport(base, current)).toMatchInlineSnapshot(`
+      "### 📦 Runtime Dependencies
+
+      🟢 **1 package smaller** · net -29 MB
+
+      | Package | Install size | Dependencies | Δ |
+      |---|---|---|---|
+      | **@unhead/vue** | 58 MB → 29 MB | 42 → 18 | 🟢 -29 MB (-50.0%) |
+
+      <details><summary>All packages (1)</summary>
+
+      | Package | External deps | Install size | Largest dependency |
+      |---|---|---|---|
+      | @unhead/vue | 18 | 29 MB | vue 2 MB |
+
+      </details>
+
+      <sub>Production dependencies only. Peer dependencies and Unhead workspace packages are excluded.</sub>"
+    `)
+  })
+
+  it('reports an unchanged dependency graph', () => {
+    expect(renderDependencyReport(base, base)).toContain('✅ **No runtime dependency changes**')
+  })
+
+  it('renders count-only growth without a negative zero size', () => {
+    const current = {
+      packages: [{
+        ...base.packages[0],
+        dependencyCount: base.packages[0].dependencyCount + 1,
+      }],
+    }
+
+    expect(renderDependencyReport(base, current)).toContain('🔴 +1 dependency')
+  })
+})

--- a/bench/bundle/dependency-report.ts
+++ b/bench/bundle/dependency-report.ts
@@ -9,6 +9,7 @@ export interface PackageDependencyStats {
   dependencyCount: number
   dependencySize: number
   dependencies: RuntimeDependency[]
+  skippedOptionalDependencies: string[]
 }
 
 export interface DependencyAnalysis {
@@ -40,6 +41,8 @@ function formatDelta(bytes: number): string {
 }
 
 function formatDependencyDelta(count: number): string {
+  if (count === 0)
+    return '0 dependencies'
   const sign = count > 0 ? '+' : '-'
   const absolute = Math.abs(count)
   return `${sign}${absolute} dependenc${absolute === 1 ? 'y' : 'ies'}`
@@ -149,14 +152,26 @@ export function renderDependencyReport(base: DependencyAnalysis | null, current:
   }
 
   out.push('', `<details><summary>All packages (${current.packages.length})</summary>`, '')
-  out.push('| Package | External deps | Install size | Largest dependency |', '|---|---|---|---|')
+  out.push('| Package | External deps | Install size | Largest dependency | Skipped optional |', '|---|---|---|---|---|')
   for (const pkg of [...current.packages].sort((a, b) => a.name.localeCompare(b.name))) {
     const largest = [...pkg.dependencies].sort((a, b) => b.size - a.size)[0]
     const largestLabel = largest ? `${largest.name} ${formatSize(largest.size)}` : 'none'
-    out.push(`| ${pkg.name} | ${pkg.dependencyCount} | ${formatSize(pkg.dependencySize)} | ${largestLabel} |`)
+    out.push(`| ${pkg.name} | ${pkg.dependencyCount} | ${formatSize(pkg.dependencySize)} | ${largestLabel} | ${pkg.skippedOptionalDependencies.length} |`)
   }
   out.push('', '</details>', '')
-  out.push('<sub>Production dependencies only. Peer dependencies and Unhead workspace packages are excluded.</sub>')
+  const skippedCount = current.packages.reduce(
+    (total, pkg) => total + pkg.skippedOptionalDependencies.length,
+    0,
+  )
+  if (skippedCount > 0) {
+    out.push(`<details><summary>Skipped optional dependencies (${skippedCount})</summary>`, '')
+    for (const pkg of current.packages.filter(pkg => pkg.skippedOptionalDependencies.length > 0)) {
+      const skipped = pkg.skippedOptionalDependencies.map(dependency => `\`${dependency}\``).join(', ')
+      out.push(`- ${pkg.name}: ${skipped}`)
+    }
+    out.push('', '</details>', '')
+  }
+  out.push('<sub>Production dependencies only. Peer dependencies and Unhead workspace packages are excluded. Skipped optional dependencies are unavailable on the CI platform.</sub>')
 
   return out.join('\n')
 }

--- a/bench/bundle/dependency-report.ts
+++ b/bench/bundle/dependency-report.ts
@@ -1,0 +1,162 @@
+export interface RuntimeDependency {
+  name: string
+  version: string
+  size: number
+}
+
+export interface PackageDependencyStats {
+  name: string
+  dependencyCount: number
+  dependencySize: number
+  dependencies: RuntimeDependency[]
+}
+
+export interface DependencyAnalysis {
+  packages: PackageDependencyStats[]
+}
+
+type DependencyChange
+  = | { _tag: 'new', current: PackageDependencyStats }
+    | { _tag: 'removed', base: PackageDependencyStats }
+    | { _tag: 'same', base: PackageDependencyStats, current: PackageDependencyStats }
+    | { _tag: 'changed', base: PackageDependencyStats, current: PackageDependencyStats, sizeDelta: number }
+
+function formatSize(bytes: number): string {
+  const units = [
+    { value: 1_000_000, suffix: 'MB' },
+    { value: 1_000, suffix: 'kB' },
+  ]
+  const unit = units.find(candidate => Math.abs(bytes) >= candidate.value)
+  if (!unit)
+    return `${bytes} B`
+  return `${Number((bytes / unit.value).toFixed(1))} ${unit.suffix}`
+}
+
+function formatDelta(bytes: number): string {
+  if (bytes === 0)
+    return '0 B'
+  const sign = bytes > 0 ? '+' : '-'
+  return `${sign}${formatSize(Math.abs(bytes))}`
+}
+
+function formatDependencyDelta(count: number): string {
+  const sign = count > 0 ? '+' : '-'
+  const absolute = Math.abs(count)
+  return `${sign}${absolute} dependenc${absolute === 1 ? 'y' : 'ies'}`
+}
+
+function formatPercent(diff: number, base: number): string {
+  if (base === 0)
+    return ''
+  const value = (diff / base) * 100
+  return ` (${value > 0 ? '+' : '-'}${Math.abs(value).toFixed(1)}%)`
+}
+
+function collectChanges(base: DependencyAnalysis | null, current: DependencyAnalysis): DependencyChange[] {
+  const basePackages = new Map(base?.packages.map(pkg => [pkg.name, pkg]))
+  const currentPackages = new Map(current.packages.map(pkg => [pkg.name, pkg]))
+  const names = [...new Set([...basePackages.keys(), ...currentPackages.keys()])].sort()
+
+  return names.map((name) => {
+    const basePackage = basePackages.get(name)
+    const currentPackage = currentPackages.get(name)
+    if (!basePackage)
+      return { _tag: 'new', current: currentPackage! }
+    if (!currentPackage)
+      return { _tag: 'removed', base: basePackage }
+    if (
+      basePackage.dependencySize === currentPackage.dependencySize
+      && basePackage.dependencyCount === currentPackage.dependencyCount
+    ) {
+      return { _tag: 'same', base: basePackage, current: currentPackage }
+    }
+    return {
+      _tag: 'changed',
+      base: basePackage,
+      current: currentPackage,
+      sizeDelta: currentPackage.dependencySize - basePackage.dependencySize,
+    }
+  })
+}
+
+function renderDelta(change: DependencyChange): string {
+  if (change._tag === 'new')
+    return '🆕 new'
+  if (change._tag === 'removed')
+    return '🟢 removed'
+  if (change._tag === 'same')
+    return 'same'
+  if (change.sizeDelta === 0) {
+    const countDelta = change.current.dependencyCount - change.base.dependencyCount
+    const emoji = countDelta > 0 ? '🔴' : '🟢'
+    return `${emoji} ${formatDependencyDelta(countDelta)}`
+  }
+  const emoji = change.sizeDelta > 0 ? '🔴' : '🟢'
+  return `${emoji} ${formatDelta(change.sizeDelta)}${formatPercent(change.sizeDelta, change.base.dependencySize)}`
+}
+
+export function renderDependencyReport(base: DependencyAnalysis | null, current: DependencyAnalysis): string {
+  const changes = collectChanges(base, current)
+  const changed = changes.filter(change => change._tag !== 'same')
+  const grew = changed.filter(change =>
+    change._tag === 'new'
+    || (change._tag === 'changed' && (
+      change.sizeDelta > 0
+      || (change.sizeDelta === 0 && change.current.dependencyCount > change.base.dependencyCount)
+    )),
+  )
+  const netSize = changed.reduce((total, change) => {
+    if (change._tag === 'new')
+      return total + change.current.dependencySize
+    if (change._tag === 'removed')
+      return total - change.base.dependencySize
+    if (change._tag === 'changed')
+      return total + change.sizeDelta
+    return total
+  }, 0)
+  const netCount = changed.reduce((total, change) => {
+    if (change._tag === 'new')
+      return total + change.current.dependencyCount
+    if (change._tag === 'removed')
+      return total - change.base.dependencyCount
+    if (change._tag === 'changed')
+      return total + change.current.dependencyCount - change.base.dependencyCount
+    return total
+  }, 0)
+  const net = netSize === 0 ? formatDependencyDelta(netCount) : formatDelta(netSize)
+
+  const out = ['### 📦 Runtime Dependencies', '']
+  if (!changed.length) {
+    out.push('✅ **No runtime dependency changes**')
+  }
+  else if (grew.length) {
+    out.push(`⚠️ **${grew.length} package${grew.length === 1 ? '' : 's'} grew** · net ${net}`)
+  }
+  else {
+    out.push(`🟢 **${changed.length} package${changed.length === 1 ? '' : 's'} smaller** · net ${net}`)
+  }
+
+  if (changed.length) {
+    out.push('', '| Package | Install size | Dependencies | Δ |', '|---|---|---|---|')
+    for (const change of changed) {
+      const name = change._tag === 'removed' ? change.base.name : change.current.name
+      const baseSize = change._tag === 'new' ? 0 : change.base.dependencySize
+      const currentSize = change._tag === 'removed' ? 0 : change.current.dependencySize
+      const baseCount = change._tag === 'new' ? 0 : change.base.dependencyCount
+      const currentCount = change._tag === 'removed' ? 0 : change.current.dependencyCount
+      out.push(`| **${name}** | ${formatSize(baseSize)} → ${formatSize(currentSize)} | ${baseCount} → ${currentCount} | ${renderDelta(change)} |`)
+    }
+  }
+
+  out.push('', `<details><summary>All packages (${current.packages.length})</summary>`, '')
+  out.push('| Package | External deps | Install size | Largest dependency |', '|---|---|---|---|')
+  for (const pkg of [...current.packages].sort((a, b) => a.name.localeCompare(b.name))) {
+    const largest = [...pkg.dependencies].sort((a, b) => b.size - a.size)[0]
+    const largestLabel = largest ? `${largest.name} ${formatSize(largest.size)}` : 'none'
+    out.push(`| ${pkg.name} | ${pkg.dependencyCount} | ${formatSize(pkg.dependencySize)} | ${largestLabel} |`)
+  }
+  out.push('', '</details>', '')
+  out.push('<sub>Production dependencies only. Peer dependencies and Unhead workspace packages are excluded.</sub>')
+
+  return out.join('\n')
+}

--- a/bench/bundle/report.ts
+++ b/bench/bundle/report.ts
@@ -1,21 +1,26 @@
 import fs from 'node:fs'
 import process from 'node:process'
 import { collectBundleData, renderBundleReport } from './bundle-report'
+import { renderDependencyReport } from './dependency-report'
 import { renderPerfReport } from './perf-report'
 
-// Combined size + perf comment for the PR. Bundle data comes from the dist dirs
-// (BASE_DIST for the base baseline); perf comes from JSON the workflow produced by
-// running perf-ci.mjs on the base and PR builds (BASE_PERF / PR_PERF).
+// Combined bundle, dependency, and perf comment for the PR. Bundle data comes
+// from the dist dirs; dependency and perf data come from JSON generated for the
+// base and PR builds.
 const sections: string[] = [renderBundleReport(collectBundleData())]
 
-function readPerf(p?: string) {
+function readJson(p?: string) {
   return p && fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')) : null
 }
 
+const prDependencies = readJson(process.env.PR_DEPENDENCIES)
+if (prDependencies?.packages?.length)
+  sections.push(renderDependencyReport(readJson(process.env.BASE_DEPENDENCIES), prDependencies))
+
 // guard on benches: a perf run that failed writes `{}`, which must skip the section, not crash
-const prPerf = readPerf(process.env.PR_PERF)
+const prPerf = readJson(process.env.PR_PERF)
 if (prPerf?.benches?.length)
-  sections.push(renderPerfReport(readPerf(process.env.BASE_PERF), prPerf))
+  sections.push(renderPerfReport(readJson(process.env.BASE_PERF), prPerf))
 
 let out = sections.join('\n\n---\n\n')
 


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Bundle size CI tracks emitted JavaScript but misses package install cost. Analyze each published package's external production dependency graph on the base and PR revisions, then add dependency counts and install size deltas to the existing PR comment. Peer dependencies and Unhead workspace packages are excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added runtime dependency analysis to bundle builds.
  - Pull request reports now include a dependency section showing added/removed/changed packages with dependency count and install-size deltas, plus per-package details (including skipped optional dependencies).
- **CI / Chores**
  - Bundle-size workflow now produces base and PR dependency snapshots and passes them into the report renderer.
- **Tests**
  - Added automated coverage for dependency report rendering, including unchanged graphs, count-only changes, and optional dependency output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->