### PR TITLE
docs: guide optional Vite DevTools setup

### DIFF
--- a/docs/head/1.guides/build-plugins/4.devtools.md
+++ b/docs/head/1.guides/build-plugins/4.devtools.md
@@ -24,7 +24,29 @@ The plugin injects `_source` metadata (file path and line number) into `useHead(
 
 ## Setup
 
-The integration is included by default when using the [unified Vite plugin](/docs/head/guides/build-plugins/overview). It only runs in `vite dev`, and only when Vite DevTools is active. For example, enable it in Vite's configuration:
+Install Vite DevTools and its integration kit:
+
+::code-group
+
+```bash [pnpm]
+pnpm add -D @vitejs/devtools @vitejs/devtools-kit
+```
+
+```bash [npm]
+npm install -D @vitejs/devtools @vitejs/devtools-kit
+```
+
+```bash [yarn]
+yarn add -D @vitejs/devtools @vitejs/devtools-kit
+```
+
+```bash [bun]
+bun add -D @vitejs/devtools @vitejs/devtools-kit
+```
+
+::
+
+The Unhead integration is included by default when using the [unified Vite plugin](/docs/head/guides/build-plugins/overview). It only runs in `vite dev`, and only when Vite DevTools is active. Enable it in Vite's configuration:
 
 ```ts [vite.config.ts]
 export default defineConfig({
@@ -73,7 +95,7 @@ Unhead({
 
 ## Requirements
 
-`@vitejs/devtools-kit` is a dependency of `@unhead/bundler`, and the panel UI ships pre-built with the package. You still need to enable Vite DevTools itself as shown above.
+`@vitejs/devtools` and `@vitejs/devtools-kit` are optional development dependencies. Projects that do not enable Vite DevTools do not need to install them. The panel UI ships pre-built with `@unhead/bundler`.
 
 ## How It Works
 

--- a/packages/bundler/README.md
+++ b/packages/bundler/README.md
@@ -44,6 +44,12 @@ export default defineConfig({
 })
 ```
 
+To use the Unhead panel in Vite DevTools, install its optional development packages:
+
+```bash
+pnpm add -D @vitejs/devtools @vitejs/devtools-kit
+```
+
 ### Options
 
 ```ts

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -80,6 +80,7 @@
   },
   "peerDependencies": {
     "@unhead/cli": "workspace:^",
+    "@vitejs/devtools-kit": "^0.4.1",
     "esbuild": ">=0.17.0",
     "lightningcss": ">=1.20.0",
     "rolldown": ">=1.0.0-beta.0",
@@ -89,6 +90,9 @@
   },
   "peerDependenciesMeta": {
     "@unhead/cli": {
+      "optional": true
+    },
+    "@vitejs/devtools-kit": {
       "optional": true
     },
     "esbuild": {
@@ -108,7 +112,6 @@
     }
   },
   "dependencies": {
-    "@vitejs/devtools-kit": "catalog:",
     "magic-string": "catalog:",
     "oxc-parser": "catalog:",
     "oxc-walker": "catalog:",
@@ -116,6 +119,7 @@
     "unplugin": "catalog:"
   },
   "devDependencies": {
+    "@vitejs/devtools-kit": "catalog:",
     "rollup": "catalog:",
     "unhead": "workspace:*",
     "vite": "catalog:"

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -115,7 +115,6 @@
     "magic-string": "catalog:",
     "oxc-parser": "catalog:",
     "oxc-walker": "catalog:",
-    "ufo": "catalog:",
     "unplugin": "catalog:"
   },
   "devDependencies": {

--- a/packages/bundler/src/devtools/lazy.ts
+++ b/packages/bundler/src/devtools/lazy.ts
@@ -4,6 +4,7 @@ import type { UnheadDevtoolsOptions } from '../unplugin/types'
 
 const HEAD_COMPOSABLE_RE = /\b(?:useHead|useSeoMeta|useHeadSafe|useScript)\b/
 const FILE_RE = /\.(vue|tsx?|jsx?|svelte)$/
+const DEVTOOLS_KIT_PACKAGE = '@vitejs/devtools-kit'
 
 interface LazyUnheadDevtoolsOptions extends UnheadDevtoolsOptions {
   _ctx?: HeadTransformContext
@@ -31,6 +32,26 @@ function isViteDevtoolsEnabled(config: { devtools?: { enabled?: boolean }, plugi
   return config.devtools?.enabled === true || config.plugins.some(isViteDevtoolsPlugin)
 }
 
+function isMissingDevtoolsKit(error: unknown): boolean {
+  let current = error
+  while (current instanceof Error) {
+    if (current.message.includes(DEVTOOLS_KIT_PACKAGE))
+      return true
+    current = current.cause
+  }
+  return false
+}
+
+function handleDevtoolsLoadError(error: unknown): never {
+  if (isMissingDevtoolsKit(error)) {
+    throw new Error(
+      'Install @vitejs/devtools and @vitejs/devtools-kit to enable Unhead DevTools. For example: pnpm add -D @vitejs/devtools @vitejs/devtools-kit',
+      { cause: error },
+    )
+  }
+  throw error
+}
+
 /**
  * Lightweight proxy for the Vite-only devtools plugin. Framework bundler
  * entries are shared by webpack/rspack/rollup, so keep the devtools
@@ -50,10 +71,12 @@ export function lazyUnheadDevtools(options?: LazyUnheadDevtoolsOptions): Plugin 
   async function resolvePlugin(): Promise<Plugin> {
     if (plugin)
       return plugin
-    pluginPromise ||= import('./vite').then((mod) => {
-      plugin = mod.unheadDevtools(options)
-      return plugin
-    })
+    pluginPromise ||= import('./vite')
+      .catch(handleDevtoolsLoadError)
+      .then((mod) => {
+        plugin = mod.unheadDevtools(options)
+        return plugin
+      })
     return pluginPromise
   }
 

--- a/packages/bundler/test/devtoolsMissingPeer.test.ts
+++ b/packages/bundler/test/devtoolsMissingPeer.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+import { lazyUnheadDevtools } from '../src/devtools/lazy'
+
+vi.mock('../src/devtools/vite', () => {
+  const error = new Error('Cannot find package \'@vitejs/devtools-kit\' imported from packages/bundler/src/devtools/vite.ts')
+  Object.assign(error, { code: 'ERR_MODULE_NOT_FOUND' })
+  throw error
+})
+
+describe('lazyUnheadDevtools', () => {
+  it('explains how to install the optional Vite DevTools packages', async () => {
+    const plugin = lazyUnheadDevtools() as any
+
+    await expect(plugin.configResolved({
+      devtools: { enabled: true },
+      plugins: [],
+    })).rejects.toThrow(
+      'Install @vitejs/devtools and @vitejs/devtools-kit to enable Unhead DevTools.',
+    )
+  })
+})

--- a/packages/bundler/test/package.test.ts
+++ b/packages/bundler/test/package.test.ts
@@ -26,4 +26,8 @@ describe('@unhead/bundler package', () => {
     expect(packageJson.peerDependenciesMeta?.['@vitejs/devtools-kit']).toEqual({ optional: true })
     expect(packageJson.devDependencies?.['@vitejs/devtools-kit']).toBeDefined()
   })
+
+  it('does not ship unused runtime dependencies', () => {
+    expect(packageJson.dependencies).not.toHaveProperty('ufo')
+  })
 })

--- a/packages/bundler/test/package.test.ts
+++ b/packages/bundler/test/package.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+interface PackageJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>
+}
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf8'),
+) as PackageJson
+
+describe('@unhead/bundler package', () => {
+  it('keeps Vite DevTools packages optional', () => {
+    const runtimeDependencies = {
+      ...packageJson.dependencies,
+      ...packageJson.optionalDependencies,
+    }
+
+    expect(Object.keys(runtimeDependencies).filter(name => name.startsWith('@vitejs/devtools'))).toEqual([])
+    expect(packageJson.peerDependencies?.['@vitejs/devtools-kit']).toBeDefined()
+    expect(packageJson.peerDependenciesMeta?.['@vitejs/devtools-kit']).toEqual({ optional: true })
+    expect(packageJson.devDependencies?.['@vitejs/devtools-kit']).toBeDefined()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ catalogs:
     typescript:
       specifier: 6.0.3
       version: 6.0.3
-    ufo:
-      specifier: ^1.6.4
-      version: 1.6.4
     unbuild:
       specifier: ^3.6.1
       version: 3.6.1
@@ -854,9 +851,6 @@ importers:
       rolldown:
         specifier: 1.1.2
         version: 1.1.2
-      ufo:
-        specifier: 'catalog:'
-        version: 1.6.4
       unplugin:
         specifier: 'catalog:'
         version: 3.3.0(esbuild@0.28.1)(rolldown@1.1.2)(rollup@4.62.2)(vite@8.1.5)(webpack@5.105.2(esbuild@0.28.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,9 +836,6 @@ importers:
       '@unhead/cli':
         specifier: workspace:^
         version: link:../cli
-      '@vitejs/devtools-kit':
-        specifier: 'catalog:'
-        version: 0.4.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.2))(srvx@0.11.22)(typescript@7.0.2)(vite@8.1.5)
       esbuild:
         specifier: '>=0.17.0'
         version: 0.28.1
@@ -867,6 +864,9 @@ importers:
         specifier: '>=5.0.0'
         version: 5.105.2(esbuild@0.28.1)
     devDependencies:
+      '@vitejs/devtools-kit':
+        specifier: 'catalog:'
+        version: 0.4.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.2))(srvx@0.11.22)(typescript@7.0.2)(vite@8.1.5)
       rollup:
         specifier: 'catalog:'
         version: 4.62.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,7 +87,6 @@ catalog:
   tinyglobby: ^0.2.17
   tslib: ^2.8.1
   typescript: 6.0.3
-  ufo: ^1.6.4
   unbuild: ^3.6.1
   unplugin: ^3.3.0
   unplugin-vue-components: ^32.1.0


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #911.

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Documents the optional Vite DevTools packages required by the Unhead panel. The lazy loader now reports the exact install command when the kit is missing, and the unused `ufo` dependency is removed.
