### PR TITLE
fix(schema-org): apply defaults when node type is absent

### DIFF
--- a/packages/schema-org/src/nodes/Organization/index.test.ts
+++ b/packages/schema-org/src/nodes/Organization/index.test.ts
@@ -1,8 +1,33 @@
 import { expect } from 'vitest'
+import { organizationResolver } from '.'
 import { defineOrganization, useSchemaOrg } from '../../'
 import { injectSchemaOrg, useSetup } from '../../../test'
 
 describe('defineOrganization', () => {
+  it('keeps a logo when the identity type is resolved from the default', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        {
+          name: 'test',
+          logo: '/logo.png',
+          _resolver: {
+            ...organizationResolver,
+            defaults: undefined,
+          },
+        },
+      ])
+
+      const graph = await injectSchemaOrg(head)
+      const identity = graph.find(node => node['@id'] === 'https://example.com/#identity')
+
+      expect(identity).toMatchObject({
+        '@type': 'Organization',
+        'logo': { '@id': 'https://example.com/#logo' },
+      })
+      expect(graph.some(node => node['@id'] === 'https://example.com/#organization')).toBe(false)
+    })
+  })
+
   it('keeps a logo on the identity organization', async () => {
     await useSetup(async (head) => {
       useSchemaOrg(head, [

--- a/packages/schema-org/src/utils/index.test.ts
+++ b/packages/schema-org/src/utils/index.test.ts
@@ -1,0 +1,12 @@
+import type { Thing } from '../types'
+import { resolveDefaultType } from '.'
+
+describe('resolveDefaultType', () => {
+  it('uses the default when the node type is missing', () => {
+    const node = {} as Thing
+
+    resolveDefaultType(node, 'Organization')
+
+    expect(node['@type']).toBe('Organization')
+  })
+})

--- a/packages/schema-org/src/utils/index.ts
+++ b/packages/schema-org/src/utils/index.ts
@@ -154,9 +154,12 @@ export function resolveDefaultType(node: Thing, defaultType: Arrayable<string>) 
   }
   // General case: dedupe with Set
   const types = new Set<string>(asArray(defaultType))
-  for (const t of asArray(val))
-    types.add(t)
-  node['@type'] = types.size === 1 ? val : [...types]
+  for (const t of asArray(val)) {
+    if (t != null)
+      types.add(t)
+  }
+  const resolved = [...types]
+  node['@type'] = resolved.length === 1 ? resolved[0] : resolved
 }
 
 export function resolveWithBase(base: string | undefined, urlOrPath: string) {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes harlan-zw/nuxt-schema-org#142

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`resolveDefaultType` included `undefined` when `@type` was absent. Organization identities then took the specialized organization path, moving the logo to a duplicate `#organization` node. Filter nullish types and assign the resolved default type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or null type values when resolving schema metadata.
  * Prevented duplicate type entries and ensured resolved types are returned in the appropriate format.

* **Tests**
  * Added coverage for applying a default type when no node type is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->