### PR TITLE
fix(scripts): keep one stable proxy across script load

### DIFF
--- a/docs/head/7.api/composables/4.use-script.md
+++ b/docs/head/7.api/composables/4.use-script.md
@@ -129,7 +129,16 @@ The `resolve` context also provides an `AbortSignal`. It is aborted if loading f
 
 ### Proxy behavior
 
-Before the API resolves, `proxy` records property access and function calls. Calls return `void`; they are replayed against the resolved API in order. After resolution, the proxy forwards calls directly.
+Before the API resolves, `proxy` records property access and function calls. Calls return `void`; they are replayed against the resolved API in order. After resolution, the proxy forwards calls directly, applying methods against their real owner so vendor receiver checks keep working.
+
+`proxy` is a stable reference. Destructuring it before load is safe, including individual methods:
+
+```ts
+const { proxy } = useScript<AnalyticsApi>('https://example.com/analytics.js', {
+  use: () => window.analytics,
+})
+const { track } = proxy // still forwards once the script loads
+```
 
 Use `onError()` for failures rather than assuming a queued call succeeded:
 

--- a/packages/unhead/src/scripts/proxy.ts
+++ b/packages/unhead/src/scripts/proxy.ts
@@ -1,55 +1,17 @@
 import type { AsVoidFunctions, RecordingEntry } from './types'
 
-export function createNoopedRecordingProxy<T extends Record<string, any>>(instance: T = {} as T): { proxy: AsVoidFunctions<T>, stack: RecordingEntry[][] } {
-  const stack: RecordingEntry[][] = []
+function NOOP() {}
 
-  let stackIdx = -1
-  const handler = (reuseStack = false) => ({
-    get(_, prop, receiver) {
-      if (!reuseStack) {
-        const v = Reflect.get(_, prop, receiver)
-        if (typeof v !== 'undefined') {
-          return v
-        }
-        stackIdx++ // root get triggers a new stack
-        stack[stackIdx] = []
-      }
-      stack[stackIdx].push({ type: 'get', key: prop })
-      // @ts-expect-error untyped
-      return new Proxy(() => {}, handler(true))
-    },
-    apply(_, __, args) {
-      stack[stackIdx].push({ type: 'apply', key: '', args })
-      return undefined
-    },
-  } as ProxyHandler<T>)
-
-  return {
-    proxy: new Proxy(instance || {}, handler()),
-    stack,
-  }
+export interface ScriptProxy<T extends Record<symbol | string, any>> {
+  proxy: AsVoidFunctions<T>
+  stack: RecordingEntry[][]
+  /**
+   * Replay everything recorded before the script loaded, then switch the proxy to forwarding.
+   */
+  resolve: (instance: T) => void
 }
 
-export function createForwardingProxy<T extends Record<string, any>>(target: T): AsVoidFunctions<T> {
-  const handler: ProxyHandler<T> = {
-    get(_, prop, receiver) {
-      const v = Reflect.get(_, prop, receiver)
-      if (typeof v === 'object') {
-        return new Proxy(v, handler)
-      }
-      return v
-    },
-    apply(_, __, args) {
-      // does not return the apply output for consistency
-      // @ts-expect-error untyped
-      Reflect.apply(_, __, args)
-      return undefined
-    },
-  }
-  return new Proxy(target, handler) as AsVoidFunctions<T>
-}
-
-export function replayProxyRecordings<T extends object>(target: T, stack: RecordingEntry[][]) {
+function replayRecordings<T extends object>(target: T, stack: RecordingEntry[][]) {
   stack.forEach((recordings) => {
     let context: any = target
     let prevContext: any = target
@@ -64,4 +26,90 @@ export function replayProxyRecordings<T extends object>(target: T, stack: Record
       }
     })
   })
+}
+
+function walk(root: any, path: PropertyKey[]) {
+  let owner: any
+  let value = root
+  for (const key of path) {
+    if (value == null) {
+      return { owner: undefined, value: undefined }
+    }
+    owner = value
+    value = value[key]
+  }
+  return { owner, value }
+}
+
+/**
+ * A single, stable proxy for a vendor API that may not exist yet.
+ *
+ * Before `resolve()` it records property access and calls so they can be replayed. After `resolve()`
+ * the same proxy forwards to the real API, applying methods against their raw owner so native
+ * receiver (brand) checks keep working.
+ *
+ * The proxy identity never changes, so a reference taken before the script loads keeps working after.
+ */
+export function createScriptProxy<T extends Record<string, any>>(initial: T = {} as T): ScriptProxy<T> {
+  const stack: RecordingEntry[][] = []
+  let instance: T | undefined
+  let stackIdx = -1
+
+  function node(path: PropertyKey[]): any {
+    const children = new Map<PropertyKey, any>()
+    return new Proxy(NOOP, {
+      get(_, prop) {
+        if (instance) {
+          const { value } = walk(instance, path)
+          const v = value == null ? undefined : Reflect.get(value, prop, value)
+          // only functions need wrapping, to bind `this` and keep the void return contract
+          if (typeof v !== 'function') {
+            return v
+          }
+        }
+        else if (!path.length) {
+          // root access to an API that already exists on the page (e.g. a spied `window._paq`)
+          const v = Reflect.get(initial, prop)
+          if (typeof v !== 'undefined') {
+            return v
+          }
+          stackIdx++ // root get triggers a new stack
+          stack[stackIdx] = []
+          stack[stackIdx].push({ type: 'get', key: prop })
+        }
+        else {
+          stack[stackIdx].push({ type: 'get', key: prop })
+        }
+        let child = children.get(prop)
+        if (!child) {
+          child = node([...path, prop])
+          children.set(prop, child)
+        }
+        return child
+      },
+      apply(_, __, args) {
+        if (instance) {
+          const { owner, value } = walk(instance, path)
+          if (typeof value === 'function') {
+            Reflect.apply(value, owner, args)
+          }
+        }
+        else {
+          stack[stackIdx].push({ type: 'apply', key: '', args })
+        }
+        // never returns the call output, a recorded call has nothing to return
+        return undefined
+      },
+    })
+  }
+
+  return {
+    proxy: node([]) as AsVoidFunctions<T>,
+    stack,
+    resolve(api: T) {
+      instance = api
+      replayRecordings(api, stack)
+      stack.length = 0
+    },
+  }
 }

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -18,7 +18,7 @@ import type {
 } from './types'
 import { hasOwn } from '../utils/hasOwn'
 import { callHook } from '../utils/hooks'
-import { createForwardingProxy, createNoopedRecordingProxy, replayProxyRecordings } from './proxy'
+import { createScriptProxy } from './proxy'
 import { createScriptScope } from './scope'
 import { createScriptWaitFor } from './waitFor'
 
@@ -469,12 +469,9 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
     throw error
   }
   if (resolveApi || use) {
-    const { proxy, stack } = createNoopedRecordingProxy<T>(head.ssr ? {} as T : initialInstance || {} as T)
+    const { proxy, resolve } = createScriptProxy<T>(head.ssr ? {} as T : initialInstance || {} as T)
     script.proxy = proxy
-    script.onLoaded((instance) => {
-      replayProxyRecordings(instance, stack)
-      script.proxy = createForwardingProxy(instance)
-    })
+    script.onLoaded(resolve)
   }
   // need to make sure it's not already registered
   const warmupStrategy = _warmupStrategy || ((typeof trigger === 'undefined' || trigger === 'client') ? 'preload' : false)

--- a/packages/unhead/test/unit/scripts/proxy.test.ts
+++ b/packages/unhead/test/unit/scripts/proxy.test.ts
@@ -3,7 +3,7 @@ import type { AsVoidFunctions } from '../../../src/scripts/types'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { createHead } from '../../../src/client'
 import { useScript } from '../../../src/composables'
-import { createForwardingProxy, createNoopedRecordingProxy, replayProxyRecordings } from '../../../src/scripts/proxy'
+import { createScriptProxy } from '../../../src/scripts/proxy'
 import { createSpyProxy } from '../../../src/scripts/utils'
 
 interface Api {
@@ -31,7 +31,7 @@ interface GoogleAnalytics {
 
 describe('proxy chain', () => {
   it('augments types', () => {
-    const proxy = createNoopedRecordingProxy<Api>()
+    const proxy = createScriptProxy<Api>()
     expectTypeOf(proxy.proxy._paq).toBeArray()
     expectTypeOf(proxy.proxy.doSomething).toBeFunction()
     expectTypeOf(proxy.proxy.doSomething).returns.toBeVoid()
@@ -40,7 +40,7 @@ describe('proxy chain', () => {
   })
   it('e2e', async () => {
     // do recording
-    const { proxy, stack } = createNoopedRecordingProxy<Api>()
+    const { proxy, stack, resolve } = createScriptProxy<Api>()
     const script = { proxy, instance: null }
     script.proxy._paq.push(['test'])
     script.proxy.say('hello world')
@@ -66,10 +66,9 @@ describe('proxy chain', () => {
     const consoleMock = vi.spyOn(console, 'log').mockImplementation((...args) => {
       log('mocked', ...args)
     })
+    // replay recording and switch the (same) proxy over to forwarding
     // @ts-expect-error untyped
-    replayProxyRecordings(script.instance, stack)
-    // @ts-expect-error untyped
-    script.proxy = createForwardingProxy(script.instance)
+    resolve(script.instance)
     expect(consoleMock).toHaveBeenCalledWith('hello world')
     script.proxy.say('proxy updated!')
     expect(consoleMock).toHaveBeenCalledWith('proxy updated!')
@@ -147,6 +146,60 @@ describe('proxy chain', () => {
     expect(consoleMock).toHaveBeenCalledWith('hello-world')
   })
 
+  it('applies vendor methods against their raw owner', () => {
+    // native APIs brand check their receiver, so they must never see the proxy as `this`
+    const branded = new WeakSet<object>()
+    const canvas = {
+      getBoundingClientRect() {
+        if (!branded.has(this)) {
+          throw new TypeError('Illegal invocation')
+        }
+        return { width: 120 }
+      },
+    }
+    branded.add(canvas)
+    const api = {
+      canvas,
+      addConfetti() {
+        return this.canvas.getBoundingClientRect().width
+      },
+    }
+
+    const { proxy, resolve } = createScriptProxy<typeof api>()
+    resolve(api)
+
+    expect(() => proxy.addConfetti()).not.toThrow()
+    // nested objects are handed back raw so vendor internals keep working
+    expect(proxy.canvas).toBe(canvas)
+  })
+
+  it('keeps references taken before load working after load', () => {
+    const greet = vi.fn((s: string) => s)
+    const { proxy, resolve } = createScriptProxy<{ greet: (s: string) => string }>()
+    // destructured in setup, before the script has loaded
+    const heldProxy = proxy
+    const heldMethod = proxy.greet
+
+    proxy.greet('before')
+    resolve({ greet })
+
+    expect(greet).toHaveBeenCalledWith('before')
+    heldProxy.greet('after-via-object')
+    heldMethod('after-via-method')
+    expect(greet).toHaveBeenCalledWith('after-via-object')
+    expect(greet).toHaveBeenCalledWith('after-via-method')
+  })
+
+  it('has a stable identity either side of load', () => {
+    const api = { say: (s: string) => s }
+    const { proxy, resolve } = createScriptProxy<typeof api>()
+    expect(proxy.say).toBe(proxy.say)
+    resolve(api)
+    expect(proxy.say).toBe(proxy.say)
+    // calls stay void once forwarding
+    expect(proxy.say('x')).toBeUndefined()
+  })
+
   it('replays calls after async use() resolves', async () => {
     const head = createHead()
     const { promise, resolve } = Promise.withResolvers<{ greet: (foo: string) => string }>()
@@ -188,8 +241,6 @@ describe('types: AsVoidFunctions', () => {
   })
 
   it('gtag types', () => {
-    // eslint-disable-next-line unused-imports/no-unused-vars
-    const gtag = {} as AsVoidFunctions<GoogleAnalytics>['gtag']
-    expectTypeOf<typeof gtag>().toBeFunction()
+    expectTypeOf<AsVoidFunctions<GoogleAnalytics>['gtag']>().toBeFunction()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue. Found via Sentry issue NUXTSEO-SITE-17. Supersedes #907.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`useScript` swapped `script.proxy` from a recording proxy to a forwarding proxy on load. Two bugs fell out of that split:

1. `createForwardingProxy` used the proxy as the receiver, so vendor methods saw the proxy as `this`. Native brand checks then threw `Illegal invocation` in Firefox. This is what #907 reported.
2. A reference taken before load kept hitting the recording proxy afterwards, pushing into a stack that had already been replayed. Those calls were silently dropped. `const { proxy } = useScript(...)` in Vue `setup`, called later from a click handler, hits this.

#907 fixes (1) by wrapping every forwarded method in a second proxy bound to its raw owner. That leaves the swap in place, so (2) survives and nested objects go through two proxy layers instead of one.

This replaces `createNoopedRecordingProxy` and `createForwardingProxy` with a single `createScriptProxy`. `script.proxy` is assigned once and never reassigned:

```ts
const { proxy, resolve } = createScriptProxy<T>(head.ssr ? {} as T : initialInstance || {} as T)
script.proxy = proxy
script.onLoaded(resolve)
```

Each proxy node tracks its key path. Before `resolve()` it records into the stack; after `resolve()` it walks the path on the real instance and calls `Reflect.apply(value, owner, args)`, so `this` is always the raw owner. Property reads return raw values and only functions are wrapped, which keeps vendor internals from ever receiving a proxy.

Three regression tests added in `packages/unhead/test/unit/scripts/proxy.test.ts`: raw-owner receiver (the Firefox case), references held across load, and stable identity with void returns.

One behaviour change worth noting: after load, `proxy.canvas` returns the raw object, so `proxy.canvas.getBoundingClientRect()` returns a real value where the recursive `AsVoidFunctions` type says `void`.