### PR TITLE
fix(v2): harden head input rendering

### DIFF
--- a/packages/unhead/src/parser/index.ts
+++ b/packages/unhead/src/parser/index.ts
@@ -1,4 +1,5 @@
 import type { SerializableHead } from '../types'
+import { hasOwn } from '../utils/hasOwn'
 
 const TAG_HTML = 0
 const TAG_HEAD = 1
@@ -131,6 +132,10 @@ export function parseAttributes(attrStr: string): Record<string, string> {
     return {}
 
   const result: Record<string, string> = {}
+  const setAttr = (name: string, value: string) => {
+    if (!hasOwn(result, name))
+      result[name] = value
+  }
   const len = attrStr.length
   let i = 0
 
@@ -175,7 +180,7 @@ export function parseAttributes(attrStr: string): Record<string, string> {
           state = BEFORE_VALUE
         }
         else if (!isSpace) {
-          result[name] = ''
+          setAttr(name, '')
           state = NAME
           nameStart = i
           nameEnd = 0 // Reset nameEnd when starting a new attribute
@@ -195,18 +200,15 @@ export function parseAttributes(attrStr: string): Record<string, string> {
         break
 
       case QUOTED_VALUE:
-        if (charCode === BACKSLASH_CHAR && i + 1 < len) {
-          i++
-        }
-        else if (charCode === quoteChar) {
-          result[name] = attrStr.substring(valueStart, i)
+        if (charCode === quoteChar) {
+          setAttr(name, attrStr.substring(valueStart, i))
           state = WHITESPACE
         }
         break
 
       case UNQUOTED_VALUE:
         if (isSpace || charCode === GT_CHAR) {
-          result[name] = attrStr.substring(valueStart, i)
+          setAttr(name, attrStr.substring(valueStart, i))
           state = WHITESPACE
         }
         break
@@ -218,14 +220,14 @@ export function parseAttributes(attrStr: string): Record<string, string> {
   // Handle the last attribute
   if (state === QUOTED_VALUE || state === UNQUOTED_VALUE) {
     if (name) {
-      result[name] = attrStr.substring(valueStart, i)
+      setAttr(name, attrStr.substring(valueStart, i))
     }
   }
   else if (state === NAME || state === AFTER_NAME || state === BEFORE_VALUE) {
     nameEnd = nameEnd || i
     const currentName = attrStr.substring(nameStart, nameEnd).toLowerCase()
     if (currentName) {
-      result[currentName] = ''
+      setAttr(currentName, '')
     }
   }
 

--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -15,6 +15,7 @@ const WhitelistAttributes = {
 } as const
 
 const BlockedLinkRels = new Set(['canonical', 'modulepreload', 'prerender', 'preload', 'prefetch', 'dns-prefetch', 'preconnect', 'manifest', 'pingback'])
+const AsciiWhitespace = /[\t\n\f\r ]+/
 
 const SafeAttrName = /^[a-z][a-z0-9\-]*[a-z0-9]$/i
 
@@ -113,6 +114,11 @@ function acceptDataAttrs(value: Record<string, string>, allowId = true) {
   )
 }
 
+function hasBlockedRel(rel: string) {
+  const tokens = rel.split(AsciiWhitespace)
+  return !tokens.some(Boolean) || tokens.some(token => BlockedLinkRels.has(token.toLowerCase()))
+}
+
 function makeTagSafe(tag: HeadTag): HeadSafe | false {
   let next: Record<string, any> = {}
   const { tag: type, props: prev } = tag
@@ -162,7 +168,7 @@ function makeTagSafe(tag: HeadTag): HeadSafe | false {
           return
         }
         // block bad rel types
-        if (key === 'rel' && (typeof val !== 'string' || BlockedLinkRels.has(val.toLowerCase()))) {
+        if (key === 'rel' && (typeof val !== 'string' || hasBlockedRel(val))) {
           return
         }
         if (key === 'href' || key === 'imagesrcset') {
@@ -240,6 +246,18 @@ export const SafeInputPlugin = /* @PURE */ defineHeadPlugin({
           return acc
         }, [])
       }
+    },
+    'tags:afterResolve': (ctx) => {
+      ctx.tags = ctx.tags.reduce((acc: HeadTag[], tag: HeadTag) => {
+        if (!(tag as any)._safe || tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs') {
+          acc.push(tag)
+          return acc
+        }
+        const safeTag = makeTagSafe(tag)
+        if (safeTag)
+          acc.push(safeTag as HeadTag)
+        return acc
+      }, [])
     },
   },
 })

--- a/packages/unhead/src/server/util/propsToString.ts
+++ b/packages/unhead/src/server/util/propsToString.ts
@@ -1,4 +1,7 @@
 /* @__PURE__ */
+import { INVALID_ATTR_NAME_RE } from '../../utils/attrs'
+import { hasOwn } from '../../utils/hasOwn'
+
 function encodeAttribute(value: string) {
   return String(value).replace(/"/g, '&quot;')
 }
@@ -8,7 +11,7 @@ export function propsToString(props: Record<string, any>) {
   let attrs = ''
 
   for (const key in props) {
-    if (!Object.hasOwn(props, key))
+    if (!hasOwn(props, key) || !key || INVALID_ATTR_NAME_RE.test(key))
       continue
 
     let value = props[key]

--- a/packages/unhead/src/utils/attrs.ts
+++ b/packages/unhead/src/utils/attrs.ts
@@ -1,0 +1,4 @@
+// Attribute names are emitted verbatim by HTML renderers. Reject characters
+// that can terminate or reshape an attribute in HTML syntax.
+// eslint-disable-next-line no-control-regex
+export const INVALID_ATTR_NAME_RE = /[\s"'<>/=\x00-\x1F\x7F]/

--- a/packages/unhead/src/utils/dedupe.ts
+++ b/packages/unhead/src/utils/dedupe.ts
@@ -87,5 +87,6 @@ export function hashTag(tag: HeadTag) {
   const inner = tag.textContent || tag.innerHTML
   if (inner)
     return inner
-  return `${tag.tag}:${Object.entries(tag.props).map(([k, v]) => `${k}:${String(v)}`).join(',')}`
+  const keys = Object.keys(tag.props).sort()
+  return `${tag.tag}:${keys.map(k => `${k}:${String(tag.props[k])}`).join(',')}`
 }

--- a/packages/unhead/src/utils/hasOwn.ts
+++ b/packages/unhead/src/utils/hasOwn.ts
@@ -1,0 +1,5 @@
+const hasOwnProperty = Object.prototype.hasOwnProperty
+
+export function hasOwn(object: object, key: PropertyKey): boolean {
+  return hasOwnProperty.call(object, key)
+}

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -1,5 +1,6 @@
 import type { HeadTag, PropResolver, ResolvableHead } from '../types'
 import { walkResolver } from '../utils/walkResolver'
+import { INVALID_ATTR_NAME_RE } from './attrs'
 import { DupeableTags, HasElementTags, TagConfigKeys } from './const'
 
 function normalizeStyleClassProps(
@@ -61,20 +62,26 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
 
   const isHtmlTag = HasElementTags.has(tag.tag) || tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs'
 
-  Object.entries(input).forEach(([prop, value]) => {
+  for (const prop of Object.keys(input)) {
     if (prop === '__proto__' || prop === 'constructor' || prop === 'prototype')
-      return
+      continue
+    const isDataKey = prop.startsWith('data-')
+    const isHtmlAttr = isHtmlTag && !TagConfigKeys.has(prop)
+    const key = isHtmlAttr && !isDataKey ? prop.toLowerCase() : prop
+    if (isHtmlAttr && (!key || INVALID_ATTR_NAME_RE.test(key)))
+      continue
     // if the value is a primitive, return early
+    const value = input[prop]
     if (value === null) {
       // @ts-expect-error untyped
-      tag.props[prop] = null
-      return
+      tag.props[key] = null
+      continue
     }
 
     if (prop === 'class' || prop === 'style') {
       // @ts-expect-error untyped
       tag.props[prop] = normalizeStyleClassProps(prop as 'class' | 'style', value)
-      return
+      continue
     }
 
     if (TagConfigKeys.has(prop)) {
@@ -84,7 +91,7 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
           type = 'application/json'
         }
         if (!type?.endsWith('json') && type !== 'speculationrules') {
-          return
+          continue
         }
         input.type = type
         tag.props.type = type
@@ -94,14 +101,11 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
         // @ts-expect-error untyped
         tag[prop] = value
       }
-      return
+      continue
     }
 
     // Normalize camelCase HTML attributes to lowercase (e.g. hrefLang -> hreflang)
     // Only for real HTML element tags, not internal virtual tags like _flatMeta
-    const isDataKey = prop.startsWith('data-')
-    const key = isHtmlTag && !isDataKey ? prop.toLowerCase() : prop
-
     const strValue = String(value)
     const isMetaContentKey = tag.tag === 'meta' && key === 'content'
 
@@ -115,7 +119,7 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
     else if (value !== undefined) {
       tag.props[key] = value
     }
-  })
+  }
 
   return tag
 }

--- a/packages/unhead/test/unit/client/resolveTags.test.ts
+++ b/packages/unhead/test/unit/client/resolveTags.test.ts
@@ -114,7 +114,7 @@ describe('resolveTags', () => {
         },
         {
           "_d": undefined,
-          "_h": "link:rel:icon,type:image/x-icon,href:https://cdn.example.com/favicon.ico",
+          "_h": "link:href:https://cdn.example.com/favicon.ico,rel:icon,type:image/x-icon",
           "_p": 1028,
           "_w": 100,
           "props": {
@@ -221,7 +221,7 @@ describe('resolveTags', () => {
         },
         {
           "_d": undefined,
-          "_h": "link:rel:icon,type:image/x-icon,href:https://cdn.example.com/favicon.ico",
+          "_h": "link:href:https://cdn.example.com/favicon.ico,rel:icon,type:image/x-icon",
           "_p": 1028,
           "_w": 100,
           "props": {

--- a/packages/unhead/test/unit/dedupe.test.ts
+++ b/packages/unhead/test/unit/dedupe.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { isMetaArrayDupeKey } from '../../src/utils/dedupe'
+import { hashTag, isMetaArrayDupeKey } from '../../src/utils/dedupe'
+
+describe('hashTag', () => {
+  it('is stable across prop insertion order', () => {
+    expect(hashTag({
+      tag: 'script',
+      props: { defer: true as any, src: '/app.js' },
+    })).toBe(hashTag({
+      tag: 'script',
+      props: { src: '/app.js', defer: true as any },
+    }))
+  })
+})
 
 describe('isMetaArrayDupeKey', () => {
   it('only treats structured Twitter images as arrayable', () => {

--- a/packages/unhead/test/unit/parser/parseAttributes.test.ts
+++ b/packages/unhead/test/unit/parser/parseAttributes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { parseAttributes } from '../../../src/parser'
+
+describe('parseAttributes', () => {
+  it('treats backslash as a literal char in quoted values', () => {
+    expect(parseAttributes('href="C:\\"')).toEqual({ href: 'C:\\' })
+  })
+
+  it('does not let a backslash swallow the closing quote', () => {
+    expect(parseAttributes('content="a\\" name="description"')).toEqual({
+      content: 'a\\',
+      name: 'description',
+    })
+  })
+
+  it('preserves the first duplicate attribute', () => {
+    expect(parseAttributes('type="application/json" type="text/javascript"')).toEqual({
+      type: 'application/json',
+    })
+  })
+})

--- a/packages/unhead/test/unit/server/normalise.test.ts
+++ b/packages/unhead/test/unit/server/normalise.test.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it } from 'vitest'
 import { renderSSRHead } from '../../../src/server'
+import { normalizeProps } from '../../../src/utils'
 import { createServerHeadWithContext } from '../../util'
 
 describe('normalise', () => {
+  it('skips invalid null attribute names during normalization', () => {
+    const tag = normalizeProps({ tag: 'meta', props: {} }, {
+      'name': 'description',
+      'content': 'safe',
+      '\'><script>alert(1)</script><meta data-x': null,
+    } as any)
+
+    expect(tag.props).toStrictEqual({
+      name: 'description',
+      content: 'safe',
+    })
+  })
+
   it('handles booleans nicely', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
+++ b/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { useHeadSafe } from '../../../src'
+import { TemplateParamsPlugin } from '../../../src/plugins'
 import { renderSSRHead } from '../../../src/server'
 import { createServerHeadWithContext } from '../../util'
 
@@ -287,6 +288,15 @@ describe('useHeadSafe edge cases', () => {
       })
     }
 
+    it('blocks token-list rel values containing a blocked token', async () => {
+      for (const rel of ['canonical alternate', 'alternate\tpreconnect', 'stylesheet\npreload']) {
+        const ctx = await safeRender({
+          link: [{ rel, href: 'https://example.com/resource' }],
+        })
+        expect(ctx.headTags).toBe('')
+      }
+    })
+
     it('allows safe rel types', async () => {
       for (const rel of ['icon', 'stylesheet', 'alternate']) {
         const ctx = await safeRender({
@@ -307,6 +317,20 @@ describe('useHeadSafe edge cases', () => {
       const ctx = await safeRender({
         link: [{ rel: 'icon' }],
       })
+      expect(ctx.headTags).toBe('')
+    })
+
+    it('revalidates link href after template param substitution', async () => {
+      const head = createServerHeadWithContext({
+        plugins: [TemplateParamsPlugin],
+      })
+      useHeadSafe(head, {
+        link: [{ rel: 'stylesheet', href: '%href' }],
+        templateParams: {
+          href: 'data:text/css,body{display:none}',
+        },
+      })
+      const ctx = await renderSSRHead(head)
       expect(ctx.headTags).toBe('')
     })
   })

--- a/packages/unhead/test/unit/server/util.test.ts
+++ b/packages/unhead/test/unit/server/util.test.ts
@@ -14,6 +14,13 @@ describe('propsToString', () => {
       style: 'color: red; font-size: 12px',
     })).toStrictEqual(' class="a b" style="color: red; font-size: 12px"')
   })
+  it('skips invalid own attribute names', () => {
+    expect(propsToString({
+      'name': 'description',
+      '\'><script>alert(1)</script><meta data-x': 'x',
+      'content': 'safe',
+    })).toStrictEqual(' name="description" content="safe"')
+  })
   it('stringifies all properties correctly', async () => {
     expect(propsToString({
       'array': ['a', 1],


### PR DESCRIPTION
### 🔗 Linked issue

Related to #823. Backports the applicable v2 fixes from #774 and #814.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The v2 parser treated backslashes as HTML escapes, kept the last duplicate attribute, and rendered malformed attribute names. Safe links were also trusted after template parameter replacement, and fallback tag hashes changed with prop insertion order.

Keep the browser's first attribute value, reject invalid names before reading them, recheck safe links after resolution, and sort fallback hash keys. No public exports or options are added.