### PR TITLE
fix(v2): stabilize useScript lifecycle

### DIFF
--- a/packages/angular/src/composables.ts
+++ b/packages/angular/src/composables.ts
@@ -49,7 +49,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
 
   effect(() => {
     isMounted = true
-    mountCbs.forEach(i => i())
+    mountCbs.splice(0).forEach(i => i())
   })
 
   if (typeof options.trigger === 'undefined') {
@@ -65,33 +65,40 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
 
   // @ts-expect-error untyped
   const script = baseUseScript(head, input as BaseUseScriptInput, options)
+  const triggerAbortController = script._triggerAbortController
 
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    let i: number | null
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
-      }
+  const baseOnLoaded = script.onLoaded as unknown as (cb: any) => (() => void) | undefined
+  const baseOnError = script.onError as unknown as (cb: any) => (() => void) | undefined
+  const _registerCb = (register: () => (() => void) | undefined) => {
+    let disposed = false
+    let off: (() => void) | undefined
+    const run = () => {
+      if (disposed)
+        return
+      off = register() ?? (() => {})
+      sideEffects.push(off)
     }
-    mountCbs.push(() => {
-      if (!script._cbs[key]) {
-        cb(script.instance)
-        return () => {}
-      }
-      i = script._cbs[key].push(cb)
-      sideEffects.push(destroy)
-      return destroy
-    })
+    if (isMounted)
+      run()
+    else
+      mountCbs.push(run)
+    return () => {
+      if (disposed)
+        return
+      disposed = true
+      const idx = mountCbs.indexOf(run)
+      if (idx !== -1)
+        mountCbs.splice(idx, 1)
+      off?.()
+    }
   }
 
   destroyRef.onDestroy(() => {
     isMounted = false
-    script._triggerAbortController?.abort()
+    triggerAbortController?.abort()
     sideEffects.forEach(i => i())
   })
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb(() => baseOnLoaded(cb))
+  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb(() => baseOnError(cb))
   return script
 }

--- a/packages/angular/src/use-script.spec.ts
+++ b/packages/angular/src/use-script.spec.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { TestBed } from '@angular/core/testing'
+import { createHead } from 'unhead/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useScript } from './composables'
+
+describe('angular useScript lifecycle', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+  })
+
+  it('disposes callbacks by identity', async () => {
+    const head = createHead({ document })
+    const calls: string[] = []
+    let offFirst!: () => void
+    let offSecond!: () => void
+
+    TestBed.runInInjectionContext(() => {
+      const script = useScript({ src: '//ordered-callbacks.js' }, { trigger: 'manual', head })
+      offFirst = script.onLoaded(() => calls.push('first')) as unknown as () => void
+      offSecond = script.onLoaded(() => calls.push('second')) as unknown as () => void
+    })
+    TestBed.flushEffects()
+
+    offFirst()
+    offSecond()
+
+    const script = (head as any)._scripts['//ordered-callbacks.js']
+    script.status = 'loaded'
+    await head.hooks?.callHook('script:updated', { script })
+    await script._loadPromise
+
+    expect(calls).toEqual([])
+  })
+})

--- a/packages/solid-js/src/composables.ts
+++ b/packages/solid-js/src/composables.ts
@@ -28,12 +28,7 @@ function withSideEffects<T extends ActiveHeadEntry<any>>(input: any, options: an
   createEffect(() => {
     entry().patch(input)
   }, [input])
-  createEffect(() => {
-    return () => {
-      // unmount
-      entry().dispose()
-    }
-  }, [])
+  onCleanup(() => entry().dispose())
   return entry()
 }
 
@@ -59,7 +54,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   let isMounted = false
   onMount(() => {
     isMounted = true
-    mountCbs.forEach(i => i())
+    mountCbs.splice(0).forEach(i => i())
   })
 
   if (typeof options.trigger === 'undefined') {
@@ -74,34 +69,40 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   }
   // @ts-expect-error untyped
   const script = baseUseScript(head, input as BaseUseScriptInput, options)
+  const triggerAbortController = script._triggerAbortController
   // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
   const sideEffects: (() => void)[] = []
   onCleanup(() => {
     isMounted = false
-    script._triggerAbortController?.abort()
+    triggerAbortController?.abort()
     sideEffects.forEach(i => i())
   })
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    let i: number | null
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
-      }
+  const baseOnLoaded = script.onLoaded as unknown as (cb: any) => (() => void) | undefined
+  const baseOnError = script.onError as unknown as (cb: any) => (() => void) | undefined
+  const _registerCb = (register: () => (() => void) | undefined) => {
+    let disposed = false
+    let off: (() => void) | undefined
+    const run = () => {
+      if (disposed)
+        return
+      off = register() ?? (() => {})
+      sideEffects.push(off)
     }
-    mountCbs.push(() => {
-      if (!script._cbs[key]) {
-        cb(script.instance)
-        return () => {}
-      }
-      i = script._cbs[key].push(cb)
-      sideEffects.push(destroy)
-      return destroy
-    })
+    if (isMounted)
+      run()
+    else
+      mountCbs.push(run)
+    return () => {
+      if (disposed)
+        return
+      disposed = true
+      const idx = mountCbs.indexOf(run)
+      if (idx !== -1)
+        mountCbs.splice(idx, 1)
+      off?.()
+    }
   }
-  // if we have a scope we should make these callbacks reactive
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb(() => baseOnLoaded(cb))
+  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb(() => baseOnError(cb))
   return script
 }

--- a/packages/solid-js/test/composables.test.ts
+++ b/packages/solid-js/test/composables.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { createRoot } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+import { useHead, useHeadSafe, useSeoMeta } from '../src'
+import { createHead } from '../src/client'
+
+describe('solid head lifecycle', () => {
+  it('disposes head entries with their owner', () => {
+    const head = createHead()
+    let dispose!: () => void
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose
+      useHead({ title: 'Head' }, { head })
+      useHeadSafe({ meta: [{ name: 'safe', content: 'value' }] }, { head })
+      useSeoMeta({ description: 'description' }, { head })
+    })
+
+    expect(head.entries.size).toBe(3)
+    dispose()
+    expect(head.entries.size).toBe(0)
+  })
+})

--- a/packages/solid-js/vitest.config.ts
+++ b/packages/solid-js/vitest.config.ts
@@ -1,10 +1,8 @@
-import solid from 'vite-plugin-solid'
 /// <reference types="vitest" />
 /// <reference types="vitest/globals" />
 import { defineProject } from 'vitest/config'
 
 export default defineProject({
-  plugins: [solid()],
   resolve: {
     conditions: ['development', 'browser'],
   },

--- a/packages/svelte/src/composables.ts
+++ b/packages/svelte/src/composables.ts
@@ -52,30 +52,21 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   }
   // @ts-expect-error untyped
   const script = baseUseScript(head, input as BaseUseScriptInput, options)
+  const triggerAbortController = script._triggerAbortController
   // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
   const sideEffects: (() => void)[] = []
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    if (!script._cbs[key]) {
-      cb(script.instance)
-      return () => {}
-    }
-    let i: number | null = script._cbs[key].push(cb)
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
-      }
-    }
-    sideEffects.push(destroy)
-    return destroy
+  const bind = (base: (cb: any) => (() => void) | undefined) => (cb: any) => {
+    const off = base(cb) ?? (() => {})
+    sideEffects.push(off)
+    return off
   }
-  // if we have a scope we should make these callbacks reactive
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  const baseOnLoaded = script.onLoaded as unknown as (cb: any) => (() => void) | undefined
+  const baseOnError = script.onError as unknown as (cb: any) => (() => void) | undefined
+  script.onLoaded = bind(baseOnLoaded)
+  script.onError = bind(baseOnError)
   onDestroy(() => {
     // stop any trigger promises
-    script._triggerAbortController?.abort()
+    triggerAbortController?.abort()
     sideEffects.forEach(i => i())
   })
   return script

--- a/packages/unhead/src/scripts/proxy.ts
+++ b/packages/unhead/src/scripts/proxy.ts
@@ -1,55 +1,14 @@
 import type { AsVoidFunctions, RecordingEntry } from './types'
 
-export function createNoopedRecordingProxy<T extends Record<string, any>>(instance: T = {} as T): { proxy: AsVoidFunctions<T>, stack: RecordingEntry[][] } {
-  const stack: RecordingEntry[][] = []
+function NOOP() {}
 
-  let stackIdx = -1
-  const handler = (reuseStack = false) => ({
-    get(_, prop, receiver) {
-      if (!reuseStack) {
-        const v = Reflect.get(_, prop, receiver)
-        if (typeof v !== 'undefined') {
-          return v
-        }
-        stackIdx++ // root get triggers a new stack
-        stack[stackIdx] = []
-      }
-      stack[stackIdx].push({ type: 'get', key: prop })
-      // @ts-expect-error untyped
-      return new Proxy(() => {}, handler(true))
-    },
-    apply(_, __, args) {
-      stack[stackIdx].push({ type: 'apply', key: '', args })
-      return undefined
-    },
-  } as ProxyHandler<T>)
-
-  return {
-    proxy: new Proxy(instance || {}, handler()),
-    stack,
-  }
+interface ScriptProxy<T extends Record<symbol | string, any>> {
+  proxy: AsVoidFunctions<T>
+  stack: RecordingEntry[][]
+  resolve: (instance: T) => void
 }
 
-export function createForwardingProxy<T extends Record<string, any>>(target: T): AsVoidFunctions<T> {
-  const handler: ProxyHandler<T> = {
-    get(_, prop, receiver) {
-      const v = Reflect.get(_, prop, receiver)
-      if (typeof v === 'object') {
-        return new Proxy(v, handler)
-      }
-      return v
-    },
-    apply(_, __, args) {
-      // does not return the apply output for consistency
-      // @ts-expect-error untyped
-      Reflect.apply(_, __, args)
-      return undefined
-    },
-  }
-  return new Proxy(target, handler) as AsVoidFunctions<T>
-}
-
-export function replayProxyRecordings<T extends object>(target: T, stack: RecordingEntry[][]) {
+function replayRecordings<T extends object>(target: T, stack: RecordingEntry[][]) {
   stack.forEach((recordings) => {
     let context: any = target
     let prevContext: any = target
@@ -59,9 +18,77 @@ export function replayProxyRecordings<T extends object>(target: T, stack: Record
         context = context[key]
       }
       else if (type === 'apply') {
-        // @ts-expect-error untyped
-        context = (context as () => any).call(prevContext, ...args)
+        context = Reflect.apply(context as () => any, prevContext, args)
       }
     })
   })
+}
+
+function walk(root: any, path: PropertyKey[]) {
+  let owner: any
+  let value = root
+  for (const key of path) {
+    if (value == null)
+      return { owner: undefined, value: undefined }
+    owner = value
+    value = value[key]
+  }
+  return { owner, value }
+}
+
+export function createScriptProxy<T extends Record<string, any>>(initial: T = {} as T): ScriptProxy<T> {
+  const stack: RecordingEntry[][] = []
+  let instance: T | undefined
+  let stackIdx = -1
+
+  function node(path: PropertyKey[]): any {
+    const children = new Map<PropertyKey, any>()
+    return new Proxy(NOOP, {
+      get(_, prop) {
+        if (instance) {
+          const { value } = walk(instance, path)
+          const result = value == null ? undefined : Reflect.get(value, prop, value)
+          if (typeof result !== 'function')
+            return result
+        }
+        else if (!path.length) {
+          const result = Reflect.get(initial, prop)
+          if (typeof result !== 'undefined')
+            return result
+          stackIdx++
+          stack[stackIdx] = [{ type: 'get', key: prop }]
+        }
+        else {
+          stack[stackIdx].push({ type: 'get', key: prop })
+        }
+        let child = children.get(prop)
+        if (!child) {
+          child = node([...path, prop])
+          children.set(prop, child)
+        }
+        return child
+      },
+      apply(_, __, args) {
+        if (instance) {
+          const { owner, value } = walk(instance, path)
+          if (typeof value === 'function')
+            Reflect.apply(value, owner, args)
+        }
+        else {
+          stack[stackIdx].push({ type: 'apply', key: '', args })
+        }
+        return undefined
+      },
+    })
+  }
+
+  return {
+    proxy: node([]) as AsVoidFunctions<T>,
+    stack,
+    resolve(api: T) {
+      instance = api
+      replayRecordings(api, stack)
+      stack.length = 0
+    },
+  }
 }

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -15,7 +15,7 @@ import type {
   WarmupStrategy,
 } from './types'
 import { ScriptNetworkEvents } from '../utils'
-import { createForwardingProxy, createNoopedRecordingProxy, replayProxyRecordings } from './proxy'
+import { createScriptProxy } from './proxy'
 
 /**
  * @deprecated compute key manually
@@ -35,7 +35,10 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   const input: UseScriptResolvedInput = typeof _input === 'string' ? { src: _input } : _input
   const options = _options || {}
   const id = resolveScriptKey(input)
-  const prevScript = head._scripts?.[id] as undefined | UseScriptContext<UseFunctionType<UseScriptOptions<T>, T>>
+  const scripts = head._scripts || (head._scripts = Object.create(null))
+  const prevScript = Object.prototype.hasOwnProperty.call(scripts, id)
+    ? scripts[id] as undefined | UseScriptContext<UseFunctionType<UseScriptOptions<T>, T>>
+    : undefined
   if (prevScript) {
     prevScript.setupTriggerHandler(options.trigger)
     return prevScript
@@ -52,6 +55,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
       const k = fn as keyof HttpEventAttributes
       const _fn = typeof input[k] === 'function' ? input[k].bind(options.eventContext) : null
       input[k] = (e: Event) => {
+        // eslint-disable-next-line ts/no-use-before-define
+        if (script.status === 'removed')
+          return
         syncStatus(fn === 'onload' ? 'loaded' : fn === 'onerror' ? 'error' : 'loading')
         _fn?.(e)
       }
@@ -64,31 +70,48 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     if (head.ssr) {
       return
     }
+    let uniqueKey: string | undefined
     if (options?.key) {
-      const key = `${options?.key}:${options.key}`
-      if (_uniqueCbs.has(key)) {
+      uniqueKey = `${key}:${options.key}`
+      if (_uniqueCbs.has(uniqueKey)) {
         return
       }
-      _uniqueCbs.add(key)
+      _uniqueCbs.add(uniqueKey)
     }
     if (_cbs[key]) {
-      const i: number = _cbs[key].push(cb)
-      return () => _cbs[key]?.splice(i - 1, 1)
+      _cbs[key].push(cb)
+      return () => {
+        const idx = _cbs[key]?.indexOf(cb) ?? -1
+        if (idx !== -1)
+          _cbs[key]?.splice(idx, 1)
+        if (uniqueKey)
+          _uniqueCbs.delete(uniqueKey)
+      }
     }
-    // the event has already happened, run immediately
     // eslint-disable-next-line ts/no-use-before-define
-    cb(script.instance)
-    return () => {}
+    if (key === 'loaded' && script.status === 'loaded')
+      // eslint-disable-next-line ts/no-use-before-define
+      cb(script.instance)
+    // eslint-disable-next-line ts/no-use-before-define
+    else if (key === 'error' && script.status === 'error')
+      cb()
+    return () => {
+      if (uniqueKey)
+        _uniqueCbs.delete(uniqueKey)
+    }
   }
   const loadPromise = new Promise<T | false>((resolve) => {
     // promise never resolves
     if (head.ssr)
       return
-    const emit = (api: T) => requestAnimationFrame(() => resolve(api))
-    const _ = head.hooks.hook('script:updated', ({ script }) => {
+    const emit = (api: T) => queueMicrotask(() => resolve(api))
+    const _ = head.hooks.hook('script:updated', ({ script: updatedScript }) => {
+      // eslint-disable-next-line ts/no-use-before-define
+      if (updatedScript !== script)
+        return
       // vue augmentation... not ideal
-      const status = script.status
-      if (script.id === id && (status === 'loaded' || status === 'error')) {
+      const status = updatedScript.status
+      if (status === 'loaded' || status === 'error' || status === 'removed') {
         if (status === 'loaded') {
           if (typeof options.use === 'function') {
             const api = options.use()
@@ -103,6 +126,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         else if (status === 'error') {
           resolve(false) // failed to load
         }
+        else if (status === 'removed') {
+          resolve(false)
+        }
         _()
       }
     })
@@ -116,19 +142,22 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     status: 'awaitingLoad',
 
     remove() {
+      const hadEntry = !!script.entry
       // cancel all pending triggers
       script._triggerAbortControllers?.forEach(ac => ac.abort())
       script._triggerAbortControllers?.clear()
       script._triggerPromises = [] // clear any pending promises
       script._warmupEl?.dispose()
+      script._warmupEl = undefined
       if (script.entry) {
         script.entry.dispose()
         script.entry = undefined
-        syncStatus('removed')
-        delete head._scripts?.[id]
-        return true
       }
-      return false
+      if (scripts[id] === script)
+        delete scripts[id]
+      if (script.status !== 'removed')
+        syncStatus('removed')
+      return hadEntry
     },
     warmup(rel: WarmupStrategy) {
       const { src } = input
@@ -155,6 +184,8 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
       return script._warmupEl
     },
     load(cb?: () => void | Promise<void>) {
+      if (script.status === 'removed')
+        return loadPromise
       // cancel all pending triggers as we've started loading
       script._triggerAbortControllers?.forEach(ac => ac.abort())
       script._triggerAbortControllers?.clear()
@@ -211,7 +242,7 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         // store the latest controller for external access
         script._triggerAbortController = abortController
         script._triggerPromises = script._triggerPromises || []
-        const idx = script._triggerPromises.push(Promise.race([
+        const triggerPromise: Promise<void> = Promise.race([
           trigger.then(v => typeof v === 'undefined' || v ? script.load : undefined),
           abortPromise,
         ])
@@ -221,9 +252,13 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
             res?.()
           })
           .finally(() => {
+            script._triggerAbortControllers?.delete(abortController)
             // remove the promise from the list
-            script._triggerPromises?.splice(idx, 1)
-          }))
+            const idx = script._triggerPromises?.indexOf(triggerPromise) ?? -1
+            if (idx !== -1)
+              script._triggerPromises?.splice(idx, 1)
+          })
+        script._triggerPromises.push(triggerPromise)
       }
       else if (typeof trigger === 'function') {
         trigger(script.load)
@@ -240,7 +275,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
         _cbs.loaded = null
       }
       else {
-        _cbs.error?.forEach(cb => cb())
+        if (script.status === 'error')
+          _cbs.error?.forEach(cb => cb())
+        _cbs.loaded = null
         _cbs.error = null
       }
     })
@@ -248,13 +285,9 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
 
   script.setupTriggerHandler(options.trigger)
   if (options.use) {
-    const { proxy, stack } = createNoopedRecordingProxy<T>(head.ssr ? {} as T : options.use() || {} as T)
+    const { proxy, resolve } = createScriptProxy<T>(head.ssr ? {} as T : options.use() || {} as T)
     script.proxy = proxy
-    script.onLoaded((instance) => {
-      replayProxyRecordings(instance, stack)
-      // just forward everything with the same behavior
-      script.proxy = createForwardingProxy(instance)
-    })
+    script.onLoaded(resolve)
   }
   // need to make sure it's not already registered
   if (!options.warmupStrategy && (typeof options.trigger === 'undefined' || options.trigger === 'client')) {
@@ -263,6 +296,6 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
   if (options.warmupStrategy) {
     script.warmup(options.warmupStrategy)
   }
-  head._scripts = Object.assign(head._scripts || {}, { [id]: script })
+  scripts[id] = script
   return script
 }

--- a/packages/unhead/test/unit/scripts/dom.test.ts
+++ b/packages/unhead/test/unit/scripts/dom.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { useScript } from '../../../src/composables'
 import { useDelayedSerializedDom, useDOMHead } from '../../../test/util'
 
@@ -44,11 +44,12 @@ describe('dom useScript', () => {
 
     expect(instance.proxy.test('hello-world')).toEqual('hello-world')
   })
-  it('remove & re-add', async () => {
+  it('keeps removed handles terminal', async () => {
     const head = useDOMHead()
+    const src = 'https://cdn.example.com/script.js'
 
     const instance = useScript<{ test: (foo: string) => void }>(head, {
-      src: 'https://cdn.example.com/script.js',
+      src,
     })
 
     let dom = await useDelayedSerializedDom()
@@ -58,14 +59,17 @@ describe('dom useScript', () => {
     await new Promise(r => setTimeout(r, 100))
     dom = await useDelayedSerializedDom()
     expect(dom.split('\n').filter(l => l.trim().startsWith('<script'))).toMatchInlineSnapshot(`[]`)
-    // reload
-    instance.load()
+    await expect(instance.load()).resolves.toBe(false)
+    expect(instance.entry).toBeUndefined()
+    expect(head._scripts?.[src]).toBeUndefined()
+
+    const nextInstance = useScript<{ test: (foo: string) => void }>(head, { src })
+    expect(nextInstance).not.toBe(instance)
+    await instance.load()
+    expect(instance.entry).toBeUndefined()
+    expect(head._scripts?.[src]).toBe(nextInstance)
     await new Promise(r => setTimeout(r, 100))
     dom = await useDelayedSerializedDom()
-    expect(dom.split('\n').filter(l => l.trim().startsWith('<script'))).toMatchInlineSnapshot(`
-      [
-        "<script defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" data-onload="" data-onerror=""></script></head>",
-      ]
-    `)
+    expect(dom).toContain('<script defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js"')
   })
 })

--- a/packages/unhead/test/unit/scripts/events.test.ts
+++ b/packages/unhead/test/unit/scripts/events.test.ts
@@ -50,4 +50,174 @@ describe('useScript events', () => {
       ]
     `)
   })
+
+  it('fires onLoaded when requestAnimationFrame is suspended', async () => {
+    const originalRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = (() => 0) as any
+    const onLoaded = vi.fn()
+
+    try {
+      const head = createHead()
+      const instance = useScript(head, '/hidden-tab.js', {
+        trigger: 'server',
+      })
+      instance.onLoaded(onLoaded)
+      instance.status = 'loaded'
+      await head.hooks.callHook('script:updated', { script: instance })
+      await Promise.resolve()
+
+      expect(onLoaded).toHaveBeenCalledOnce()
+    }
+    finally {
+      globalThis.requestAnimationFrame = originalRaf
+    }
+  })
+
+  it('releases keyed callback dedupe state when disposed', async () => {
+    const head = createHead()
+    const instance = useScript(head, '/keyed-callback.js', {
+      trigger: 'server',
+    })
+    const calls: string[] = []
+
+    const offFirst = instance.onLoaded(() => {
+      calls.push('first')
+    }, { key: 'once' }) as unknown as (() => void)
+    offFirst()
+    instance.onLoaded(() => {
+      calls.push('second')
+    }, { key: 'once' })
+
+    instance.status = 'loaded'
+    await head.hooks.callHook('script:updated', { script: instance })
+    await instance._loadPromise
+
+    expect(calls).toEqual(['second'])
+  })
+
+  it('disposes callbacks by identity', () => {
+    const head = createHead()
+    const instance = useScript(head, '/ordered-callbacks.js', {
+      trigger: 'manual',
+    })
+
+    const offFirst = instance.onLoaded(() => {}) as unknown as (() => void)
+    const offSecond = instance.onLoaded(() => {}) as unknown as (() => void)
+    offFirst()
+    offSecond()
+
+    expect(instance._cbs.loaded).toHaveLength(0)
+  })
+
+  it('cleans trigger promises by identity', async () => {
+    const head = createHead()
+    let resolveFirst!: (value: boolean) => void
+    let resolveSecond!: (value: boolean) => void
+    const firstTrigger = new Promise<boolean>(resolve => resolveFirst = resolve)
+    const secondTrigger = new Promise<boolean>(resolve => resolveSecond = resolve)
+
+    const instance = useScript(head, '/ordered-triggers.js', { trigger: firstTrigger })
+    useScript(head, '/ordered-triggers.js', { trigger: secondTrigger })
+
+    const firstPromise = instance._triggerPromises![0]
+    resolveFirst(false)
+    await firstPromise
+    expect(instance._triggerPromises).toHaveLength(1)
+
+    const secondPromise = instance._triggerPromises![0]
+    resolveSecond(false)
+    await secondPromise
+    expect(instance._triggerPromises).toHaveLength(0)
+  })
+
+  it('keeps removed scripts terminal', async () => {
+    const head = createHead()
+    const instance = useScript(head, '/removed-script.js', {
+      trigger: 'manual',
+    })
+
+    expect(instance.remove()).toBe(false)
+    await expect(instance._loadPromise).resolves.toBe(false)
+    await expect(instance.load()).resolves.toBe(false)
+
+    expect(instance.status).toBe('removed')
+    expect(instance.entry).toBeUndefined()
+    expect(head._scripts?.[instance.id]).toBeUndefined()
+  })
+
+  it('does not replay callbacks after removal', async () => {
+    const head = createHead()
+    const instance = useScript(head, '/removed-callback.js', {
+      trigger: 'manual',
+    })
+    instance.remove()
+    await instance._loadPromise
+
+    const onLoaded = vi.fn()
+    const onError = vi.fn()
+    instance.onLoaded(onLoaded)
+    instance.onError(onError)
+    await Promise.resolve()
+
+    expect(onLoaded).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('does not let a stale handle evict a replacement', async () => {
+    const head = createHead()
+    const first = useScript(head, '/replacement.js', { trigger: 'manual' })
+    first.remove()
+    await first._loadPromise
+
+    const second = useScript(head, '/replacement.js', { trigger: 'manual' })
+    first.remove()
+
+    expect(head._scripts?.[second.id]).toBe(second)
+  })
+
+  it('stores special script ids as own registry entries', () => {
+    const head = createHead()
+
+    for (const key of ['constructor', 'toString', '__proto__']) {
+      const instance = useScript(head, { key, src: `/${key}.js` }, { trigger: 'manual' })
+      expect(Object.prototype.hasOwnProperty.call(head._scripts, key)).toBe(true)
+      expect(head._scripts?.[key]).toBe(instance)
+    }
+  })
+
+  it('ignores lifecycle updates from removed same-id scripts', async () => {
+    const head = createHead()
+    const first = useScript(head, '/same-id.js', { trigger: 'manual' })
+    first.remove()
+    await first._loadPromise
+
+    const api = { ready: true }
+    const second = useScript(head, '/same-id.js', {
+      trigger: 'manual',
+      use: () => api,
+    })
+    const onLoaded = vi.fn()
+    second.onLoaded(onLoaded)
+    second.load()
+
+    first.status = 'loaded'
+    await head.hooks.callHook('script:updated', { script: first })
+    await Promise.resolve()
+
+    expect(second.status).toBe('loading')
+    expect(onLoaded).not.toHaveBeenCalled()
+  })
+
+  it('drops settled trigger abort controllers', async () => {
+    const head = createHead()
+    let resolveTrigger!: (value: boolean) => void
+    const trigger = new Promise<boolean>(resolve => resolveTrigger = resolve)
+    const instance = useScript(head, '/settled-trigger.js', { trigger })
+
+    const triggerPromise = instance._triggerPromises![0]
+    resolveTrigger(false)
+    await triggerPromise
+
+    expect(instance._triggerAbortControllers?.size).toBe(0)
+  })
 })

--- a/packages/unhead/test/unit/scripts/proxy.test.ts
+++ b/packages/unhead/test/unit/scripts/proxy.test.ts
@@ -3,7 +3,7 @@ import type { AsVoidFunctions } from '../../../src/scripts/types'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { createHead } from '../../../src/client'
 import { useScript } from '../../../src/composables'
-import { createForwardingProxy, createNoopedRecordingProxy, replayProxyRecordings } from '../../../src/scripts/proxy'
+import { createScriptProxy } from '../../../src/scripts/proxy'
 import { createSpyProxy } from '../../../src/scripts/utils'
 
 interface Api {
@@ -31,7 +31,7 @@ interface GoogleAnalytics {
 
 describe('proxy chain', () => {
   it('augments types', () => {
-    const proxy = createNoopedRecordingProxy<Api>()
+    const proxy = createScriptProxy<Api>()
     expectTypeOf(proxy.proxy._paq).toBeArray()
     expectTypeOf(proxy.proxy.doSomething).toBeFunction()
     expectTypeOf(proxy.proxy.doSomething).returns.toBeVoid()
@@ -40,7 +40,7 @@ describe('proxy chain', () => {
   })
   it('e2e', async () => {
     // do recording
-    const { proxy, stack } = createNoopedRecordingProxy<Api>()
+    const { proxy, stack, resolve } = createScriptProxy<Api>()
     const script = { proxy, instance: null }
     script.proxy._paq.push(['test'])
     script.proxy.say('hello world')
@@ -62,14 +62,12 @@ describe('proxy chain', () => {
       say: w.say,
     }
     const log = console.log
-    // replay recording
+    // replay recording and switch the same proxy to forwarding
     const consoleMock = vi.spyOn(console, 'log').mockImplementation((...args) => {
       log('mocked', ...args)
     })
     // @ts-expect-error untyped
-    replayProxyRecordings(script.instance, stack)
-    // @ts-expect-error untyped
-    script.proxy = createForwardingProxy(script.instance)
+    resolve(script.instance)
     expect(consoleMock).toHaveBeenCalledWith('hello world')
     script.proxy.say('proxy updated!')
     expect(consoleMock).toHaveBeenCalledWith('proxy updated!')
@@ -145,6 +143,64 @@ describe('proxy chain', () => {
     expectTypeOf(instance.proxy.greet).toBeFunction()
     instance.proxy.greet('hello-world')
     expect(consoleMock).toHaveBeenCalledWith('hello-world')
+  })
+
+  it('keeps proxy references working after load', async () => {
+    const head = createHead()
+    const greet = vi.fn()
+    let loaded = false
+    const instance = useScript(head, '/stable-proxy.js', {
+      trigger: 'manual',
+      use: () => loaded ? { greet } : undefined,
+    })
+    const heldProxy = instance.proxy
+    const heldMethod = instance.proxy.greet
+
+    heldProxy.greet('before')
+    loaded = true
+    instance.load()
+    instance.status = 'loaded'
+    await head.hooks.callHook('script:updated', { script: instance })
+    await instance._loadPromise
+
+    heldProxy.greet('after-object')
+    heldMethod('after-method')
+    expect(greet).toHaveBeenCalledWith('before')
+    expect(greet).toHaveBeenCalledWith('after-object')
+    expect(greet).toHaveBeenCalledWith('after-method')
+  })
+
+  it('applies proxied methods against their raw owner', async () => {
+    const head = createHead()
+    const branded = new WeakSet<object>()
+    const canvas = {
+      readWidth() {
+        if (!branded.has(this))
+          throw new TypeError('Illegal invocation')
+        return 120
+      },
+    }
+    branded.add(canvas)
+    const api = {
+      canvas,
+      readWidth() {
+        return this.canvas.readWidth()
+      },
+    }
+    let loaded = false
+    const instance = useScript(head, '/raw-receiver.js', {
+      trigger: 'manual',
+      use: () => loaded ? api : undefined,
+    })
+
+    loaded = true
+    instance.load()
+    instance.status = 'loaded'
+    await head.hooks.callHook('script:updated', { script: instance })
+    await instance._loadPromise
+
+    expect(() => instance.proxy.readWidth()).not.toThrow()
+    expect(instance.proxy.canvas).toBe(canvas)
   })
 })
 

--- a/packages/vue/src/scripts/useScript.ts
+++ b/packages/vue/src/scripts/useScript.ts
@@ -42,25 +42,15 @@ function registerVueScopeHandlers<T extends Record<symbol | string, any> = Recor
   if (!scope) {
     return
   }
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    if (!script._cbs[key]) {
-      cb(script.instance)
-      return () => {}
-    }
-    let i: number | null = script._cbs[key].push(cb)
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
-      }
-    }
-    onScopeDispose(destroy)
-    return destroy
+  const bind = (base: (cb: any) => (() => void) | undefined) => (cb: any) => {
+    const off = base(cb) ?? (() => {})
+    onScopeDispose(off)
+    return off
   }
-  // if we have a scope we should make these callbacks reactive
-  script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)
-  script.onError = (cb: (err?: Error) => void | Promise<void>) => _registerCb('error', cb)
+  const baseOnLoaded = script.onLoaded as unknown as (cb: any) => (() => void) | undefined
+  const baseOnError = script.onError as unknown as (cb: any) => (() => void) | undefined
+  script.onLoaded = bind(baseOnLoaded)
+  script.onError = bind(baseOnError)
   // capture the controller at registration time so this scope only aborts
   // the controller it was associated with, not a newer one created by a later scope
   const triggerAbortController = script._triggerAbortController

--- a/packages/vue/test/unit/useScript.test.ts
+++ b/packages/vue/test/unit/useScript.test.ts
@@ -203,6 +203,39 @@ describe('vue e2e scripts', () => {
     script.remove()
   })
 
+  it('disposes callbacks by identity', async () => {
+    const dom = useDom()
+    const head = createHead({ document: dom.window.document })
+    const calls: string[] = []
+    let offFirst!: () => void
+    let offSecond!: () => void
+    const el = dom.window.document.createElement('div')
+    const app = createApp({
+      setup() {
+        const script = useScript({ src: '//ordered-callbacks.js' }, { trigger: 'manual', head })
+        offFirst = script.onLoaded(() => {
+          calls.push('first')
+        }) as unknown as () => void
+        offSecond = script.onLoaded(() => {
+          calls.push('second')
+        }) as unknown as () => void
+        return () => h('div')
+      },
+    })
+    app.mount(el)
+
+    offFirst()
+    offSecond()
+
+    const script = (head as any)._scripts['//ordered-callbacks.js']
+    script.status = 'loaded'
+    await head.hooks?.callHook('script:updated', { script })
+    await script._loadPromise
+
+    expect(calls).toEqual([])
+    app.unmount()
+  })
+
   it('setupTriggerHandler race condition: old scope disposal should not abort new scope trigger', async () => {
     const dom = useDom()
     const head = createHead({


### PR DESCRIPTION
## Summary

Backports the v2-safe script fixes from #772, #807, #808, #867, and #925.

- resolve loaded callbacks through a microtask so hidden tabs do not stall
- dispose callbacks and trigger promises by identity in core, Vue, Svelte, Solid, and Angular
- keep removed handles terminal, ignore stale same-ID events, and support special registry keys
- keep one proxy reference across loading and call vendor methods with their real receiver
- fix Solid head entry cleanup on owner disposal

No public exports, options, or script APIs are added.

## Validation

- `pnpm vitest run --config packages/unhead/vitest.config.ts --dir packages/unhead/test --exclude '.claude/**'`, 435 passed
- Vue suite, 69 passed
- Svelte suite, 14 passed
- Angular lifecycle regression, passed
- Solid lifecycle regression, passed
- scoped ESLint, passed
- `pnpm typecheck`, passed
- `pnpm build`, passed
