### PR TITLE
fix(v2): harden framework lifecycles

### DIFF
--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import type { CreateClientHeadOptions, Unhead } from 'unhead/types'
-import { createElement } from 'react'
+import { createElement, useRef } from 'react'
 import { createHead as _createHead, createDebouncedFn, renderDOMHead } from 'unhead/client'
 import { UnheadContext } from './context'
 
@@ -34,10 +34,14 @@ interface UniversalUnheadProviderProps {
 export type UnheadProviderProps = LegacyUnheadProviderProps | UniversalUnheadProviderProps
 
 export function UnheadProvider({ children, value, head }: UnheadProviderProps) {
+  const headRef = useRef<Unhead | null>(null)
   if (value !== undefined && head !== undefined)
     throw new TypeError('UnheadProvider received both value and head props')
 
-  return createElement(UnheadContext.Provider, { value: value ?? head ?? createHead() }, children)
+  const suppliedHead = value ?? head
+  if (suppliedHead === undefined && headRef.current === null)
+    headRef.current = createHead()
+  return createElement(UnheadContext.Provider, { value: suppliedHead ?? headRef.current }, children)
 }
 
 export type {

--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -87,7 +87,7 @@ const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
       const data = normalizeReactPropAliases(props)
       normalizeRawContent(tagName, data)
 
-      if (TagsWithInnerContent.has(tagName) && data.children) {
+      if (TagsWithInnerContent.has(tagName) && data.children != null) {
         const contentKey = tagName === 'script' ? 'innerHTML' : 'textContent'
         data[contentKey] = Array.isArray(data.children)
           ? data.children.map(String).join('')
@@ -112,18 +112,18 @@ const Head: React.FC<HeadProps> = ({ children, titleTemplate }) => {
     return input
   }, [processedElements, titleTemplate])
 
-  const headRef = useRef<ActiveHeadEntry<any> | null>(
-    head.push(getHeadChanges()),
-  )
+  const headRef = useRef<ActiveHeadEntry<any> | null>(null)
+
+  if (head.ssr && !headRef.current)
+    headRef.current = head.push(getHeadChanges())
 
   useEffect(() => {
+    headRef.current = head.push(getHeadChanges())
     return () => {
-      if (headRef.current?.dispose) {
-        headRef.current.dispose()
-      }
+      headRef.current?.dispose()
       headRef.current = null
     }
-  }, [])
+  }, [head])
 
   useEffect(() => {
     headRef.current?.patch(getHeadChanges())

--- a/packages/react/src/composables.ts
+++ b/packages/react/src/composables.ts
@@ -13,6 +13,16 @@ import { useContext, useEffect, useRef } from 'react'
 import { useHead as baseHead, useHeadSafe as baseHeadSafe, useSeoMeta as baseSeoMeta, useScript as baseUseScript } from 'unhead'
 import { UnheadContext } from './context'
 
+interface ScriptCallbackRecord {
+  active: boolean
+  handler: any
+  key: 'loaded' | 'error'
+  registered: boolean
+  renderScoped: boolean
+  renderId: number
+  script: UseScriptReturn<any>
+}
+
 export function useUnhead(): Unhead {
   // fallback to react context
   const instance = useContext<Unhead | null>(UnheadContext)
@@ -83,57 +93,106 @@ export function useSeoMeta(input: UseSeoMetaInput = {}, options: HeadEntryOption
 export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(_input: UseScriptInput, _options?: UseScriptOptions<T>): UseScriptReturn<T> {
   const input = (typeof _input === 'string' ? { src: _input } : _input) as UseScriptInput
   const options = _options || {} as UseScriptOptions<T>
-  const head = options?.head || useUnhead()
-  options.head = head
+  const head = options.head || useUnhead()
+  const trigger = options.trigger
+  const resolvedOptions = {
+    ...options,
+    head,
+    trigger: head.ssr && trigger === 'server' ? 'server' : 'manual',
+  } as UseScriptOptions<T>
 
-  const mountCbs: (() => void)[] = []
-  let isMounted = false
-  useEffect(() => {
-    isMounted = true
-    mountCbs.forEach(i => i())
-    return () => {
-      isMounted = false
-    }
-  }, [])
+  const callbackRecords = useRef<ScriptCallbackRecord[]>([])
+  const isMounted = useRef(false)
+  const renderId = useRef(0)
+  const committedRenderId = useRef(0)
+  const currentRenderId = ++renderId.current
 
-  if (typeof options.trigger === 'undefined') {
-    options.trigger = (load) => {
-      if (isMounted) {
-        load()
-      }
-      else {
-        mountCbs.push(load)
-      }
-    }
-  }
   // @ts-expect-error untyped
-  const script = baseUseScript(head, input as BaseUseScriptInput, options)
-  // Note: we don't remove scripts on unmount as it's not a common use case and reloading the script may be expensive
-  const sideEffects: (() => void)[] = []
+  const script = baseUseScript(head, input as BaseUseScriptInput, resolvedOptions)
+
   useEffect(() => {
+    isMounted.current = true
+    committedRenderId.current = currentRenderId
+    reconcileScriptCallbacks(currentRenderId)
+    callbackRecords.current.forEach(registerScriptCallback)
     return () => {
-      script._triggerAbortController?.abort()
-      sideEffects.forEach(i => i())
+      isMounted.current = false
+      callbackRecords.current.forEach(unregisterScriptCallback)
     }
-  }, [])
-  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
-    let i: number | null
-    const destroy = () => {
-      // avoid removing the wrong callback
-      if (i) {
-        script._cbs[key]?.splice(i - 1, 1)
-        i = null
+  })
+
+  useEffect(() => {
+    const existingControllers = new Set(script._triggerAbortControllers)
+    script.setupTriggerHandler(trigger)
+    const triggerAbortControllers = script._triggerAbortControllers
+      ? [...script._triggerAbortControllers].filter(controller => !existingControllers.has(controller))
+      : []
+
+    return () => triggerAbortControllers.forEach(controller => controller.abort())
+  }, [script, trigger])
+
+  function reconcileScriptCallbacks(activeRenderId: number) {
+    callbackRecords.current.forEach((record) => {
+      if (record.renderScoped && record.renderId !== activeRenderId) {
+        record.active = false
+        unregisterScriptCallback(record)
       }
-    }
-    mountCbs.push(() => {
-      if (!script._cbs[key]) {
-        cb(script.instance)
-        return () => {}
-      }
-      i = script._cbs[key].push(cb)
-      sideEffects.push(destroy)
-      return destroy
     })
+    callbackRecords.current = callbackRecords.current.filter(record => record.active && (!record.renderScoped || record.renderId === activeRenderId))
+  }
+
+  function registerScriptCallback(record: ScriptCallbackRecord) {
+    if (!record.active || record.registered)
+      return
+    const cbs = record.script._cbs[record.key]
+    if (!cbs) {
+      record.handler(record.script.instance)
+      return
+    }
+    cbs.push(record.handler)
+    record.registered = true
+  }
+
+  function unregisterScriptCallback(record: ScriptCallbackRecord) {
+    if (!record.registered)
+      return
+    const idx = record.script._cbs[record.key]?.indexOf(record.handler) ?? -1
+    if (idx !== -1)
+      record.script._cbs[record.key]?.splice(idx, 1)
+    record.registered = false
+  }
+
+  const _registerCb = (key: 'loaded' | 'error', cb: any) => {
+    const renderScoped = !(isMounted.current && committedRenderId.current === currentRenderId)
+    const record: ScriptCallbackRecord = {
+      active: true,
+      handler: (...args: any[]) => {
+        if (!record.active)
+          return
+        record.active = false
+        record.registered = false
+        cb(...args)
+      },
+      key,
+      registered: false,
+      renderScoped,
+      renderId: currentRenderId,
+      script,
+    }
+    callbackRecords.current.push(record)
+    if (isMounted.current && committedRenderId.current === currentRenderId)
+      registerScriptCallback(record)
+    return destroy
+
+    function destroy() {
+      if (!record.active)
+        return
+      record.active = false
+      unregisterScriptCallback(record)
+      const idx = callbackRecords.current.indexOf(record)
+      if (idx !== -1)
+        callbackRecords.current.splice(idx, 1)
+    }
   }
   // if we have a scope we should make these callbacks reactive
   script.onLoaded = (cb: (instance: T) => void | Promise<void>) => _registerCb('loaded', cb)

--- a/packages/react/test/SimpleHeadSSR.test.tsx
+++ b/packages/react/test/SimpleHeadSSR.test.tsx
@@ -163,4 +163,25 @@ describe('simpleHead component in ssr', () => {
     expect(headTags).toContain('nomodule')
     expect(headTags).toContain('referrerpolicy="origin"')
   })
+
+  it('preserves numeric zero children', async () => {
+    const head = createHead({ disableDefaults: true })
+
+    renderToString(
+      <ServerUnheadProvider value={head}>
+        <Head>
+          <title>{0}</title>
+          <script type="text/plain">{0}</script>
+          <style>{0}</style>
+          <noscript>{0}</noscript>
+        </Head>
+      </ServerUnheadProvider>,
+    )
+
+    const { headTags } = await renderSSRHead(head)
+    expect(headTags).toContain('<title>0</title>')
+    expect(headTags).toContain('<script type="text/plain">0</script>')
+    expect(headTags).toContain('<style>0</style>')
+    expect(headTags).toContain('<noscript>0</noscript>')
+  })
 })

--- a/packages/react/test/framework-lifecycle.test.tsx
+++ b/packages/react/test/framework-lifecycle.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react'
+import React, { StrictMode } from 'react'
+import { describe, expect, it } from 'vitest'
+import { Head, useScript, useUnhead } from '../src'
+import { createHead, UnheadProvider } from '../src/client'
+
+function wait(ms = 10) {
+  return new Promise<void>(resolve => setTimeout(resolve, ms))
+}
+
+describe('react framework lifecycle', () => {
+  it('keeps an implicit provider head stable across rerenders', () => {
+    const seen: unknown[] = []
+    function Capture({ label }: { label: string }) {
+      seen.push(useUnhead())
+      return <div>{label}</div>
+    }
+    const renderApp = (label: string) => (
+      <UnheadProvider>
+        <Capture label={label} />
+      </UnheadProvider>
+    )
+    const { rerender } = render(renderApp('first'))
+    rerender(renderApp('second'))
+
+    expect(seen.at(-1)).toBe(seen[0])
+  })
+
+  it('keeps one Head entry in StrictMode and disposes it', async () => {
+    const head = createHead({ init: [{ title: 'Initial' }] })
+    const { unmount } = render(
+      <StrictMode>
+        <UnheadProvider head={head}>
+          <Head><title>Page</title></Head>
+        </UnheadProvider>
+      </StrictMode>,
+    )
+
+    await act(() => wait())
+    expect(head.entries.size).toBe(2)
+
+    await act(async () => {
+      unmount()
+      await wait()
+    })
+    expect(head.entries.size).toBe(1)
+  })
+
+  it('does not load promise-triggered scripts after unmount', async () => {
+    const head = createHead()
+    let resolveTrigger!: () => void
+    const trigger = new Promise<void>(resolve => resolveTrigger = resolve)
+    function Page() {
+      useScript('//strict-unmount.js', { trigger, head })
+      return null
+    }
+    const { unmount } = render(
+      <StrictMode>
+        <UnheadProvider head={head}><Page /></UnheadProvider>
+      </StrictMode>,
+    )
+    await act(() => wait())
+    const script = (head as any)._scripts['//strict-unmount.js']
+
+    unmount()
+    resolveTrigger()
+    await act(() => wait())
+
+    expect(script.status).toBe('awaitingLoad')
+  })
+
+  it('keeps render callbacks through StrictMode effect replay', async () => {
+    const head = createHead()
+    function Page() {
+      const script = useScript('//strict-callback.js', { trigger: 'manual', head })
+      script.onLoaded(() => {})
+      return null
+    }
+    render(
+      <StrictMode>
+        <UnheadProvider head={head}><Page /></UnheadProvider>
+      </StrictMode>,
+    )
+    await act(() => wait())
+
+    const script = (head as any)._scripts['//strict-callback.js']
+    expect(script._cbs.loaded).toHaveLength(1)
+  })
+
+  it('registers callbacks created after commit', async () => {
+    const head = createHead()
+    function Page() {
+      const script = useScript('//effect-callback.js', { trigger: 'manual', head })
+      React.useEffect(() => script.onLoaded(() => {}), [script])
+      return null
+    }
+    render(<UnheadProvider head={head}><Page /></UnheadProvider>)
+    await act(() => wait())
+
+    const script = (head as any)._scripts['//effect-callback.js']
+    expect(script._cbs.loaded).toHaveLength(1)
+  })
+})

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -1,6 +1,6 @@
 import type { DefineComponent, Ref, VNode } from 'vue'
 import type { ReactiveHead } from './types'
-import { defineComponent, onBeforeUnmount, ref, watchEffect } from 'vue'
+import { defineComponent, ref } from 'vue'
 import { useHead } from './composables'
 
 function addVNodeToHeadObj(node: VNode, obj: ReactiveHead) {
@@ -66,18 +66,10 @@ export const Head: DefineComponent = /* @__PURE__ */ defineComponent({
   setup(_, { slots }) {
     const obj: Ref<ReactiveHead> = ref({})
 
-    const entry = useHead(obj)
-
-    onBeforeUnmount(() => {
-      entry.dispose()
-    })
+    useHead(obj)
 
     return () => {
-      watchEffect(() => {
-        if (!slots.default)
-          return
-        entry.patch(vnodesToHeadObj(slots.default()))
-      })
+      obj.value = slots.default ? vnodesToHeadObj(slots.default()) : {}
       return null
     }
   },

--- a/packages/vue/src/composables.ts
+++ b/packages/vue/src/composables.ts
@@ -10,6 +10,7 @@ import { FlatMetaPlugin, SafeInputPlugin } from 'unhead/plugins'
 import { walkResolver } from 'unhead/utils'
 import {
   getCurrentInstance,
+  getCurrentScope,
   hasInjectionContext,
   inject,
   onActivated,
@@ -39,6 +40,10 @@ export function useHead<I = UseHeadInput>(input?: UseHeadInput, options: UseHead
 }
 
 function clientUseHead<I = UseHeadInput>(head: Unhead<I>, input?: I, options: HeadEntryOptions = {}): ActiveHeadEntry<I> {
+  const scope = getCurrentScope()
+  if (scope && !scope.active)
+    return { patch() {}, dispose() {}, _poll() {} }
+
   const deactivated = ref(false)
 
   let entry: ActiveHeadEntry<I>
@@ -77,12 +82,28 @@ export function useHeadSafe(input: UseHeadSafeInput = {}, options: UseHeadOption
 export function useSeoMeta(input: UseSeoMetaInput = {}, options: UseHeadOptions = {}): ActiveHeadEntry<UseSeoMetaInput> {
   const head = options.head || injectHead()
   head.use(FlatMetaPlugin)
-  const { title, titleTemplate, ...meta } = input
-  return useHead({
-    title,
-    titleTemplate,
+  const entry = useHead<UseSeoMetaInput>(normalizeSeoMetaInput(input), options)
+  const corePatch = entry.patch
+  entry.patch = input => corePatch(normalizeSeoMetaInput(input))
+  return entry
+}
+
+function normalizeSeoMetaInput(input: UseSeoMetaInput) {
+  // @ts-expect-error internal normalized input
+  if (input._flatMeta)
+    return input
+
+  const meta: Record<string, any> = {}
+  for (const key in input) {
+    if (!Object.prototype.hasOwnProperty.call(input, key) || key === 'title' || key === 'titleTemplate')
+      continue
+    meta[key] = input[key as keyof UseSeoMetaInput]
+  }
+  return {
+    title: input.title,
+    titleTemplate: input.titleTemplate,
     _flatMeta: meta,
-  } as UseSeoMetaInput, options)
+  } as UseSeoMetaInput
 }
 
 /**

--- a/packages/vue/test/unit/dom/frameworkLifecycle.test.ts
+++ b/packages/vue/test/unit/dom/frameworkLifecycle.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { createApp, defineComponent, getCurrentScope, h, nextTick, ref } from 'vue'
+import { createHead, renderDOMHead } from '../../../src/client'
+import { Head } from '../../../src/components'
+import { useHead, useSeoMeta } from '../../../src/composables'
+
+describe('vue framework lifecycle', () => {
+  it('returns a usable entry from a stopped scope', () => {
+    const head = createHead({ document })
+    let entry: ReturnType<typeof useHead> | undefined
+    const app = createApp(defineComponent({
+      setup() {
+        getCurrentScope()!.stop()
+        entry = useHead({ title: 'late' }, { head })
+        return () => h('div')
+      },
+    }))
+
+    app.mount(document.createElement('div'))
+
+    expect(entry).toBeDefined()
+    expect(() => entry!.patch({ title: 'ignored' })).not.toThrow()
+    expect(() => entry!.dispose()).not.toThrow()
+    expect(() => app.unmount()).not.toThrow()
+  })
+
+  it('normalizes useSeoMeta patches', async () => {
+    const head = createHead({ document })
+    let entry: ReturnType<typeof useSeoMeta> | undefined
+    const app = createApp(defineComponent({
+      setup() {
+        entry = useSeoMeta({ description: 'initial' }, { head })
+        return () => h('div')
+      },
+    }))
+    app.mount(document.createElement('div'))
+
+    entry!.patch({ description: 'updated', ogTitle: 'Updated OG' })
+    await renderDOMHead(head, { document })
+
+    expect(document.head.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('updated')
+    expect(document.head.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe('Updated OG')
+    app.unmount()
+  })
+
+  it('keeps one Head watcher across rerenders', async () => {
+    const css = ref('body { color: blue }')
+    const tick = ref(0)
+    let entriesUpdated = 0
+    const head = createHead({
+      document,
+      hooks: {
+        'entries:updated': () => {
+          entriesUpdated++
+        },
+      },
+    })
+    const app = createApp(defineComponent({
+      render() {
+        return h('div', [
+          h('span', tick.value),
+          h(Head, null, {
+            default: () => h('style', null, css.value),
+          }),
+        ])
+      },
+    }))
+    app.use(head)
+    app.mount(document.createElement('div'))
+    await nextTick()
+
+    for (let i = 0; i < 3; i++) {
+      tick.value++
+      await nextTick()
+    }
+    entriesUpdated = 0
+    css.value = 'body { color: green }'
+    await nextTick()
+
+    expect(entriesUpdated).toBe(1)
+    app.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Backports the v2-safe parts of #778, #805, #806, #809, and #894.

- return an inert Vue head entry when async setup resumes in a stopped scope
- normalize Vue `useSeoMeta().patch()` input and keep one `Head` watcher
- keep an implicit React provider head stable across rerenders
- create React `Head` entries at the correct client or server lifecycle point
- scope React script triggers and callbacks to committed renders
- preserve numeric zero children in React `Head`

No public exports, props, options, or composables are added.

## Validation

- React suite, 51 passed
- Vue suite, 71 passed
- scoped ESLint, passed
- `pnpm typecheck`, passed
- `pnpm build`, passed
