### PR TITLE
fix(v2): correct schema organization resolution

### DIFF
--- a/packages/schema-org/src/core/util.ts
+++ b/packages/schema-org/src/core/util.ts
@@ -5,7 +5,7 @@ export function merge(target: any, source: any): any {
     return target
 
   for (const key in source) {
-    if (!Object.hasOwn(source, key) || UNSAFE_KEYS.has(key))
+    if (!Object.prototype.hasOwnProperty.call(source, key) || UNSAFE_KEYS.has(key))
       continue
 
     const value = source[key]

--- a/packages/schema-org/src/nodes/Article/index.test.ts
+++ b/packages/schema-org/src/nodes/Article/index.test.ts
@@ -305,6 +305,9 @@ describe('defineArticle', () => {
           {
             "@id": "https://example.com/#identity",
             "@type": "Organization",
+            "logo": {
+              "@id": "https://example.com/#logo",
+            },
             "name": "Identity",
             "url": "https://example.com/",
           },
@@ -378,13 +381,6 @@ describe('defineArticle', () => {
             "contentUrl": "https://example.com/test.png",
             "inLanguage": "en-AU",
             "url": "https://example.com/test.png",
-          },
-          {
-            "@id": "https://example.com/#organization",
-            "@type": "Organization",
-            "logo": "https://example.com/test.png",
-            "name": "Identity",
-            "url": "https://example.com/",
           },
           {
             "@id": "https://example.com/#/schema/image/1",

--- a/packages/schema-org/src/nodes/Organization/index.test.ts
+++ b/packages/schema-org/src/nodes/Organization/index.test.ts
@@ -3,6 +3,37 @@ import { defineOrganization, useSchemaOrg } from '../../'
 import { injectSchemaOrg, useSetup } from '../../../test'
 
 describe('defineOrganization', () => {
+  it('keeps a logo on the identity organization', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        defineOrganization({ name: 'Identity', logo: '/logo.png' }),
+      ])
+
+      const graph = await injectSchemaOrg(head)
+      const identity = graph.find(node => node['@id'] === 'https://example.com/#identity')
+      const logo = graph.find(node => node['@id'] === 'https://example.com/#logo')
+
+      expect(identity?.logo).toEqual({ '@id': 'https://example.com/#logo' })
+      expect(logo?.contentUrl).toBe('https://example.com/logo.png')
+      expect(graph.filter(node => node['@type'] === 'Organization')).toHaveLength(1)
+    })
+  })
+
+  it('keeps a compact node for specialized organizations', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        defineOrganization({ '@type': 'Corporation', 'name': 'Corp', 'logo': '/logo.png' } as any),
+      ])
+
+      const graph = await injectSchemaOrg(head)
+      const identity = graph.find(node => node['@id'] === 'https://example.com/#identity')
+      const compact = graph.find(node => node['@id'] === 'https://example.com/#organization')
+
+      expect(identity).not.toHaveProperty('logo')
+      expect(compact).toMatchObject({ '@type': 'Organization', 'logo': 'https://example.com/logo.png' })
+    })
+  })
+
   it('can be registered', async () => {
     await useSetup(async (head) => {
       useSchemaOrg(head, [
@@ -30,6 +61,9 @@ describe('defineOrganization', () => {
               "postalCode": "2000",
               "streetAddress": "123 st",
             },
+            "logo": {
+              "@id": "https://example.com/#logo",
+            },
             "name": "test",
             "url": "https://example.com/",
           },
@@ -40,19 +74,6 @@ describe('defineOrganization', () => {
             "contentUrl": "https://example.com/logo.png",
             "inLanguage": "en-AU",
             "url": "https://example.com/logo.png",
-          },
-          {
-            "@id": "https://example.com/#organization",
-            "@type": "Organization",
-            "address": {
-              "@type": "PostalAddress",
-              "addressCountry": "Australia",
-              "postalCode": "2000",
-              "streetAddress": "123 st",
-            },
-            "logo": "https://example.com/logo.png",
-            "name": "test",
-            "url": "https://example.com/",
           },
         ]
       `)

--- a/packages/schema-org/src/nodes/Organization/index.ts
+++ b/packages/schema-org/src/nodes/Organization/index.ts
@@ -92,36 +92,38 @@ export const organizationResolver
       const isIdentity = resolveAsGraphKey(node['@id']) === IdentityId
       const webPage = ctx.find<WebPage>(PrimaryWebPageId)
       if (node.logo && isIdentity) {
-        if (!ctx.find('#organization')) {
-        // create a node for the logo
-          const logoNode = resolveRelation(node.logo, ctx, imageResolver, {
-            root: true,
-            afterResolve(logo) {
-              logo['@id'] = prefixId(ctx.meta.host, '#logo')
-              setIfEmpty(logo, 'caption', node.name)
-            },
-          })
+        const logoInput = Array.isArray(node.logo) ? node.logo[0] : node.logo
+        const logoNode = resolveRelation(logoInput, ctx, imageResolver, {
+          root: true,
+          afterResolve(logo) {
+            logo['@id'] = prefixId(ctx.meta.host, '#logo')
+            setIfEmpty(logo, 'caption', node.name)
+          },
+        })
 
-          if (webPage && logoNode)
-            setIfEmpty(webPage, 'primaryImageOfPage', idReference(logoNode))
+        if (webPage && logoNode)
+          setIfEmpty(webPage, 'primaryImageOfPage', idReference(logoNode))
 
-          // push a separate node that will just be used for the Logo rich result
+        if (node['@type'] === 'Organization') {
+          node.logo = logoNode
+        }
+        else if (!ctx.find('#organization')) {
+          const resolvedLogo = logoNode && typeof logoNode === 'object' && logoNode['@id']
+            ? ctx.find<ImageObject>(logoNode['@id'])
+            : null
           ctx.nodes.push({
-            // we want to make a simple node that has the essentials, this will allow parent nodes to inject
-            // as well without inserting invalid data (i.e LocalBusiness operatingHours)
             '@type': 'Organization',
             'name': node.name,
             'url': node.url,
             'sameAs': node.sameAs,
-            // 'image': idReference(logoNode),
             'address': node.address,
-            // needs to be a URL
-            'logo': resolveRelation(node.logo, ctx, imageResolver, { root: false }).url,
+            'logo': resolvedLogo?.url || resolvedLogo?.contentUrl,
             '_priority': -1,
-            '@id': prefixId(ctx.meta.host, '#organization'), // avoid the id so nothing can link to it
+            '@id': prefixId(ctx.meta.host, '#organization'),
           })
         }
-        delete node.logo
+        if (node['@type'] !== 'Organization')
+          delete node.logo
       }
 
       if (isIdentity && webPage)

--- a/packages/schema-org/src/nodes/WebPage/index.test.ts
+++ b/packages/schema-org/src/nodes/WebPage/index.test.ts
@@ -270,6 +270,9 @@ describe('defineWebPage', () => {
           {
             "@id": "https://example.com/#identity",
             "@type": "Organization",
+            "logo": {
+              "@id": "https://example.com/#logo",
+            },
             "name": "Harlan Wilton",
             "url": "https://example.com/",
           },
@@ -290,13 +293,6 @@ describe('defineWebPage', () => {
             "contentUrl": "https://example.com/logo.png",
             "inLanguage": "en-AU",
             "url": "https://example.com/logo.png",
-          },
-          {
-            "@id": "https://example.com/#organization",
-            "@type": "Organization",
-            "logo": "https://example.com/logo.png",
-            "name": "Harlan Wilton",
-            "url": "https://example.com/",
           },
         ]
       `)

--- a/packages/schema-org/src/plugin.ts
+++ b/packages/schema-org/src/plugin.ts
@@ -26,7 +26,7 @@ async function preloadNestedResolvers(obj: any): Promise<void> {
   }
 
   for (const key in obj) {
-    if (!Object.hasOwn(obj, key) || UNSAFE_KEYS.has(key))
+    if (!Object.prototype.hasOwnProperty.call(obj, key) || UNSAFE_KEYS.has(key))
       continue
     const val = obj[key]
     if (val && typeof val === 'object') {
@@ -48,7 +48,7 @@ async function preloadNestedResolvers(obj: any): Promise<void> {
 function mergeObjects(target: any, source: any): any {
   const result = { ...target }
   for (const key in source) {
-    if (!Object.hasOwn(source, key) || source[key] === undefined || UNSAFE_KEYS.has(key))
+    if (!Object.prototype.hasOwnProperty.call(source, key) || source[key] === undefined || UNSAFE_KEYS.has(key))
       continue
 
     const isNestedObject = result[key]

--- a/packages/schema-org/src/utils/index.test.ts
+++ b/packages/schema-org/src/utils/index.test.ts
@@ -1,0 +1,29 @@
+import type { Thing } from '../types'
+import { resolveDefaultType, stripEmptyProperties } from '.'
+import { merge } from '../core/util'
+
+describe('schema.org utilities', () => {
+  it('uses the default when the node type is missing', () => {
+    const node = {} as Thing
+
+    resolveDefaultType(node, 'Organization')
+
+    expect(node['@type']).toBe('Organization')
+  })
+
+  it('works without Object.hasOwn', () => {
+    const originalHasOwn = Object.hasOwn
+    let merged: any
+    let stripped: any
+    Object.hasOwn = undefined as any
+    try {
+      merged = merge({ nested: { first: true } }, { nested: { second: true } })
+      stripped = stripEmptyProperties({ empty: '', name: 'Compatible' })
+    }
+    finally {
+      Object.hasOwn = originalHasOwn
+    }
+    expect(merged).toEqual({ nested: { first: true, second: true } })
+    expect(stripped).toEqual({ name: 'Compatible' })
+  })
+})

--- a/packages/schema-org/src/utils/index.ts
+++ b/packages/schema-org/src/utils/index.ts
@@ -115,9 +115,12 @@ export function resolveDefaultType(node: Thing, defaultType: Arrayable<string>) 
   }
   // General case: dedupe with Set
   const types = new Set<string>(asArray(defaultType))
-  for (const t of asArray(val))
-    types.add(t)
-  node['@type'] = types.size === 1 ? val : [...types]
+  for (const t of asArray(val)) {
+    if (t != null)
+      types.add(t)
+  }
+  const resolved = [...types]
+  node['@type'] = resolved.length === 1 ? resolved[0] : resolved
 }
 
 export function resolveWithBase(base: string, urlOrPath: string) {
@@ -138,7 +141,7 @@ export function resolveAsGraphKey(key?: Id | string) {
  */
 export function stripEmptyProperties(obj: any) {
   for (const k in obj) {
-    if (!Object.hasOwn(obj, k))
+    if (!Object.prototype.hasOwnProperty.call(obj, k))
       continue
 
     const v = obj[k]


### PR DESCRIPTION
## Summary

Backports #872, #924, and the Schema.org compatibility part of #891.

- keep a standard Organization logo attached to the identity node
- retain the compact rich-result node for specialized organization types
- apply the default schema type when `@type` is absent
- remove the runtime dependency on `Object.hasOwn`

No schema types, node definitions, exports, or options are added.

## Validation

- Schema.org suite, 118 passed
- scoped ESLint, passed
- `pnpm typecheck`, passed
- `pnpm --filter @unhead/schema-org build`, passed
