### PR TITLE
perf(v2): reduce resolver allocations

### DIFF
--- a/packages/unhead/src/plugins/safe.ts
+++ b/packages/unhead/src/plugins/safe.ts
@@ -2,6 +2,7 @@ import type { HeadSafe } from '../types/safeSchema'
 import type { RawInput } from '../types/schema'
 import type { HeadTag } from '../types/tags'
 import { hasContent } from '../utils/const'
+import { isUnsafeKey } from '../utils/unsafeKey'
 import { defineHeadPlugin } from './defineHeadPlugin'
 
 const WhitelistAttributes = {
@@ -98,7 +99,7 @@ function stripProtoKeys(obj: any): any {
   if (obj && typeof obj === 'object') {
     const clean: Record<string, any> = {}
     for (const key of Object.keys(obj)) {
-      if (key === '__proto__' || key === 'constructor' || key === 'prototype')
+      if (isUnsafeKey(key))
         continue
       clean[key] = stripProtoKeys(obj[key])
     }

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -1,6 +1,7 @@
 import type { HeadTag, PropResolver, ResolvableHead } from '../types'
 import { walkResolver } from '../utils/walkResolver'
 import { DupeableTags, HasElementTags, TagConfigKeys } from './const'
+import { isUnsafeKey } from './unsafeKey'
 
 function normalizeStyleClassProps(
   key: 'class' | 'style',
@@ -62,7 +63,7 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
   const isHtmlTag = HasElementTags.has(tag.tag) || tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs'
 
   Object.entries(input).forEach(([prop, value]) => {
-    if (prop === '__proto__' || prop === 'constructor' || prop === 'prototype')
+    if (isUnsafeKey(prop))
       return
     // if the value is a primitive, return early
     if (value === null) {

--- a/packages/unhead/src/utils/unsafeKey.ts
+++ b/packages/unhead/src/utils/unsafeKey.ts
@@ -1,0 +1,4 @@
+/* @__NO_SIDE_EFFECTS__ */
+export function isUnsafeKey(key: string): boolean {
+  return key === '__proto__' || key === 'constructor' || key === 'prototype'
+}

--- a/packages/unhead/src/utils/walkResolver.ts
+++ b/packages/unhead/src/utils/walkResolver.ts
@@ -34,7 +34,8 @@ export function walkResolver(val: any, resolve?: PropResolver, key?: string): an
     for (const k in v) {
       const unsafe = isUnsafeKey(k)
       const resolved = unsafe ? undefined : walkResolver(v[k], resolve, k)
-      if (!next && (unsafe || resolved !== v[k])) {
+      const requiresCopy = k === '_resolver'
+      if (!next && (unsafe || requiresCopy || resolved !== v[k])) {
         next = {}
         for (const previousKey in v) {
           if (previousKey === k) {

--- a/packages/unhead/src/utils/walkResolver.ts
+++ b/packages/unhead/src/utils/walkResolver.ts
@@ -1,4 +1,5 @@
 import type { PropResolver } from '../types'
+import { isUnsafeKey } from './unsafeKey'
 
 export function walkResolver(val: any, resolve?: PropResolver, key?: string): any {
   // Combined primitive type check
@@ -14,15 +15,39 @@ export function walkResolver(val: any, resolve?: PropResolver, key?: string): an
   const v = resolve ? resolve(key, val) : val
 
   if (Array.isArray(v)) {
-    return v.map(r => walkResolver(r, resolve))
+    let out: any[] | undefined
+    for (let i = 0; i < v.length; i++) {
+      const resolved = walkResolver(v[i], resolve)
+      if (out) {
+        out[i] = resolved
+      }
+      else if (resolved !== v[i]) {
+        out = v.slice(0, i)
+        out[i] = resolved
+      }
+    }
+    return out || v
   }
 
   if (v?.constructor === Object) {
-    const next: Record<string, any> = {}
-    for (const k of Object.keys(v)) {
-      next[k] = walkResolver(v[k], resolve, k)
+    let next: Record<string, any> | undefined
+    for (const k in v) {
+      const unsafe = isUnsafeKey(k)
+      const resolved = unsafe ? undefined : walkResolver(v[k], resolve, k)
+      if (!next && (unsafe || resolved !== v[k])) {
+        next = {}
+        for (const previousKey in v) {
+          if (previousKey === k) {
+            break
+          }
+          next[previousKey] = v[previousKey]
+        }
+      }
+      if (next && !unsafe) {
+        next[k] = resolved
+      }
     }
-    return next
+    return next || v
   }
 
   return v

--- a/packages/unhead/test/unit/walkResolver.test.ts
+++ b/packages/unhead/test/unit/walkResolver.test.ts
@@ -29,6 +29,21 @@ describe('walkResolver structural sharing', () => {
     expect(resolved.meta[1].content).toBe('resolved')
   })
 
+  it('copies branches with resolver markers', () => {
+    const node = {
+      _resolver: 'searchAction',
+      target: '/search?query={search_term_string}',
+    }
+    const input = { nodes: [node] }
+
+    const resolved = walkResolver(input)
+
+    expect(resolved).not.toBe(input)
+    expect(resolved.nodes).not.toBe(input.nodes)
+    expect(resolved.nodes[0]).not.toBe(node)
+    expect(resolved.nodes[0]).toEqual(node)
+  })
+
   it('drops unsafe keys without changing the result prototype', () => {
     const input = { title: 'Safe' }
     Object.defineProperty(input, '__proto__', {

--- a/packages/unhead/test/unit/walkResolver.test.ts
+++ b/packages/unhead/test/unit/walkResolver.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { walkResolver } from '../../src/utils/walkResolver'
+
+describe('walkResolver structural sharing', () => {
+  it('reuses a static input tree', () => {
+    const input = {
+      title: 'Static',
+      meta: [{ name: 'description', content: 'static' }],
+    }
+
+    const resolved = walkResolver(input)
+
+    expect(resolved).toBe(input)
+    expect(resolved.meta).toBe(input.meta)
+    expect(resolved.meta[0]).toBe(input.meta[0])
+  })
+
+  it('copies only branches changed by a resolver', () => {
+    const stable = { name: 'author', content: 'Harlan' }
+    const dynamic = { name: 'description', content: () => 'resolved' }
+    const input = { meta: [stable, dynamic] }
+
+    const resolved = walkResolver(input)
+
+    expect(resolved).not.toBe(input)
+    expect(resolved.meta).not.toBe(input.meta)
+    expect(resolved.meta[0]).toBe(stable)
+    expect(resolved.meta[1]).not.toBe(dynamic)
+    expect(resolved.meta[1].content).toBe('resolved')
+  })
+
+  it('drops unsafe keys without changing the result prototype', () => {
+    const input = { title: 'Safe' }
+    Object.defineProperty(input, '__proto__', {
+      enumerable: true,
+      value: { polluted: true },
+    })
+
+    const resolved = walkResolver(input)
+
+    expect(resolved).not.toBe(input)
+    expect(Object.getPrototypeOf(resolved)).toBe(Object.prototype)
+    expect(Object.prototype.hasOwnProperty.call(resolved, '__proto__')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Backports #812.

- reuse static arrays and objects while walking resolver input
- shallow copy only after a resolver or function changes a branch
- preserve isolated copies for v2's mutable Schema.org resolver markers
- drop unsafe prototype keys from copied results
- keep the shared prototype key guard internal

The upstream benchmark measured roughly 18% lower SSR allocation in this path. No exports, options, or public types are added.

## Validation

- workspace suite: 707 passed, 2 skipped
- Unhead suite: 427 passed, 2 skipped
- Schema.org duplicate action regression: 9 passed
- scoped ESLint
- `pnpm typecheck`
- `pnpm build`
