### PR TITLE
fix: type origin-trial meta directive

### DIFF
--- a/packages/unhead/src/types/schema/head.ts
+++ b/packages/unhead/src/types/schema/head.ts
@@ -381,7 +381,7 @@ export type {
 export interface MetaGeneric extends MetaBase {
   'name'?: MetaNames | (string & Record<never, never>)
   'property'?: MetaProperties | (string & Record<never, never>)
-  'http-equiv'?: 'content-security-policy' | 'content-type' | 'default-style' | 'x-ua-compatible' | 'refresh' | 'accept-ch' | (string & Record<never, never>)
+  'http-equiv'?: 'content-security-policy' | 'content-type' | 'default-style' | 'x-ua-compatible' | 'refresh' | 'accept-ch' | 'origin-trial' | (string & Record<never, never>)
   'charset'?: 'utf-8' | (string & Record<never, never>)
   'content'?: string | number
 }

--- a/packages/unhead/src/types/schema/meta.ts
+++ b/packages/unhead/src/types/schema/meta.ts
@@ -201,7 +201,7 @@ export interface HttpEquivMeta extends MetaBase {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-http-equiv
    */
-  'http-equiv': 'content-security-policy' | 'content-type' | 'default-style' | 'x-ua-compatible' | 'refresh' | 'accept-ch' | (string & Record<never, never>)
+  'http-equiv': 'content-security-policy' | 'content-type' | 'default-style' | 'x-ua-compatible' | 'refresh' | 'accept-ch' | 'origin-trial' | (string & Record<never, never>)
   /**
    * This attribute contains the value for the http-equiv attribute.
    *


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `http-equiv` type accepted custom strings, but editor autocomplete omitted `origin-trial`. Add it to the strict and generic meta value unions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `origin-trial` value in HTTP-equivalent metadata definitions.
  * Improved compatibility with pages using origin trial browser features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->