### PR TITLE
fix(schema-org): limit identity `about` links to homepage

### DIFF
--- a/packages/schema-org/src/nodes/Organization/index.test.ts
+++ b/packages/schema-org/src/nodes/Organization/index.test.ts
@@ -1,9 +1,38 @@
 import { expect } from 'vitest'
 import { organizationResolver } from '.'
-import { defineOrganization, useSchemaOrg } from '../../'
+import { defineOrganization, defineWebPage, useSchemaOrg } from '../../'
 import { injectSchemaOrg, useSetup } from '../../../test'
 
 describe('defineOrganization', () => {
+  it('sets webpage about to the identity on the homepage', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        defineOrganization({ name: 'RankEval' }),
+        defineWebPage(),
+      ])
+
+      const graph = await injectSchemaOrg(head)
+      const webPage = graph.find(node => node['@id'] === 'https://example.com/#webpage')
+
+      expect(webPage?.about).toEqual({ '@id': 'https://example.com/#identity' })
+    })
+  })
+
+  it('does not set webpage about to the identity off the homepage', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        defineOrganization({ name: 'RankEval' }),
+        defineWebPage(),
+      ])
+
+      const graph = await injectSchemaOrg(head)
+      const webPage = graph.find(node => node['@id'] === 'https://example.com/orgs/rustopia#webpage')
+
+      expect(webPage).toBeDefined()
+      expect(webPage).not.toHaveProperty('about')
+    }, { path: '/orgs/rustopia' })
+  })
+
   it('keeps a logo when the identity type is resolved from the default', async () => {
     await useSetup(async (head) => {
       useSchemaOrg(head, [

--- a/packages/schema-org/src/nodes/Organization/index.ts
+++ b/packages/schema-org/src/nodes/Organization/index.ts
@@ -456,7 +456,7 @@ export const organizationResolver
           delete node.logo
       }
 
-      // Only the homepage is about the identity, see webPageResolver.
+      // Default the homepage's about relation to the site identity.
       if (isIdentity && webPage && isHomePage(ctx.meta))
         setIfEmpty(webPage, 'about', idReference(node as Organization))
 

--- a/packages/schema-org/src/nodes/Organization/index.ts
+++ b/packages/schema-org/src/nodes/Organization/index.ts
@@ -11,6 +11,7 @@ import {
   asArray,
   IdentityId,
   idReference,
+  isHomePage,
   prefixId,
   resolvableDateToIso,
   resolveAsGraphKey,
@@ -446,14 +447,17 @@ export const organizationResolver
             // needs to be a URL
             'logo': resolvedLogo?.url,
             '_priority': -1,
-            '@id': prefixId(ctx.meta.host, '#organization'), // avoid the id so nothing can link to it
+            // Distinct from #identity so the specialized identity node stays the linkable one;
+            // the id is stable so repeat resolves dedupe on the ctx.find('#organization') guard.
+            '@id': prefixId(ctx.meta.host, '#organization'),
           })
         }
         if (node['@type'] !== 'Organization')
           delete node.logo
       }
 
-      if (isIdentity && webPage)
+      // Only the homepage is about the identity, see webPageResolver.
+      if (isIdentity && webPage && isHomePage(ctx.meta))
         setIfEmpty(webPage, 'about', idReference(node as Organization))
 
       const webSite = ctx.find(PrimaryWebSiteId)

--- a/packages/schema-org/src/nodes/Person/index.test.ts
+++ b/packages/schema-org/src/nodes/Person/index.test.ts
@@ -1,10 +1,39 @@
 import type { Article } from '../Article'
 import { describe, expect, it } from 'vitest'
-import { defineArticle, defineOrganization, definePerson, useSchemaOrg } from '../../'
+import { defineArticle, defineOrganization, definePerson, defineWebPage, useSchemaOrg } from '../../'
 import { findNode, injectSchemaOrg, useSetup } from '../../../test'
 import { PrimaryArticleId } from '../Article'
 
 describe('definePerson', () => {
+  it('sets webpage about to the identity on the homepage', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        definePerson({ name: 'Harlan Wilton' }),
+        defineWebPage(),
+      ])
+
+      const graph = await injectSchemaOrg(head)
+      const webPage = graph.find(node => node['@id'] === 'https://example.com/#webpage')
+
+      expect(webPage?.about).toEqual({ '@id': 'https://example.com/#identity' })
+    })
+  })
+
+  it('does not set webpage about to the identity off the homepage', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        definePerson({ name: 'Harlan Wilton' }),
+        defineWebPage(),
+      ])
+
+      const graph = await injectSchemaOrg(head)
+      const webPage = graph.find(node => node['@id'] === 'https://example.com/posts/hello#webpage')
+
+      expect(webPage).toBeDefined()
+      expect(webPage).not.toHaveProperty('about')
+    }, { path: '/posts/hello' })
+  })
+
   it('can be registered', async () => {
     await useSetup(async (head) => {
       useSchemaOrg(head, [

--- a/packages/schema-org/src/nodes/Person/index.ts
+++ b/packages/schema-org/src/nodes/Person/index.ts
@@ -5,6 +5,7 @@ import { interactionCounterResolver, propertyValueResolver } from '../../core/co
 import {
   IdentityId,
   idReference,
+  isHomePage,
   resolveAsGraphKey,
   resolveWithBase,
   setIfEmpty,
@@ -95,8 +96,9 @@ export const personResolver = defineSchemaOrgResolver<Person, Person | string>({
     if (resolveAsGraphKey(node['@id']) === IdentityId) {
       setIfEmpty(node, 'url', meta.host)
 
+      // Only the homepage is about the identity, see webPageResolver.
       const webPage = find(PrimaryWebPageId)
-      if (webPage)
+      if (webPage && isHomePage(meta))
         setIfEmpty(webPage, 'about', idReference(node as Person))
 
       const webSite = find(PrimaryWebSiteId)

--- a/packages/schema-org/src/nodes/Person/index.ts
+++ b/packages/schema-org/src/nodes/Person/index.ts
@@ -96,7 +96,7 @@ export const personResolver = defineSchemaOrgResolver<Person, Person | string>({
     if (resolveAsGraphKey(node['@id']) === IdentityId) {
       setIfEmpty(node, 'url', meta.host)
 
-      // Only the homepage is about the identity, see webPageResolver.
+      // Default the homepage's about relation to the site identity.
       const webPage = find(PrimaryWebPageId)
       if (webPage && isHomePage(meta))
         setIfEmpty(webPage, 'about', idReference(node as Person))

--- a/packages/schema-org/src/nodes/WebPage/index.ts
+++ b/packages/schema-org/src/nodes/WebPage/index.ts
@@ -17,6 +17,7 @@ import { defineSchemaOrgResolver, resolveIdentityRelation, resolveRelation } fro
 import {
   IdentityId,
   idReference,
+  isHomePage,
   resolvableDateToIso,
   resolveDefaultType,
   setIfEmpty,
@@ -267,7 +268,7 @@ export const webPageResolver = defineSchemaOrgResolver<WebPage>({
     /*
      * When it's a homepage, add additional about property which references the identity of the site.
      */
-    if (identity && meta.url === meta.host)
+    if (identity && isHomePage(meta))
       setIfEmpty(webPage, 'about', idReference(identity))
 
     if (logo)

--- a/packages/schema-org/src/utils/index.ts
+++ b/packages/schema-org/src/utils/index.ts
@@ -91,10 +91,7 @@ export function resolvableDateToIso(val: Date | string | undefined) {
 
 export const IdentityId = '#identity'
 
-/**
- * The site identity describes the site as a whole, so it may only be the subject
- * (`WebPage.about`) of the homepage. Every other page is about something else.
- */
+/** Whether identity resolvers should default `WebPage.about` to the site identity. */
 export function isHomePage(meta: ResolvedMeta) {
   return meta.url === meta.host
 }

--- a/packages/schema-org/src/utils/index.ts
+++ b/packages/schema-org/src/utils/index.ts
@@ -1,6 +1,7 @@
 import type {
   Arrayable,
   Id,
+  ResolvedMeta,
   Thing,
 } from '../types'
 import { hasOwn } from 'unhead/utils'
@@ -89,6 +90,14 @@ export function resolvableDateToIso(val: Date | string | undefined) {
 }
 
 export const IdentityId = '#identity'
+
+/**
+ * The site identity describes the site as a whole, so it may only be the subject
+ * (`WebPage.about`) of the homepage. Every other page is about something else.
+ */
+export function isHomePage(meta: ResolvedMeta) {
+  return meta.url === meta.host
+}
 
 export function setIfEmpty<T extends Thing>(node: T, field: keyof T, value: any) {
   if (node?.[field] === undefined && value != null)


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`organizationResolver` and `personResolver` assigned the site's identity to `WebPage.about` on every route, bypassing the homepage guard used by `webPageResolver`. This extracts `isHomePage(meta)` and uses it in all three resolvers; Organization and Person tests cover homepage and nested route output. Locale roots such as `/en` remain non-home pages under the existing exact host comparison, and the compact organization ID now has an accurate dedupe comment.