### PR TITLE
perf: keep runtime minification linear

### DIFF
--- a/packages/unhead/src/minify/css.ts
+++ b/packages/unhead/src/minify/css.ts
@@ -3,25 +3,34 @@
  * Strips comments and collapses whitespace while preserving string literals.
  */
 export function minifyCSS(code: string): string {
+  if (!/[\s/]|;\}|0\.\d/.test(code))
+    return code
+
   let result = ''
+  // Reading the growing result forces V8 to repeatedly flatten its string rope.
+  let last = ''
   let i = 0
   let parenDepth = 0
   const len = code.length
+  const append = (value: string) => {
+    result += value
+    last = value
+  }
 
   while (i < len) {
     const ch = code[i]
     // string literals - preserve as-is
     if (ch === '\'' || ch === '"') {
       const quote = ch
-      result += ch
+      append(ch)
       i++
       while (i < len && code[i] !== quote) {
         if (code[i] === '\\' && i + 1 < len)
-          result += code[i++]
-        result += code[i++]
+          append(code[i++]!)
+        append(code[i++]!)
       }
       if (i < len)
-        result += code[i++]
+        append(code[i++]!)
     }
     // comments
     else if (ch === '/' && code[i + 1] === '*') {
@@ -33,19 +42,18 @@ export function minifyCSS(code: string): string {
     // track paren depth for calc()/min()/max()/clamp()/var()
     else if (ch === '(') {
       parenDepth++
-      result += ch
+      append(ch)
       i++
     }
     else if (ch === ')') {
       parenDepth = Math.max(0, parenDepth - 1)
-      result += ch
+      append(ch)
       i++
     }
     // whitespace - collapse to single space, remove around punctuation
     else if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
       while (i < len && (code[i] === ' ' || code[i] === '\t' || code[i] === '\n' || code[i] === '\r'))
         i++
-      const prev = result.at(-1)
       const next = code[i]
       // strip space before ! for !important
       if (next === '!')
@@ -53,11 +61,11 @@ export function minifyCSS(code: string): string {
       if (parenDepth > 0) {
         // inside parens (calc/min/max/clamp/var): strip around * and / (safe per spec),
         // preserve around + and - (required by spec), strip around base punctuation
-        if (prev && next && !isCSSCalcPunctuation(prev) && !isCSSCalcPunctuation(next))
-          result += ' '
+        if (last && next && !isCSSCalcPunctuation(last) && !isCSSCalcPunctuation(next))
+          append(' ')
       }
-      else if (prev && next && !isCSSPunctuation(prev) && !isCSSPunctuation(next)) {
-        result += ' '
+      else if (last && next && !isCSSPunctuation(last) && !isCSSPunctuation(next)) {
+        append(' ')
       }
     }
     // trailing semicolon before } is optional
@@ -69,16 +77,15 @@ export function minifyCSS(code: string): string {
         i++ // skip the semicolon
       }
       else {
-        result += ch
+        append(ch)
         i++
       }
     }
     // leading zero: 0.x → .x
     else if (ch === '0' && code[i + 1] === '.' && code[i + 2] >= '0' && code[i + 2] <= '9') {
-      const prev = result.at(-1)
       // only strip if prev is not a digit (avoid turning 10.5 into 1.5)
-      if (prev && prev >= '0' && prev <= '9') {
-        result += ch
+      if (last && last >= '0' && last <= '9') {
+        append(ch)
         i++
       }
       else {
@@ -86,7 +93,7 @@ export function minifyCSS(code: string): string {
       }
     }
     else {
-      result += ch
+      append(ch!)
       i++
     }
   }

--- a/packages/unhead/src/minify/js.ts
+++ b/packages/unhead/src/minify/js.ts
@@ -3,25 +3,34 @@
  * Strips comments and collapses whitespace while preserving string literals.
  */
 export function minifyJS(code: string): string {
+  if (!/[\s/]/.test(code))
+    return code
+
   let result = ''
+  // Reading the growing result forces V8 to repeatedly flatten its string rope.
+  let last = ''
   let i = 0
   const len = code.length
+  const append = (value: string) => {
+    result += value
+    last = value
+  }
 
   while (i < len) {
     const ch = code[i]
     // string literals - preserve as-is
     if (ch === '\'' || ch === '"' || ch === '`') {
       const quote = ch
-      result += ch
+      append(ch)
       i++
       while (i < len && code[i] !== quote) {
         if (code[i] === '\\' && i + 1 < len) {
-          result += code[i++]
+          append(code[i++]!)
         }
-        result += code[i++]
+        append(code[i++]!)
       }
       if (i < len)
-        result += code[i++] // closing quote
+        append(code[i++]!) // closing quote
     }
     // single-line comment
     else if (ch === '/' && code[i + 1] === '/') {
@@ -44,18 +53,17 @@ export function minifyJS(code: string): string {
           hasNewline = true
         i++
       }
-      const prev = result.at(-1)
       const next = code[i]
-      if (hasNewline && prev && next && prev !== '{' && prev !== '}' && prev !== ';' && next !== '}' && next !== ';')
-        result += '\n'
-      else if (prev && next && isIdentChar(prev) && isIdentChar(next))
-        result += ' '
+      if (hasNewline && last && next && last !== '{' && last !== '}' && last !== ';' && next !== '}' && next !== ';')
+        append('\n')
+      else if (last && next && isIdentChar(last) && isIdentChar(next))
+        append(' ')
       // preserve space between identical + or - to avoid creating ++/-- operators
-      else if (prev && next && ((prev === '+' && next === '+') || (prev === '-' && next === '-')))
-        result += ' '
+      else if (last && next && ((last === '+' && next === '+') || (last === '-' && next === '-')))
+        append(' ')
     }
     else {
-      result += ch
+      append(ch!)
       i++
     }
   }

--- a/packages/unhead/test/unit/minify.test.ts
+++ b/packages/unhead/test/unit/minify.test.ts
@@ -51,6 +51,11 @@ describe('minifyJS', () => {
     expect(result).toContain('window.__NUXT__')
     expect(result.length).toBeLessThan(input.length)
   })
+
+  it('returns compact input unchanged', () => {
+    const input = 'globalThis.item={key:"value",count:1};'
+    expect(minifyJS(input)).toBe(input)
+  })
 })
 
 describe('minifyCSS', () => {
@@ -111,6 +116,11 @@ describe('minifyCSS', () => {
     expect(result).toContain('html,body{')
     expect(result.length).toBeLessThan(input.length)
   })
+
+  it('returns compact input unchanged', () => {
+    const input = '.item{color:red;padding:1rem}'
+    expect(minifyCSS(input)).toBe(input)
+  })
 })
 
 describe('minifyJSON', () => {
@@ -147,5 +157,30 @@ describe('minifyJSON', () => {
   fcIt.prop([fc.jsonValue()])('returns arbitrary invalid JSON unchanged', (value) => {
     const invalid = ` \n${JSON.stringify(value)} trailing`
     expect(minifyJSON(invalid)).toBe(invalid)
+  })
+})
+
+describe('large input performance', () => {
+  it.each([
+    ['JavaScript', minifyJS, 'const   item   =   { key: "value", count: 1 }; // comment\n'],
+    ['CSS', minifyCSS, '.item   { color: red; padding: calc(1rem + 2px); } /* comment */\n'],
+  ] as const)('keeps %s minification near linear', (_, minify, unit) => {
+    const small = unit.repeat(Math.ceil(32_768 / unit.length))
+    const large = unit.repeat(Math.ceil(262_144 / unit.length))
+    const fastestDuration = (input: string, attempts: number) => {
+      let fastest = Number.POSITIVE_INFINITY
+      for (let i = 0; i < attempts; i++) {
+        const start = performance.now()
+        minify(input)
+        fastest = Math.min(fastest, performance.now() - start)
+      }
+      return fastest
+    }
+
+    minify(small)
+    const smallDuration = fastestDuration(small, 5)
+    const largeDuration = fastestDuration(large, 3)
+
+    expect(largeDuration).toBeLessThan(smallDuration * 20)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Both lightweight minifiers read the last result character while building output. V8 repeatedly flattened the growing rope, making dense 1 MiB inputs take roughly 12 seconds.

This tracks the last emitted character separately and returns early for candidate-free inputs. Existing output remains byte-for-byte identical across differential fuzz tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved JavaScript and CSS minification efficiency, especially for repeated and larger inputs.
  * Compact JavaScript and CSS that require no minification are now returned immediately.
* **Bug Fixes**
  * Preserved existing minification behavior across strings, whitespace, punctuation, and formatting edge cases.
* **Tests**
  * Added regression and performance coverage to verify output consistency and near-linear scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->