### PR TITLE
perf(unhead): defer promise walk allocations

### DIFF
--- a/packages/unhead/src/plugins/promises.ts
+++ b/packages/unhead/src/plugins/promises.ts
@@ -5,6 +5,72 @@ function isThenable(v: any): v is PromiseLike<any> {
   return typeof v?.then === 'function'
 }
 
+const maxSyncPrefix = 256
+
+function walkArrayPromises(v: any[], index: number): any[] | undefined {
+  if (index === v.length)
+    return
+
+  if (index === maxSyncPrefix) {
+    // eslint-disable-next-line unicorn/no-new-array -- Bound recursion for unusually large inputs.
+    const values = new Array(v.length)
+    let hasThenable = false
+    for (; index < v.length; index++) {
+      const value = walkPromises(v[index])
+      values[index] = value
+      hasThenable ||= isThenable(value)
+    }
+    return hasThenable ? values : undefined
+  }
+
+  const value = walkPromises(v[index])
+  if (isThenable(value)) {
+    // eslint-disable-next-line unicorn/no-new-array -- Allocate only after the first thenable.
+    const values = new Array(v.length)
+    values[index] = value
+    for (let rest = index + 1; rest < v.length; rest++)
+      values[rest] = walkPromises(v[rest])
+    return values
+  }
+
+  const values = walkArrayPromises(v, index + 1)
+  if (values)
+    values[index] = value
+  return values
+}
+
+function walkObjectPromises(v: Record<string, any>, keys: string[], index: number): any[] | undefined {
+  if (index === keys.length)
+    return
+
+  if (index === maxSyncPrefix) {
+    // eslint-disable-next-line unicorn/no-new-array -- Bound recursion for unusually large inputs.
+    const values = new Array(keys.length)
+    let hasThenable = false
+    for (; index < keys.length; index++) {
+      const value = walkPromises(v[keys[index]])
+      values[index] = value
+      hasThenable ||= isThenable(value)
+    }
+    return hasThenable ? values : undefined
+  }
+
+  const value = walkPromises(v[keys[index]])
+  if (isThenable(value)) {
+    // eslint-disable-next-line unicorn/no-new-array -- Allocate only after the first thenable.
+    const values = new Array(keys.length)
+    values[index] = value
+    for (let rest = index + 1; rest < keys.length; rest++)
+      values[rest] = walkPromises(v[keys[rest]])
+    return values
+  }
+
+  const values = walkObjectPromises(v, keys, index + 1)
+  if (values)
+    values[index] = value
+  return values
+}
+
 function walkPromises(v: any): any {
   if (typeof v === 'function')
     return v
@@ -13,41 +79,17 @@ function walkPromises(v: any): any {
     return Promise.resolve(v).then(walkPromises)
 
   if (Array.isArray(v)) {
-    for (let index = 0; index < v.length; index++) {
-      const value = walkPromises(v[index])
-      if (isThenable(value)) {
-        // eslint-disable-next-line unicorn/no-new-array -- Allocate only after the first thenable.
-        const values = new Array(v.length)
-        for (let prefix = 0; prefix < index; prefix++)
-          values[prefix] = v[prefix]
-        values[index] = value
-        for (let rest = index + 1; rest < v.length; rest++)
-          values[rest] = walkPromises(v[rest])
-        return Promise.all(values)
-      }
-    }
-    return v
+    const values = walkArrayPromises(v, 0)
+    return values ? Promise.all(values) : v
   }
 
   if (v?.constructor === Object) {
     const keys = Object.keys(v)
-    for (let index = 0; index < keys.length; index++) {
-      const value = walkPromises(v[keys[index]])
-      if (isThenable(value)) {
-        // eslint-disable-next-line unicorn/no-new-array -- Allocate only after the first thenable.
-        const values = new Array(keys.length)
-        for (let prefix = 0; prefix < index; prefix++)
-          values[prefix] = v[keys[prefix]]
-        values[index] = value
-        for (let rest = index + 1; rest < keys.length; rest++)
-          values[rest] = walkPromises(v[keys[rest]])
-        return Promise.all(values).then((resolved) => {
-          const output: Record<string, any> = {}
-          for (let resolvedIndex = 0; resolvedIndex < keys.length; resolvedIndex++)
-            output[keys[resolvedIndex]] = resolved[resolvedIndex]
-          return output
-        })
-      }
+    const values = walkObjectPromises(v, keys, 0)
+    if (values) {
+      return Promise.all(values).then(resolved => Object.fromEntries(
+        keys.map((key, index) => [key, resolved[index]]),
+      ))
     }
   }
 

--- a/packages/unhead/src/plugins/promises.ts
+++ b/packages/unhead/src/plugins/promises.ts
@@ -13,17 +13,41 @@ function walkPromises(v: any): any {
     return Promise.resolve(v).then(walkPromises)
 
   if (Array.isArray(v)) {
-    const values = v.map(walkPromises)
-    return values.some(isThenable) ? Promise.all(values) : v
+    for (let index = 0; index < v.length; index++) {
+      const value = walkPromises(v[index])
+      if (isThenable(value)) {
+        // eslint-disable-next-line unicorn/no-new-array -- Allocate only after the first thenable.
+        const values = new Array(v.length)
+        for (let prefix = 0; prefix < index; prefix++)
+          values[prefix] = v[prefix]
+        values[index] = value
+        for (let rest = index + 1; rest < v.length; rest++)
+          values[rest] = walkPromises(v[rest])
+        return Promise.all(values)
+      }
+    }
+    return v
   }
 
   if (v?.constructor === Object) {
     const keys = Object.keys(v)
-    const values = keys.map(key => walkPromises(v[key]))
-    if (values.some(isThenable)) {
-      return Promise.all(values).then(resolved => Object.fromEntries(
-        keys.map((key, index) => [key, resolved[index]]),
-      ))
+    for (let index = 0; index < keys.length; index++) {
+      const value = walkPromises(v[keys[index]])
+      if (isThenable(value)) {
+        // eslint-disable-next-line unicorn/no-new-array -- Allocate only after the first thenable.
+        const values = new Array(keys.length)
+        for (let prefix = 0; prefix < index; prefix++)
+          values[prefix] = v[keys[prefix]]
+        values[index] = value
+        for (let rest = index + 1; rest < keys.length; rest++)
+          values[rest] = walkPromises(v[keys[rest]])
+        return Promise.all(values).then((resolved) => {
+          const output: Record<string, any> = {}
+          for (let resolvedIndex = 0; resolvedIndex < keys.length; resolvedIndex++)
+            output[keys[resolvedIndex]] = resolved[resolvedIndex]
+          return output
+        })
+      }
     }
   }
 

--- a/packages/unhead/test/unit/plugins/promises.test.ts
+++ b/packages/unhead/test/unit/plugins/promises.test.ts
@@ -49,6 +49,78 @@ describe('promisesPlugin', () => {
     expect(renderSSRHead(head).headTags).toContain('content="nested"')
   })
 
+  it('reads synchronous getters once before a later thenable', async () => {
+    let reads = 0
+    const head = createServerHead({
+      disableDefaults: true,
+      plugins: [PromisesPlugin],
+    })
+    head.push({
+      get title() {
+        reads++
+        return `title ${reads}`
+      },
+      meta: Promise.resolve([{ name: 'description', content: 'promised' }]),
+    } as any)
+
+    renderSSRHead(head)
+    await flushPromises()
+
+    expect(renderSSRHead(head).headTags).toContain('<title>title 1</title>')
+    expect(reads).toBe(1)
+  })
+
+  it('reads synchronous array getters once before a later thenable', async () => {
+    let reads = 0
+    const meta = [
+      { name: 'description', content: 'getter' },
+      Promise.resolve({ name: 'keywords', content: 'promised' }),
+    ]
+    Object.defineProperty(meta, 0, {
+      enumerable: true,
+      get() {
+        reads++
+        return { name: 'description', content: `getter ${reads}` }
+      },
+    })
+    const head = createServerHead({
+      disableDefaults: true,
+      plugins: [PromisesPlugin],
+    })
+    head.push({ meta } as any)
+
+    renderSSRHead(head)
+    await flushPromises()
+
+    expect(renderSSRHead(head).headTags).toContain('content="getter 1"')
+    expect(reads).toBe(1)
+  })
+
+  it('preserves an own __proto__ property after promise resolution', async () => {
+    const head = createServerHead({
+      disableDefaults: true,
+      plugins: [PromisesPlugin],
+    })
+    const input = { title: Promise.resolve('resolved') }
+    Object.defineProperty(input, '__proto__', {
+      enumerable: true,
+      value: Promise.resolve('own value'),
+    })
+    let observedInput: Record<string, unknown> | undefined
+    head.hooks.hook('entries:resolve', ({ entries }) => {
+      if (entries[0])
+        observedInput = entries[0].input as Record<string, unknown>
+    })
+    head.push(input as any)
+
+    renderSSRHead(head)
+    await flushPromises()
+    renderSSRHead(head)
+
+    expect(Object.hasOwn(observedInput!, '__proto__')).toBe(true)
+    expect(Reflect.get(observedInput!, '__proto__')).toBe('own value')
+  })
+
   it('starts sibling thenables before either sibling settles', async () => {
     const started: string[] = []
     let resolveTitle!: (value: string) => void

--- a/packages/unhead/test/unit/plugins/promises.test.ts
+++ b/packages/unhead/test/unit/plugins/promises.test.ts
@@ -10,6 +10,106 @@ async function flushPromises() {
 }
 
 describe('promisesPlugin', () => {
+  it('preserves synchronous nested input identity for later listeners', () => {
+    const head = createServerHead({
+      disableDefaults: true,
+      plugins: [PromisesPlugin],
+    })
+    const input = {
+      meta: [{ name: 'description', content: 'synchronous' }],
+      title: 'identity',
+    }
+    let observedInput: unknown
+    head.hooks.hook('entries:resolve', ({ entries }) => {
+      observedInput = entries[0].input
+    })
+    head.push(input)
+
+    const rendered = renderSSRHead(head)
+
+    expect(observedInput).toBe(input)
+    expect(rendered.headTags).toContain('<title>identity</title>')
+    expect(rendered.headTags).toContain('content="synchronous"')
+  })
+
+  it('resolves thenables nested behind promised arrays and objects', async () => {
+    const head = createServerHead({
+      disableDefaults: true,
+      plugins: [PromisesPlugin],
+    })
+    head.push({
+      meta: Promise.resolve([
+        { name: 'description', content: Promise.resolve('nested') },
+      ]),
+    } as any)
+
+    expect(renderSSRHead(head).headTags).not.toContain('description')
+    await flushPromises()
+
+    expect(renderSSRHead(head).headTags).toContain('content="nested"')
+  })
+
+  it('starts sibling thenables before either sibling settles', async () => {
+    const started: string[] = []
+    let resolveTitle!: (value: string) => void
+    let resolveContent!: (value: string) => void
+    const title = {
+      then(resolve: (value: string) => void) {
+        started.push('title')
+        resolveTitle = resolve
+      },
+    }
+    const content = {
+      then(resolve: (value: string) => void) {
+        started.push('content')
+        resolveContent = resolve
+      },
+    }
+    const head = createServerHead({
+      disableDefaults: true,
+      plugins: [PromisesPlugin],
+    })
+    head.push({
+      title,
+      meta: [{ name: 'description', content }],
+    } as any)
+
+    renderSSRHead(head)
+    await Promise.resolve()
+
+    expect(started).toEqual(['title', 'content'])
+    resolveContent('concurrent')
+    resolveTitle('siblings')
+    await flushPromises()
+    expect(renderSSRHead(head).headTags).toContain('<title>siblings</title>')
+    expect(renderSSRHead(head).headTags).toContain('content="concurrent"')
+  })
+
+  it('isolates pending promise state between concurrent server heads', async () => {
+    let resolveFirst!: (value: string) => void
+    let resolveSecond!: (value: string) => void
+    const first = createServerHead({ disableDefaults: true, plugins: [PromisesPlugin] })
+    const second = createServerHead({ disableDefaults: true, plugins: [PromisesPlugin] })
+    first.push({ title: new Promise<string>((resolve) => {
+      resolveFirst = resolve
+    }) } as any)
+    second.push({ title: new Promise<string>((resolve) => {
+      resolveSecond = resolve
+    }) } as any)
+
+    expect(renderSSRHead(first).headTags).not.toContain('<title>')
+    expect(renderSSRHead(second).headTags).not.toContain('<title>')
+
+    resolveSecond('second')
+    await flushPromises()
+    expect(renderSSRHead(first).headTags).not.toContain('<title>')
+    expect(renderSSRHead(second).headTags).toContain('<title>second</title>')
+
+    resolveFirst('first')
+    await flushPromises()
+    expect(renderSSRHead(first).headTags).toContain('<title>first</title>')
+  })
+
   it('remains enabled by the legacy entrypoints', async () => {
     expect(legacyPlugins).toContain(PromisesPlugin)
     const head = createLegacyServerHead({ disableDefaults: true })


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Most SSR inputs are synchronous, but `walkPromises` allocated result arrays for every visited array and object. This change keeps synchronous input identity and allocates result buffers only after traversal finds a thenable. It still starts sibling thenables together and keeps pending state local to each head instance.

| Rank | Opportunity | Measured result | Decision |
| --- | --- | --- | --- |
| 1 | Lazy `walkPromises` result buffers | `resolveTags` allocation fell 56.3 KiB per SSR. Sampled traversal self CPU fell from 67.1 µs to 50.4 µs. | Ship |
| 2 | Clone tags after deduplication | Clone allocation fell 5.7 KiB, but total SSR allocation fell only 1.34%. | Reject |
| 3 | Proxy or plugin aware tag copy on write | At most 27.1 KiB is available. Proxies risk tag identity, reflection, cache, and streaming behavior. | Reject |
| 4 | More normalization, deduplication, and template fast paths | The base already caches normalization and uses lazy structural sharing. Template processing allocates about 1.5 KiB. | Reject |

The same generated SSR application and base commit produced a 56.0 to 104.0 KiB allocation reduction per request across three pairs. The mean reduction was 84.2 KiB, or 3.42%. The profile pair showed `resolveTags` inclusive allocation falling from 328.4 KiB to 272.1 KiB.

Overall CPU ranged from 13.8% lower to 7.9% higher, with a 0.8% higher mean inside benchmark uncertainty. The sampled traversal hotspot fell 25.0%. The main server caller is `renderRoute → renderSSRHead → resolveTags → entries:resolve → walkPromises`; `renderDOMHead` shares the resolver on clients.

Allocation profiles measure churn, not retained heap. The full memory guard passes, but this benchmark does not establish a retained memory delta. Traversal recursion is capped at 256 values. Larger synchronous containers preserve behavior but allocate a temporary result buffer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested asynchronous values in arrays and objects.
  * Preserved already-resolved values while pending values are processed.
  * Ensured concurrent asynchronous operations resolve correctly and independently.
  * Improved server-rendered output when asynchronous data is present.
  * Preserved object properties and reliably handled synchronous accessors during resolution.

* **Tests**
  * Added coverage for nested values, concurrent resolution, state isolation, special object properties, and SSR output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->