### PR TITLE
perf(unhead): skip template parsing without tokens

### DIFF
--- a/packages/unhead/src/plugins/templateParams.ts
+++ b/packages/unhead/src/plugins/templateParams.ts
@@ -10,6 +10,12 @@ const SupportedAttrs: Partial<Record<string, string>> = {
 
 const contentAttrs: (keyof Pick<HeadTag, 'innerHTML' | 'textContent'>)[] = ['innerHTML', 'textContent']
 
+function processIfNeeded(value: string, params: TemplateParams, separator: string, isJson = false) {
+  return typeof value === 'string' && value.includes('%')
+    ? processTemplateParams(value, params, separator, isJson)
+    : value
+}
+
 export const TemplateParamsPlugin = /* @__PURE__ */ defineHeadPlugin((head) => {
   return {
     key: 'template-params',
@@ -21,7 +27,7 @@ export const TemplateParamsPlugin = /* @__PURE__ */ defineHeadPlugin((head) => {
         const sep = params.separator || '|'
         delete params.separator
         // pre-process title
-        params.pageTitle = processTemplateParams(
+        params.pageTitle = processIfNeeded(
           // find templateParams
           params.pageTitle as string || head._title || '',
           params,
@@ -33,13 +39,13 @@ export const TemplateParamsPlugin = /* @__PURE__ */ defineHeadPlugin((head) => {
           }
           const v = SupportedAttrs[tag.tag]
           if (v && typeof tag.props[v] === 'string') {
-            tag.props[v] = processTemplateParams(tag.props[v], params, sep)
+            tag.props[v] = processIfNeeded(tag.props[v], params, sep)
           }
           // everything else requires explicit opt-in
           else if (tag.processTemplateParams || tag.tag === 'titleTemplate' || tag.tag === 'title') {
             for (const p of contentAttrs) {
               if (typeof tag[p] === 'string')
-                tag[p] = processTemplateParams(tag[p], params, sep, tag.tag === 'script' && typeof tag.props.type === 'string' && tag.props.type.endsWith('json'))
+                tag[p] = processIfNeeded(tag[p], params, sep, tag.tag === 'script' && typeof tag.props.type === 'string' && tag.props.type.endsWith('json'))
             }
           }
         }
@@ -51,7 +57,7 @@ export const TemplateParamsPlugin = /* @__PURE__ */ defineHeadPlugin((head) => {
         // we need to re-process in case then user had a function as the titleTemplate
         const title: HeadTag | undefined = tagMap.get('title')
         if (title?.textContent && title.processTemplateParams !== false) {
-          title.textContent = processTemplateParams(title.textContent, head._templateParams!, head._separator!)
+          title.textContent = processIfNeeded(title.textContent, head._templateParams!, head._separator!)
         }
       },
     },

--- a/packages/unhead/test/unit/server/hot-path-invariants.test.ts
+++ b/packages/unhead/test/unit/server/hot-path-invariants.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { createHead, renderSSRHead } from '../../../src/server'
 import { normalizeEntryToTags } from '../../../src/utils'
 
-describe('SSR hot path invariants', () => {
+describe('ssr hot path invariants', () => {
   it('resolves a wrapped root function before normalizing primitive tags', () => {
     const calls: Array<string | undefined> = []
     const resolver: PropResolver = (key, value) => {

--- a/packages/unhead/test/unit/server/hot-path-invariants.test.ts
+++ b/packages/unhead/test/unit/server/hot-path-invariants.test.ts
@@ -1,0 +1,96 @@
+import type { HeadTag, PropResolver } from '../../../src/types'
+import { describe, expect, it } from 'vitest'
+import { createHead, renderSSRHead } from '../../../src/server'
+import { normalizeEntryToTags } from '../../../src/utils'
+
+describe('SSR hot path invariants', () => {
+  it('resolves a wrapped root function before normalizing primitive tags', () => {
+    const calls: Array<string | undefined> = []
+    const resolver: PropResolver = (key, value) => {
+      calls.push(key)
+      return value && typeof value === 'object' && 'current' in value ? value.current : value
+    }
+
+    const tags = normalizeEntryToTags({
+      current: () => ({
+        noscript: 'fallback',
+        style: 'body { color: red }',
+        title: 'Resolved title',
+      }),
+    }, [resolver])
+
+    expect(calls.slice(0, 2)).toEqual([undefined, undefined])
+    expect(tags).toEqual([
+      { tag: 'noscript', props: {}, innerHTML: 'fallback' },
+      { tag: 'style', props: {}, innerHTML: 'body { color: red }' },
+      { tag: 'title', props: {}, textContent: 'Resolved title' },
+    ])
+  })
+
+  it('preserves hook order, resolved tag identity, and later-entry precedence', () => {
+    const order: string[] = []
+    const resolvedTags: HeadTag[] = []
+    const head = createHead({
+      disableDefaults: true,
+      hooks: {
+        'entries:resolve': () => order.push('entries:resolve'),
+        'entries:normalize': () => order.push('entries:normalize'),
+        'tags:beforeResolve': ({ tags }) => {
+          order.push('tags:beforeResolve')
+          resolvedTags.push(tags[0])
+        },
+        'tags:resolve': ({ tags }) => {
+          order.push('tags:resolve')
+          resolvedTags.push(tags[0])
+        },
+        'tags:afterResolve': ({ tags }) => {
+          order.push('tags:afterResolve')
+          resolvedTags.push(tags[0])
+        },
+        'ssr:render': ({ tags }) => {
+          order.push('ssr:render')
+          resolvedTags.push(tags[0])
+        },
+        'ssr:rendered': ({ tags }) => {
+          order.push('ssr:rendered')
+          resolvedTags.push(tags[0])
+        },
+      },
+    })
+    head.push({ meta: [{ name: 'description', content: 'first' }] })
+    head.push({ meta: [{ name: 'description', content: 'second' }] })
+
+    const result = renderSSRHead(head)
+
+    expect(order).toEqual([
+      'entries:resolve',
+      'entries:normalize',
+      'entries:normalize',
+      'tags:beforeResolve',
+      'tags:resolve',
+      'tags:afterResolve',
+      'ssr:render',
+      'ssr:rendered',
+    ])
+    expect(resolvedTags.every(tag => tag === resolvedTags[0])).toBe(true)
+    expect(result.headTags).toBe('<meta name="description" content="second">')
+  })
+
+  it('filters unsafe attributes added at the SSR render boundary', () => {
+    const inherited = { onload: 'alert(1)' }
+    const head = createHead({
+      disableDefaults: true,
+      hooks: {
+        'ssr:render': ({ tags }) => {
+          const props = Object.assign(Object.create(inherited), tags[0].props)
+          props['bad name'] = 'unsafe'
+          props.title = 'safe" onload="alert(1)'
+          tags[0].props = props
+        },
+      },
+    })
+    head.push({ meta: [{ name: 'description', content: 'safe' }] })
+
+    expect(renderSSRHead(head).headTags).toBe('<meta name="description" content="safe" title="safe&quot; onload=&quot;alert(1)">')
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

`TemplateParamsPlugin` called `processTemplateParams` for every supported string, even when it had no `%` token. Move the cheap token check into a small dispatch helper so V8 can bypass the larger parser function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template parameter handling so values without template placeholders remain unchanged.
  * Preserved expected behavior for page titles, attributes, content, and resolved titles.

* **Tests**
  * Added server-rendering coverage for tag resolution, hook ordering, precedence, and attribute filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->