### PR TITLE
perf: reduce client and server bundle size

### DIFF
--- a/packages/unhead/src/client/renderDOMHead.ts
+++ b/packages/unhead/src/client/renderDOMHead.ts
@@ -114,32 +114,22 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
     }
     state._s = {}
     const renderState = state
+    const previous = renderState._p
 
-    function track(id: string, scope: string, fn: () => void, fresh?: boolean) {
-      const k = `${id}:${scope}`
+    function track(key: string, fn: () => void, fresh?: boolean) {
       // reuse the previous render's cleanup for a stable key: same $el/attr/class means an identical
       // closure, so this avoids reallocating ~one closure per tracked prop every frame. `fresh` opts
       // out for content closures, which capture a value that can change between renders.
-      renderState._s[k] = (!fresh && renderState._p[k]) || fn
-      delete renderState._p[k]
-    }
-
-    // Reclaim the previous render's cleanup for a key (and remove it from the pool), or undefined.
-    // Used as `_s[key] = reclaim(key) || (() => ...)` so the cleanup closure sits on the right of
-    // `||` and is only allocated when the key is new — a stable re-render allocates no closures.
-    function reclaim(key: string): (() => void) | undefined {
-      const prev = renderState._p[key]
-      delete renderState._p[key]
-      return prev
+      renderState._s[key] = (!fresh && previous[key]) || fn
+      delete previous[key]
     }
 
     function trackEvent(id: string, k: string, ev: string, source: DomEventHandler, $el: Element, target: EventTarget) {
-      const scope = `event:${k}`
-      const key = `${id}:${scope}`
+      const key = `${id}:event:${k}`
       const prev = renderState._l.get(key)
       // same target/type/source: keep the existing listener, just re-track its cleanup
       if (prev && prev[0] === target && prev[1] === ev && prev[2] === source) {
-        track(id, scope, prev[4])
+        track(key, prev[4])
         return
       }
       prev?.[4]()
@@ -156,7 +146,7 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
       renderState._l.set(key, [target, ev, source, handler, cleanup])
       $el.setAttribute(dk, '')
       // fresh: this cleanup removes a brand-new listener, the stale _p entry points at the old one
-      track(id, scope, cleanup, true)
+      track(key, cleanup, true)
     }
 
     function trackCtx({ id, $el, tag }: DomRenderTagContext & { $el: Element }) {
@@ -170,7 +160,7 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
         if (text != null && text !== '') {
           if (text !== $el.textContent)
             $el.textContent = text as string
-          track(id, 'text', () => {
+          track(`${id}:text`, () => {
             if ($el.textContent === text)
               $el.textContent = ''
           }, true)
@@ -179,16 +169,16 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
         if (html != null && html !== '') {
           if (html !== $el.innerHTML)
             $el.innerHTML = html as string
-          track(id, 'html', () => {
+          track(`${id}:html`, () => {
             if ($el.innerHTML === html)
               $el.innerHTML = ''
           }, true)
         }
         const elKey = `${id}:el`
-        renderState._s[elKey] = reclaim(elKey) || (() => {
+        track(elKey, previous[elKey] || (() => {
           $el?.remove()
           renderState._e.delete(id)
-        })
+        }))
       }
       for (const k in tag.props) {
         const v = tag.props[k]
@@ -203,7 +193,7 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
         if (k === 'class' && v) {
           for (const c of v as Iterable<string>) {
             const key = `${ck}:${c}`
-            renderState._s[key] = reclaim(key) || (() => $el.classList.remove(c))
+            track(key, previous[key] || (() => $el.classList.remove(c)))
             if (!$el.classList.contains(c))
               $el.classList.add(c)
           }
@@ -211,14 +201,14 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
         else if (k === 'style' && v) {
           for (const [sk, sv] of v as Iterable<[string, string]>) {
             const key = `${ck}:${sk}`
-            renderState._s[key] = reclaim(key) || (() => ($el as HTMLElement).style.removeProperty(sk))
+            track(key, previous[key] || (() => ($el as HTMLElement).style.removeProperty(sk)))
             ;($el as HTMLElement).style.setProperty(sk, sv)
           }
         }
         else if (v !== false as any && v !== null) {
           if ($el.getAttribute(k) !== v as any)
             $el.setAttribute(k, v === true as any ? '' : String(v))
-          renderState._s[ck] = reclaim(ck) || (() => $el.removeAttribute(k))
+          track(ck, previous[ck] || (() => $el.removeAttribute(k)))
         }
       }
     }
@@ -239,7 +229,7 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
       tags.push(ctx)
       if (tag.tag === 'title') {
         dom.title = tag.textContent as string
-        track('title', '', () => dom.title = renderState._t)
+        track('title:', () => dom.title = renderState._t)
         continue
       }
       ctx.$el = renderState._e.get(id)
@@ -259,8 +249,8 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
       dom.body.insertBefore(frag.bodyOpen, dom.body.firstChild)
     if (frag.bodyClose)
       dom.body.appendChild(frag.bodyClose)
-    for (const k in renderState._p)
-      renderState._p[k]()
+    for (const k in previous)
+      previous[k]()
     head._dom = renderState
     didRender = true
     callHook(head, 'dom:rendered', { renders: tags })

--- a/packages/unhead/src/server/createHead.ts
+++ b/packages/unhead/src/server/createHead.ts
@@ -1,6 +1,6 @@
 import type { HookableCore } from 'hookable'
 import type { CreateServerHeadOptions, HeadTag, PropResolver, ResolvableHead, ServerHeadHooks, SSRHeadPayload, Unhead } from '../types'
-import { createUnhead, registerPlugin } from '../unhead'
+import { createUnhead } from '../unhead'
 import { dedupeKey, hashTag } from '../utils/dedupe'
 import { createHooks } from '../utils/hooks'
 import { normalizeEntryToTags } from '../utils/normalize'
@@ -101,8 +101,6 @@ export function createHead<T = ResolvableHead>(options: CreateServerHeadOptions 
   const hooks = createHooks<ServerHeadHooks>(options.hooks)
   const head = core as ServerUnhead<T>
   head.hooks = hooks
-  head.render = () => render(head)
-  head.use = p => registerPlugin(head, p)
 
   // Register plugins
   options.plugins?.forEach(p => head.use(p))

--- a/packages/unhead/src/utils/meta.ts
+++ b/packages/unhead/src/utils/meta.ts
@@ -3,12 +3,10 @@ import { MetaTagsArrayable } from './const'
 
 export type MetaKeyType = 'name' | 'property' | 'http-equiv'
 
-const NAMESPACES = /* @__PURE__ */ {
-  META: new Set(['twitter', 'fediverse']),
-  OG: new Set(['og', 'book', 'article', 'profile', 'fb', 'payment']),
-  MEDIA: new Set(['ogImage', 'ogVideo', 'ogAudio', 'twitterImage']),
-  HTTP_EQUIV: new Set(['contentType', 'defaultStyle', 'xUaCompatible']),
-} as const
+const META_NAMESPACES: readonly string[] = ['twitter', 'fediverse']
+const PROPERTY_NAMESPACES: readonly string[] = ['og', 'book', 'article', 'profile', 'fb', 'payment']
+const MEDIA_KEYS: readonly string[] = ['ogImage', 'ogVideo', 'ogAudio', 'twitterImage']
+const HTTP_EQUIV_KEYS: readonly string[] = ['contentType', 'defaultStyle', 'xUaCompatible']
 
 const META_ALIASES: Record<string, string> = /* @__PURE__ */ {
   articleExpirationTime: 'article:expiration_time',
@@ -85,7 +83,7 @@ function fixKeyCase(key: string): string {
   return prefixIndex === -1
     ? updated
     : (
-        NAMESPACES.META.has(updated.slice(0, prefixIndex)) || NAMESPACES.OG.has(updated.slice(0, prefixIndex))
+        META_NAMESPACES.includes(updated.slice(0, prefixIndex)) || PROPERTY_NAMESPACES.includes(updated.slice(0, prefixIndex))
           ? key.replace(CAPS_RE, ':$1').toLowerCase()
           : updated
       )
@@ -142,7 +140,7 @@ function handleObjectEntry(key: string, value: Record<string, any>): UnheadMeta[
 }
 
 export function resolveMetaKeyType(key: string): MetaKeyType {
-  if (MetaPackingSchema[key]?.metaKey === 'http-equiv' || NAMESPACES.HTTP_EQUIV.has(key)) {
+  if (MetaPackingSchema[key]?.metaKey === 'http-equiv' || HTTP_EQUIV_KEYS.includes(key)) {
     return 'http-equiv'
   }
 
@@ -150,7 +148,7 @@ export function resolveMetaKeyType(key: string): MetaKeyType {
   const colonIndex = fixed.indexOf(':')
   return colonIndex === -1
     ? 'name'
-    : NAMESPACES.OG.has(fixed.slice(0, colonIndex))
+    : PROPERTY_NAMESPACES.includes(fixed.slice(0, colonIndex))
       ? 'property'
       : 'name'
 }
@@ -208,7 +206,7 @@ export function unpackMeta<T extends MetaFlat>(input: T): UnheadMeta[] {
     }
 
     if (typeof value === 'object' && value) {
-      if (NAMESPACES.MEDIA.has(key)) {
+      if (MEDIA_KEYS.includes(key)) {
         const prefix = key.startsWith('twitter') ? 'twitter' : 'og'
         const type = key.replace(OG_TWITTER_RE, '').toLowerCase()
         const metaKey = prefix === 'twitter' ? 'name' : 'property'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Bundle builds were paying for duplicate DOM cleanup paths, redundant server method wrappers, and Set overhead on lists with at most six keys. The tracked bundles drop 34 to 158 raw bytes and 17 to 54 gzip bytes; stable DOM rerenders still reuse cleanup closures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of outdated document head elements after updates.
  * Preserved consistent handling of metadata, properties, media values, and HTTP-equivalent attributes.

* **Refactor**
  * Streamlined internal document head rendering and metadata classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->