### PR TITLE
perf(unhead): optimize SSR rendering hot paths

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -61,7 +61,7 @@ jobs:
           cp -r bench/bundle/dist /tmp/base-dist
           # measure base perf with the PR's harness against the base-built packages;
           # run from /tmp so the working tree stays clean across the checkout back
-          node --expose-gc /tmp/perf-ci.mjs > /tmp/base-perf.json || echo '{}' > /tmp/base-perf.json
+          node --expose-gc /tmp/perf-ci.mjs > /tmp/base-perf.json
           pnpm exec vitest bench bench/unplugin-transform.bench.ts --config bench/vitest.config.ts --run --outputJson /tmp/base-transform-perf.json
           # the base pnpm install may have rewritten the lockfile; discard before switching back
           git checkout -f -
@@ -75,7 +75,7 @@ jobs:
           pnpm test:vue-bundle-size
           pnpm test:react-bundle-size
           pnpm test:schema-org-bundle-size
-          node --expose-gc bench/perf-ci.mjs > /tmp/pr-perf.json || echo '{}' > /tmp/pr-perf.json
+          node --expose-gc bench/perf-ci.mjs > /tmp/pr-perf.json
           pnpm exec vitest bench bench/unplugin-transform.bench.ts --config bench/vitest.config.ts --run --outputJson /tmp/pr-transform-perf.json
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/bench/bundle/perf-report.test.ts
+++ b/bench/bundle/perf-report.test.ts
@@ -44,7 +44,26 @@ describe('parseVitestBenchmarks', () => {
 })
 
 describe('renderPerfReport allocation noise gate', () => {
-  it('keeps allocation changes within the combined RME out of the verdict', () => {
+  it('keeps allocation changes within the combined 95% confidence interval out of the verdict', () => {
+    const report = renderPerfReport(
+      {
+        benches: [
+          { id: 'alloc', name: 'Allocated / render', kind: 'alloc', value: 100_000, rme: 8 },
+        ],
+      },
+      {
+        benches: [
+          { id: 'alloc', name: 'Allocated / render', kind: 'alloc', value: 108_000, rme: 8 },
+        ],
+      },
+    )
+
+    expect(report).toContain('No significant change')
+    expect(report).toContain('~ +8.0%')
+    expect(report).not.toContain('slower')
+  })
+
+  it('does not double an RME that already represents a 95% confidence interval', () => {
     const report = renderPerfReport(
       {
         benches: [
@@ -58,9 +77,8 @@ describe('renderPerfReport allocation noise gate', () => {
       },
     )
 
-    expect(report).toContain('No significant change')
-    expect(report).toContain('~ noise')
-    expect(report).not.toContain('slower')
+    expect(report).toContain('1 slower')
+    expect(report).toContain('+11.7 KiB (+12.0%)')
   })
 
   it('reports allocation changes that exceed the absolute and RME gates', () => {

--- a/bench/bundle/perf-report.ts
+++ b/bench/bundle/perf-report.ts
@@ -1,8 +1,8 @@
 // Renders the directional Performance section. A change is only surfaced past a gate:
-//  - time:  |Δ| > max(5%, 2× combined relative margin of error). Wall/CPU time is
-//           noisy on shared runners, so the gate is RME-bound; small gains stay hidden.
-//  - alloc: |Δ| > max(2%, 1 KiB). Synchronous bytes allocated per render is
-//           near-deterministic, so a tight gate surfaces gains time can't show.
+//  - time:  |Δ| > max(5% of base, combined 95% confidence interval). Wall/CPU
+//           time is noisy on shared runners, so the gate is confidence-bound.
+//  - alloc: |Δ| > max(2% of base, 1 KiB, combined 95% confidence interval).
+//           Synchronous allocated bytes are stable enough for a tight gate.
 //  - count: |Δ| > max(2%, 0.5). DOM mutations per CSR navigation; deterministic,
 //           so a half-op change is real (a renderer touching more of the DOM).
 // Noisy metrics are `informational`: shown for reference but excluded from the verdict.
@@ -108,18 +108,19 @@ function classify(pr: PerfBench, base?: PerfBench): Row {
     return { bench: pr, base, status: 'new', deltaPct: 0 }
   const delta = pr.value - base.value
   const deltaPct = base.value !== 0 ? (delta / Math.abs(base.value)) * 100 : 0
+  const baseCi = Math.abs(base.value) * (base.rme || 0) / 100
+  const prCi = Math.abs(pr.value) * (pr.rme || 0) / 100
+  const combinedCi = Math.hypot(baseCi, prCi)
   let significant: boolean
   if (pr.kind === 'time') {
-    const threshold = Math.max(TIME_FLOOR_PCT, 2 * ((base.rme || 0) + (pr.rme || 0)))
-    significant = Math.abs(deltaPct) > threshold
+    significant = Math.abs(delta) > Math.max(Math.abs(base.value) * TIME_FLOOR_PCT / 100, combinedCi)
   }
   else if (pr.kind === 'count') {
     // a zero baseline (0 -> N) has no meaningful percentage; fall back to the absolute floor
     significant = Math.abs(delta) > COUNT_FLOOR_UNITS && (base.value === 0 || Math.abs(deltaPct) > COUNT_FLOOR_PCT)
   }
   else {
-    const threshold = Math.max(ALLOC_FLOOR_PCT, 2 * ((base.rme || 0) + (pr.rme || 0)))
-    significant = Math.abs(delta) > ALLOC_FLOOR_BYTES && (base.value === 0 || Math.abs(deltaPct) > threshold)
+    significant = Math.abs(delta) > Math.max(ALLOC_FLOOR_BYTES, Math.abs(base.value) * ALLOC_FLOOR_PCT / 100, combinedCi)
   }
   if (!significant)
     return { bench: pr, base, status: 'same', deltaPct }
@@ -132,9 +133,9 @@ function deltaCell(row: Row): string {
     return '🆕 new'
   // informational metrics report their delta neutrally, never as slower/faster
   if (row.bench.informational)
-    return row.status === 'same' ? '~ noise' : `ℹ️ ${fmtPct(row.deltaPct)}`
+    return row.status === 'same' ? `~ ${fmtPct(row.deltaPct)}` : `ℹ️ ${fmtPct(row.deltaPct)}`
   if (row.status === 'same')
-    return '~ noise'
+    return `~ ${fmtPct(row.deltaPct)}`
   const emoji = row.status === 'slower' ? '🔴' : '🟢'
   if (row.bench.kind === 'time')
     return `${emoji} ${fmtPct(row.deltaPct)}`

--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -51,6 +51,28 @@ function renderMediumSsrHead() {
   return renderSSRHead(head, { omitLineBreaks: true })
 }
 
+function createCachedDuplicateHeavyRenderer() {
+  const head = createHead({ disableDefaults: true })
+  for (let i = 0; i < 100; i++) {
+    head.push({
+      htmlAttrs: {
+        class: `theme-${i}`,
+        [`data-benchmark-${i}`]: `${i}`,
+      },
+    })
+  }
+  head.push({
+    meta: Array.from({ length: 100 }, (_, i) => ({
+      property: 'og:image',
+      content: `/images/${i}.png`,
+    })),
+  })
+
+  const options = { omitLineBreaks: true }
+  renderSSRHead(head, options)
+  return () => renderSSRHead(head, options)
+}
+
 function createCachedSchemaOrgRenderer() {
   const head = createHead({ disableDefaults: true })
   head.push({
@@ -391,6 +413,9 @@ async function csrBenches() {
 
 const times = measureTimes(renderMediumSsrHead)
 const alloc = await measureAlloc(renderMediumSsrHead)
+const renderCachedDuplicateHeavyHead = createCachedDuplicateHeavyRenderer()
+const duplicateHeavyTimes = measureTimes(renderCachedDuplicateHeavyHead, { reps: 30, runs: 250 })
+const duplicateHeavyAlloc = await measureAlloc(renderCachedDuplicateHeavyHead)
 const renderCachedSchemaOrgHead = createCachedSchemaOrgRenderer()
 const schemaOrgTimes = measureTimes(renderCachedSchemaOrgHead, { reps: 30, runs: 120 })
 const schemaOrgAlloc = await measureAlloc(renderCachedSchemaOrgHead)
@@ -400,6 +425,9 @@ const result = {
     { id: 'ssr-medium-cpu', name: 'SSR render (CPU)', kind: 'time', value: times.cpu.value, rme: times.cpu.rme },
     { id: 'ssr-medium-wall', name: 'SSR render (wall)', kind: 'time', value: times.wall.value, rme: times.wall.rme, informational: true },
     { id: 'ssr-medium-alloc', name: 'SSR allocated / render', kind: 'alloc', value: alloc.value, rme: alloc.rme },
+    { id: 'ssr-duplicate-heavy-cached-cpu', name: 'Duplicate-heavy cached render (CPU)', kind: 'time', value: duplicateHeavyTimes.cpu.value, rme: duplicateHeavyTimes.cpu.rme },
+    { id: 'ssr-duplicate-heavy-cached-wall', name: 'Duplicate-heavy cached render (wall)', kind: 'time', value: duplicateHeavyTimes.wall.value, rme: duplicateHeavyTimes.wall.rme, informational: true },
+    { id: 'ssr-duplicate-heavy-cached-alloc', name: 'Duplicate-heavy cached allocated / render', kind: 'alloc', value: duplicateHeavyAlloc.value, rme: duplicateHeavyAlloc.rme },
     { id: 'schema-org-cached-cpu', name: 'Schema.org cached render (CPU)', kind: 'time', value: schemaOrgTimes.cpu.value, rme: schemaOrgTimes.cpu.rme },
     { id: 'schema-org-cached-wall', name: 'Schema.org cached render (wall)', kind: 'time', value: schemaOrgTimes.wall.value, rme: schemaOrgTimes.wall.rme, informational: true },
     { id: 'schema-org-cached-alloc', name: 'Schema.org cached allocated / render', kind: 'alloc', value: schemaOrgAlloc.value, rme: schemaOrgAlloc.rme },

--- a/bench/resolve-tags.bench.ts
+++ b/bench/resolve-tags.bench.ts
@@ -39,6 +39,24 @@ function createBenchHead(count: number, plugin?: keyof typeof benchPlugins) {
   return head
 }
 
+function createMergeBenchHead(count: number) {
+  const head = createHead({ disableDefaults: true })
+  for (let i = 0; i < count; i++) {
+    head.push({
+      htmlAttrs: { [`data-entry-${i}`]: String(i) },
+    })
+  }
+  return head
+}
+
+function createArrayableMetaBenchHead(count: number) {
+  const head = createHead({ disableDefaults: true })
+  head.push({
+    meta: Array.from({ length: count }, (_, i) => ({ property: 'og:image', content: `/image-${i}.png` })),
+  })
+  return head
+}
+
 describe('resolveTags many entries, first render', () => {
   bench('20 entries, no plugins', () => {
     createBenchHead(20).render()
@@ -75,5 +93,15 @@ describe('resolveTags many entries, cached render', () => {
 
   bench('20 entries, flatMeta plugin', () => {
     flatMeta.render()
+  })
+})
+
+describe('resolveTags duplicate scaling', () => {
+  bench('100 merged attribute entries', () => {
+    createMergeBenchHead(100).render()
+  })
+
+  bench('100 arrayable meta tags', () => {
+    createArrayableMetaBenchHead(100).render()
   })
 })

--- a/packages/schema-org/src/core/define.ts
+++ b/packages/schema-org/src/core/define.ts
@@ -1,5 +1,16 @@
 import type { SchemaOrgNodeDefinition, Thing } from '../types'
 
+const builtinSchemaNodes = new WeakSet<object>()
+
+export function markBuiltinSchemaNode<T extends object>(node: T): T {
+  builtinSchemaNodes.add(node)
+  return node
+}
+
+export function isBuiltinSchemaNode(node: object): boolean {
+  return builtinSchemaNodes.has(node)
+}
+
 /* @__NO_SIDE_EFFECTS__ */
 export function defineSchemaOrgResolver<T extends Thing, CastInput = T>(schema: SchemaOrgNodeDefinition<T, CastInput>) {
   return schema

--- a/packages/schema-org/src/plugin.ts
+++ b/packages/schema-org/src/plugin.ts
@@ -1,12 +1,125 @@
-import type { HeadPlugin, HeadTag, Unhead } from 'unhead/types'
+import type { HeadEntry, HeadPlugin, HeadTag, Unhead } from 'unhead/types'
 import type { SchemaOrgGraph } from './core/graph'
 import type { MetaInput, ResolvedMeta } from './types'
 import { defineHeadPlugin, TemplateParamsPlugin } from 'unhead/plugins'
 import { hasOwn, processTemplateParams } from 'unhead/utils'
+import { isBuiltinSchemaNode } from './core/define'
 import {
   createSchemaOrgGraph,
 } from './core/graph'
 import { resolveMeta } from './core/resolve'
+
+type InputSnapshot
+  = | { _tag: 'value', value: unknown }
+    | { _tag: 'date', value: number }
+    | { _tag: 'array', keys: string[], length: number, values: InputSnapshot[] }
+    | { _tag: 'object', keys: string[], values: InputSnapshot[] }
+type EntrySnapshot = [entry: HeadEntry<any>, input: unknown, tags: HeadTag[] | undefined, value: InputSnapshot]
+type GraphCache = { _tag: 'empty' } | {
+  _tag: 'ready'
+  entries: EntrySnapshot[]
+  html: string
+  minify: boolean
+  year: number
+}
+const StaticHook = Symbol.for('unhead:static-hook')
+const TagMutationHook = /^(?:entries:(?:resolve|normalize)|tags?:)/
+
+function hooksAreCacheable(head: Unhead, ownHooks: Set<(...args: any[]) => any>): boolean {
+  const hooks = (head.hooks as any)?._hooks || {}
+  for (const name in hooks) {
+    if (!TagMutationHook.test(name))
+      continue
+    for (const hook of hooks[name] || []) {
+      if (!ownHooks.has(hook) && !(hook as any)[StaticHook])
+        return false
+    }
+  }
+  return true
+}
+
+function hasDynamicInput(value: unknown, seen = new WeakSet<object>()): boolean {
+  if (typeof value === 'function')
+    return true
+  if (!value || typeof value !== 'object')
+    return false
+  if (seen.has(value))
+    return true
+  if (!(Array.isArray(value) || value instanceof Date || Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null))
+    return true
+  seen.add(value)
+  if (Object.hasOwn(value, '_resolver') && !isBuiltinSchemaNode(value))
+    return true
+  for (const key in value) {
+    if (key !== '_resolver' && Object.hasOwn(value, key) && hasDynamicInput((value as Record<string, unknown>)[key], seen))
+      return true
+  }
+  return false
+}
+
+function snapshotInput(value: unknown): InputSnapshot {
+  if (!value || typeof value !== 'object')
+    return { _tag: 'value', value }
+  if (value instanceof Date)
+    return { _tag: 'date', value: value.getTime() }
+  const keys = Object.keys(value)
+  const values = keys.map((key) => {
+    const child = (value as Record<string, unknown>)[key]
+    return key === '_resolver' ? { _tag: 'value', value: child } as const : snapshotInput(child)
+  })
+  return Array.isArray(value)
+    ? { _tag: 'array', keys, length: value.length, values }
+    : { _tag: 'object', keys, values }
+}
+
+function inputMatches(value: unknown, snapshot: InputSnapshot): boolean {
+  if (snapshot._tag === 'value')
+    return Object.is(value, snapshot.value)
+  if (snapshot._tag === 'date')
+    return value instanceof Date && value.getTime() === snapshot.value
+  if (!value || typeof value !== 'object' || Array.isArray(value) !== (snapshot._tag === 'array'))
+    return false
+  if (snapshot._tag === 'array' && (value as unknown[]).length !== snapshot.length)
+    return false
+  let keyCount = 0
+  for (const key in value) {
+    if (Object.hasOwn(value, key))
+      keyCount++
+  }
+  if (keyCount !== snapshot.keys.length)
+    return false
+  for (let i = 0; i < snapshot.keys.length; i++) {
+    const key = snapshot.keys[i]
+    if (!Object.hasOwn(value, key)
+      || !inputMatches((value as Record<string, unknown>)[key], snapshot.values[i])) {
+      return false
+    }
+  }
+  return true
+}
+
+function captureEntries(entries: HeadEntry<any>[]): EntrySnapshot[] {
+  return entries.map(entry => [entry, entry.input, entry._tags, snapshotInput(entry.input)])
+}
+
+function entriesMatch(entries: HeadEntry<any>[], snapshot: EntrySnapshot[]): boolean {
+  if (entries.length !== snapshot.length)
+    return false
+  for (let i = 0; i < entries.length; i++) {
+    if (entries[i] !== snapshot[i][0]
+      || entries[i].input !== snapshot[i][1]
+      || entries[i]._tags !== snapshot[i][2]
+      || !inputMatches(entries[i].input, snapshot[i][3])) {
+      return false
+    }
+  }
+  return true
+}
+
+function hasDynamicEntries(entries: HeadEntry<any>[]): boolean {
+  const seen = new WeakSet<object>()
+  return entries.some(entry => hasDynamicInput(entry.input, seen))
+}
 
 // Simple merge utility that recursively merges objects
 function mergeObjects(target: any, source: any): any {
@@ -38,12 +151,16 @@ export interface PluginSchemaOrgOptions {
   trailingSlash?: boolean
 }
 
-export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () => Partial<MetaInput> = () => ({}), options?: PluginSchemaOrgOptions) {
+export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta?: () => Partial<MetaInput>, options?: PluginSchemaOrgOptions) {
   config = resolveMeta({ ...config })
   let graph: SchemaOrgGraph
   let resolvedMeta: Partial<ResolvedMeta> = {}
+  let cache: GraphCache = { _tag: 'empty' }
+  let entries: HeadEntry<any>[] = []
+  let reuseGraph = false
   return defineHeadPlugin((head: Unhead): HeadPlugin => {
     head.use(TemplateParamsPlugin)
+    const ownHooks = new Set<(...args: any[]) => any>()
     function collectTag(tag: HeadTag) {
       if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && tag.props.nodes) {
         // this is a bit expensive, load in seperate chunk
@@ -95,10 +212,22 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
         }
       }
     }
-    return {
+    const plugin: HeadPlugin = {
       key: 'schema-org',
       hooks: {
         'entries:resolve': (ctx) => {
+          entries = ctx.entries
+          // eslint-disable-next-line node/prefer-global/process
+          const minify = options?.minify || process.env.NODE_ENV === 'production'
+          const year = new Date().getFullYear()
+          reuseGraph = hooksAreCacheable(head, ownHooks)
+            && cache._tag === 'ready'
+            && cache.minify === minify
+            && cache.year === year
+            && entriesMatch(entries, cache.entries)
+          if (reuseGraph)
+            return
+          cache = { _tag: 'empty' }
           graph = graph || createSchemaOrgGraph()
           // Reset graph nodes each cycle so disposed entries don't leave stale nodes.
           graph.nodes = []
@@ -116,6 +245,8 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
           }
         },
         'entries:normalize': ({ tags }) => {
+          if (reuseGraph)
+            return
           for (const tag of tags)
             collectTag(tag)
         },
@@ -125,6 +256,10 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
             const tag = ctx.tags[k]
             if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && tag.props.nodes) {
               delete tag.props.nodes
+              if (cache._tag === 'ready' && reuseGraph) {
+                tag.innerHTML = cache.html
+                return
+              }
               const resolvedGraph = graph.resolveGraph({ ...(meta?.() || {}), ...config, ...resolvedMeta })
               if (!resolvedGraph.length) {
                 // removes the tag
@@ -142,6 +277,18 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
                   return processTemplateParams(value, head._templateParams!, head._separator!)
                 return value
               }, minify ? 0 : 2)
+              if (!meta
+                && !head.resolvedOptions.propResolvers?.length
+                && hooksAreCacheable(head, ownHooks)
+                && !hasDynamicEntries(entries)) {
+                cache = {
+                  _tag: 'ready',
+                  entries: captureEntries(entries),
+                  html: tag.innerHTML,
+                  minify,
+                  year: new Date().getFullYear(),
+                }
+              }
               return
             }
           }
@@ -171,5 +318,7 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
         },
       },
     }
+    for (const hook of Object.values(plugin.hooks || {})) ownHooks.add(hook)
+    return plugin
   }, 'schema-org')
 }

--- a/packages/schema-org/src/plugin.ts
+++ b/packages/schema-org/src/plugin.ts
@@ -14,7 +14,10 @@ type InputSnapshot
     | { _tag: 'date', value: number }
     | { _tag: 'array', keys: string[], length: number, values: InputSnapshot[] }
     | { _tag: 'object', keys: string[], values: InputSnapshot[] }
-type EntrySnapshot = [entry: HeadEntry<any>, input: unknown, tags: HeadTag[] | undefined, value: InputSnapshot]
+type GraphDependencySnapshot
+  = | { _tag: 'nodes', tag: HeadTag, value: unknown, snapshot: InputSnapshot }
+    | { _tag: 'templateParams', tag: HeadTag, value: unknown, snapshot: InputSnapshot }
+type EntrySnapshot = [entry: HeadEntry<any>, input: unknown, tags: HeadTag[] | undefined, dependencies: GraphDependencySnapshot[], inputSnapshot?: InputSnapshot]
 type GraphCache = { _tag: 'empty' } | {
   _tag: 'ready'
   entries: EntrySnapshot[]
@@ -98,8 +101,30 @@ function inputMatches(value: unknown, snapshot: InputSnapshot): boolean {
   return true
 }
 
+function captureGraphDependencies(tags: HeadTag[] | undefined): GraphDependencySnapshot[] {
+  const dependencies: GraphDependencySnapshot[] = []
+  for (const tag of tags || []) {
+    if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && tag.props.nodes) {
+      dependencies.push({ _tag: 'nodes', tag, value: tag.props.nodes, snapshot: snapshotInput(tag.props.nodes) })
+    }
+    else if (tag.tag === 'templateParams') {
+      dependencies.push({ _tag: 'templateParams', tag, value: tag.props, snapshot: snapshotInput(tag.props) })
+    }
+  }
+  return dependencies
+}
+
 function captureEntries(entries: HeadEntry<any>[]): EntrySnapshot[] {
-  return entries.map(entry => [entry, entry.input, entry._tags, snapshotInput(entry.input)])
+  return entries.map((entry) => {
+    const dependencies = captureGraphDependencies(entry._tags)
+    return [
+      entry,
+      entry.input,
+      entry._tags,
+      dependencies,
+      dependencies.some(dependency => dependency._tag === 'nodes') ? snapshotInput(entry.input) : undefined,
+    ]
+  })
 }
 
 function entriesMatch(entries: HeadEntry<any>[], snapshot: EntrySnapshot[]): boolean {
@@ -108,9 +133,16 @@ function entriesMatch(entries: HeadEntry<any>[], snapshot: EntrySnapshot[]): boo
   for (let i = 0; i < entries.length; i++) {
     if (entries[i] !== snapshot[i][0]
       || entries[i].input !== snapshot[i][1]
-      || entries[i]._tags !== snapshot[i][2]
-      || !inputMatches(entries[i].input, snapshot[i][3])) {
+      || entries[i]._tags !== snapshot[i][2]) {
       return false
+    }
+    const inputSnapshot = snapshot[i][4]
+    if (inputSnapshot && !inputMatches(entries[i].input, inputSnapshot))
+      return false
+    for (const dependency of snapshot[i][3]) {
+      const value = dependency._tag === 'nodes' ? dependency.tag.props.nodes : dependency.tag.props
+      if (value !== dependency.value || !inputMatches(value, dependency.snapshot))
+        return false
     }
   }
   return true
@@ -153,13 +185,13 @@ export interface PluginSchemaOrgOptions {
 
 export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta?: () => Partial<MetaInput>, options?: PluginSchemaOrgOptions) {
   config = resolveMeta({ ...config })
-  let graph: SchemaOrgGraph
-  let resolvedMeta: Partial<ResolvedMeta> = {}
-  let cache: GraphCache = { _tag: 'empty' }
-  let entries: HeadEntry<any>[] = []
-  let reuseGraph = false
   return defineHeadPlugin((head: Unhead): HeadPlugin => {
     head.use(TemplateParamsPlugin)
+    let graph: SchemaOrgGraph
+    let resolvedMeta: Partial<ResolvedMeta> = {}
+    let cache: GraphCache = { _tag: 'empty' }
+    let entries: HeadEntry<any>[] = []
+    let reuseGraph = false
     const ownHooks = new Set<(...args: any[]) => any>()
     function collectTag(tag: HeadTag) {
       if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && tag.props.nodes) {

--- a/packages/schema-org/src/runtime.ts
+++ b/packages/schema-org/src/runtime.ts
@@ -54,6 +54,7 @@ import type {
 import type { Place } from './nodes/Place'
 import type { VirtualLocation } from './nodes/VirtualLocation'
 import type { Arrayable, SchemaOrgNodeDefinition, Thing } from './types'
+import { markBuiltinSchemaNode } from './core/define'
 import { aggregateOfferResolver } from './nodes/AggregateOffer'
 import { aggregateRatingResolver } from './nodes/AggregateRating'
 import { articleResolver } from './nodes/Article'
@@ -115,7 +116,7 @@ type DefinedSchemaOrgNode<ResolvedInput, CastInput, Input> = (
 ) & { _resolver?: SchemaOrgNodeDefinition<ResolvedInput, CastInput> }
 
 function provideResolver<Input extends object | undefined, ResolvedInput extends Thing, CastInput>(input: Input | undefined, resolver?: SchemaOrgNodeDefinition<ResolvedInput, CastInput>): DefinedSchemaOrgNode<ResolvedInput, CastInput, Input> {
-  return { ...(input || {} as Input), _resolver: resolver } as DefinedSchemaOrgNode<ResolvedInput, CastInput, Input>
+  return markBuiltinSchemaNode({ ...(input || {} as Input), _resolver: resolver }) as DefinedSchemaOrgNode<ResolvedInput, CastInput, Input>
 }
 
 export function defineAddress<Input extends object | undefined = undefined>(input?: SchemaOrgDefinerInput<PostalAddress, Input>) {

--- a/packages/schema-org/test/ssr/cache.test.ts
+++ b/packages/schema-org/test/ssr/cache.test.ts
@@ -1,0 +1,93 @@
+import { defineSchemaOrgResolver, defineWebPage, defineWebSite, UnheadSchemaOrg } from '@unhead/schema-org'
+import { createHead, renderSSRHead } from 'unhead/server'
+import { describe, expect, it } from 'vitest'
+
+describe('schema.org render cache', () => {
+  it('invalidates when entries change', () => {
+    const head = createHead({ disableDefaults: true })
+    head.use(UnheadSchemaOrg({ host: 'https://example.com' }))
+    const entry = head.push({
+      script: [{ type: 'application/ld+json', key: 'schema-org-graph', nodes: [defineWebSite({ name: 'First' })] }],
+    } as any)
+
+    expect(renderSSRHead(head).bodyTags).toContain('First')
+    expect(renderSSRHead(head).bodyTags).toContain('First')
+
+    entry.patch({
+      script: [{ type: 'application/ld+json', key: 'schema-org-graph', nodes: [defineWebSite({ name: 'Second' })] }],
+    } as any)
+    expect(renderSSRHead(head).bodyTags).toContain('Second')
+
+    entry.dispose()
+    expect(renderSSRHead(head).bodyTags).toBe('')
+  })
+
+  it('does not cache dynamic metadata callbacks', () => {
+    let host = 'https://first.example.com'
+    const head = createHead({ disableDefaults: true })
+    head.use(UnheadSchemaOrg({}, () => ({ host })))
+    head.push({
+      script: [{ type: 'application/ld+json', key: 'schema-org-graph', nodes: [defineWebPage({ name: 'Page' })] }],
+    } as any)
+
+    expect(renderSSRHead(head).bodyTags).toContain('https://first.example.com')
+    host = 'https://second.example.com'
+    expect(renderSSRHead(head).bodyTags).toContain('https://second.example.com')
+  })
+
+  it('does not cache custom resolvers', () => {
+    let renders = 0
+    const resolver = defineSchemaOrgResolver({
+      defaults: { '@type': 'Thing' },
+      resolve(node: any) {
+        node.name = String(++renders)
+        return node
+      },
+    })
+    const head = createHead({ disableDefaults: true })
+    head.use(UnheadSchemaOrg({ host: 'https://example.com' }))
+    head.push({
+      script: [{ type: 'application/ld+json', key: 'schema-org-graph', nodes: [{ _resolver: resolver }] }],
+    } as any)
+
+    expect(renderSSRHead(head).bodyTags).toContain('"name": "1"')
+    expect(renderSSRHead(head).bodyTags).toContain('"name": "2"')
+  })
+
+  it('invalidates when a schema node changes in place', () => {
+    const site = defineWebSite({ name: 'First' })
+    const head = createHead({ disableDefaults: true })
+    head.use(UnheadSchemaOrg({ host: 'https://example.com' }))
+    head.push({
+      script: [{ type: 'application/ld+json', key: 'schema-org-graph', nodes: [site] }],
+    } as any)
+
+    expect(renderSSRHead(head).bodyTags).toContain('First')
+    site.name = 'Second'
+    expect(renderSSRHead(head).bodyTags).toContain('Second')
+  })
+
+  it('does not cache output from custom tag hooks', () => {
+    let name = 'First'
+    const head = createHead({
+      disableDefaults: true,
+      hooks: {
+        'entries:normalize': ({ tags }) => {
+          for (const tag of tags) {
+            if (tag.props.nodes) {
+              ;(tag.props as any).nodes = [defineWebSite({ name })]
+            }
+          }
+        },
+      },
+    })
+    head.use(UnheadSchemaOrg({ host: 'https://example.com' }))
+    head.push({
+      script: [{ type: 'application/ld+json', key: 'schema-org-graph', nodes: [defineWebSite()] }],
+    } as any)
+
+    expect(renderSSRHead(head).bodyTags).toContain('First')
+    name = 'Second'
+    expect(renderSSRHead(head).bodyTags).toContain('Second')
+  })
+})

--- a/packages/schema-org/test/ssr/cache.test.ts
+++ b/packages/schema-org/test/ssr/cache.test.ts
@@ -3,6 +3,25 @@ import { createHead, renderSSRHead } from 'unhead/server'
 import { describe, expect, it } from 'vitest'
 
 describe('schema.org render cache', () => {
+  it('isolates one plugin instance across nested head renders', () => {
+    const plugin = UnheadSchemaOrg({ host: 'https://example.com' })
+    const first = createHead({ disableDefaults: true })
+    const second = createHead({ disableDefaults: true })
+    first.use(plugin)
+    second.use(plugin)
+    first.push({
+      script: [{ type: 'application/ld+json', key: 'schema-org-graph', nodes: [defineWebSite({ name: 'First' })] }],
+    } as any)
+    second.push({
+      script: [{ type: 'application/ld+json', key: 'schema-org-graph', nodes: [defineWebPage({ name: 'Second' })] }],
+    } as any)
+    first.hooks.hook('entries:resolve', () => renderSSRHead(second))
+
+    const result = renderSSRHead(first).bodyTags
+    expect(result).toContain('First')
+    expect(result).not.toContain('Second')
+  })
+
   it('invalidates when entries change', () => {
     const head = createHead({ disableDefaults: true })
     head.use(UnheadSchemaOrg({ host: 'https://example.com' }))
@@ -64,6 +83,19 @@ describe('schema.org render cache', () => {
 
     expect(renderSSRHead(head).bodyTags).toContain('First')
     site.name = 'Second'
+    expect(renderSSRHead(head).bodyTags).toContain('Second')
+  })
+
+  it('invalidates when a schema node array changes in place', () => {
+    const input: any = {
+      script: [{ type: 'application/ld+json', key: 'schema-org-graph', nodes: [defineWebSite({ name: 'First' })] }],
+    }
+    const head = createHead({ disableDefaults: true })
+    head.use(UnheadSchemaOrg({ host: 'https://example.com' }))
+    head.push(input)
+
+    expect(renderSSRHead(head).bodyTags).toContain('First')
+    input.script[0].nodes = [defineWebSite({ name: 'Second' })]
     expect(renderSSRHead(head).bodyTags).toContain('Second')
   })
 

--- a/packages/unhead/src/client/createHead.ts
+++ b/packages/unhead/src/client/createHead.ts
@@ -3,6 +3,7 @@ import type { ClientUnhead } from './adapter'
 import { createUnhead } from '../unhead'
 import { TagPriorityAliases } from '../utils/const'
 import { createHooks } from '../utils/hooks'
+import { createPropResolver } from '../utils/normalize'
 import { createClientHeadAdapter } from './adapter'
 import { createDomRenderer } from './renderDOMHead'
 
@@ -13,7 +14,8 @@ const tagWeight = (tag: HeadTag) => typeof tag.tagPriority === 'number' ? tag.ta
 export function createHead<T = ResolvableHead>(options: CreateClientHeadOptions = {}): ClientUnhead<T> {
   options.document = options.document || (typeof window !== 'undefined' ? document : undefined)
   const renderer = (options.render || createDomRenderer({ document: options.document })) as HeadRenderer<boolean>
-  const core = createUnhead<T, boolean>(renderer, { document: options.document, propResolvers: options.propResolvers, _tagWeight: tagWeight, init: [] })
+  const propResolvers = [...(options.propResolvers || [])]
+  const core = createUnhead<T, boolean>(renderer, { document: options.document, propResolvers, _propResolver: { resolve: createPropResolver(propResolvers, false), source: propResolvers }, _tagWeight: tagWeight, init: [] })
   const hooks = createHooks<ClientHeadHooks>(options.hooks)
   const head = createClientHeadAdapter(core, hooks, renderer)
   options.plugins?.forEach(p => head.use(p))

--- a/packages/unhead/src/composables.ts
+++ b/packages/unhead/src/composables.ts
@@ -10,7 +10,7 @@ import { FlatMetaPlugin } from './plugins/flatMeta'
 import { SafeInputPlugin } from './plugins/safe'
 import { hasOwn } from './utils/hasOwn'
 
-export function useHead<T extends Unhead<any>, I = ResolvableHead>(unhead: T, input?: ResolvableHead, options: HeadEntryOptions = {}): ActiveHeadEntry<I> {
+export function useHead<T extends Unhead<any>, I = ResolvableHead>(unhead: T, input?: ResolvableHead, options?: HeadEntryOptions): ActiveHeadEntry<I> {
   return unhead.push((input || {}) as I, options) as ActiveHeadEntry<I>
 }
 

--- a/packages/unhead/src/plugins/flatMeta.ts
+++ b/packages/unhead/src/plugins/flatMeta.ts
@@ -1,11 +1,12 @@
 import type { HeadTag } from '../types'
+import { markStaticPropsNormalizedHook } from '../utils/hooks'
 import { unpackMeta } from '../utils/meta'
 import { defineHeadPlugin } from './defineHeadPlugin'
 
 export const FlatMetaPlugin = /* @__PURE__ */ defineHeadPlugin({
   key: 'flatMeta',
   hooks: {
-    'entries:normalize': (ctx) => {
+    'entries:normalize': /* @__PURE__ */ markStaticPropsNormalizedHook((ctx) => {
       let hasFlatMeta = false
       const tags: HeadTag[] = []
       const tagsToAdd: HeadTag[] = []
@@ -22,6 +23,6 @@ export const FlatMetaPlugin = /* @__PURE__ */ defineHeadPlugin({
         return
       for (const tag of tagsToAdd) tags.push(tag)
       ctx.tags = tags
-    },
+    }),
   },
 })

--- a/packages/unhead/src/plugins/templateParams.ts
+++ b/packages/unhead/src/plugins/templateParams.ts
@@ -1,5 +1,6 @@
 import type { HeadTag, TemplateParams } from '../types/tags'
 import { processTemplateParams } from '../utils'
+import { markStaticPropsNormalizedHook } from '../utils/hooks'
 import { defineHeadPlugin } from './defineHeadPlugin'
 
 const SupportedAttrs: Partial<Record<string, string>> = {
@@ -20,7 +21,7 @@ export const TemplateParamsPlugin = /* @__PURE__ */ defineHeadPlugin((head) => {
   return {
     key: 'template-params',
     hooks: {
-      'tags:resolve': ({ tagMap, tags }) => {
+      'tags:resolve': markStaticPropsNormalizedHook(({ tagMap, tags }) => {
         // we always process params so we can substitute the title
         const params = (tagMap.get('templateParams')?.props || {}) as TemplateParams
         // ensure a separator exists
@@ -52,14 +53,14 @@ export const TemplateParamsPlugin = /* @__PURE__ */ defineHeadPlugin((head) => {
         // resolved template params
         head._templateParams = params
         head._separator = sep
-      },
-      'tags:afterResolve': ({ tagMap }) => {
+      }),
+      'tags:afterResolve': markStaticPropsNormalizedHook(({ tagMap }) => {
         // we need to re-process in case then user had a function as the titleTemplate
         const title: HeadTag | undefined = tagMap.get('title')
         if (title?.textContent && title.processTemplateParams !== false) {
           title.textContent = processIfNeeded(title.textContent, head._templateParams!, head._separator!)
         }
-      },
+      }),
     },
   }
 }, 'template-params')

--- a/packages/unhead/src/server/createHead.ts
+++ b/packages/unhead/src/server/createHead.ts
@@ -1,9 +1,9 @@
 import type { HookableCore } from 'hookable'
-import type { CreateServerHeadOptions, HeadTag, PropResolver, ResolvableHead, ServerHeadHooks, SSRHeadPayload, Unhead } from '../types'
+import type { CreateServerHeadOptions, HeadTag, ResolvableHead, ServerHeadHooks, SSRHeadPayload, Unhead } from '../types'
 import { createUnhead } from '../unhead'
 import { dedupeKey, hashTag } from '../utils/dedupe'
 import { createHooks } from '../utils/hooks'
-import { normalizeEntryToTags } from '../utils/normalize'
+import { createPropResolver, normalizeEntryToTags } from '../utils/normalize'
 import { createServerRenderer } from './renderSSRHead'
 import { capoTagWeight } from './sort'
 
@@ -27,18 +27,6 @@ const DEFAULT_INIT = {
     },
   ],
 }
-
-// identity for anything but `on*` function handlers, so `_static` for the
-// default init fast path (the default entry has no event handlers)
-const serverPropResolver: PropResolver = /* @__PURE__ */ Object.assign(
-  (k?: string, v?: any) => {
-    if (k && k.startsWith('on') && typeof v === 'function') {
-      return `this.dataset.${k}fired = true`
-    }
-    return v
-  },
-  { _static: true },
-)
 
 let defaultInitTags: HeadTag[] | undefined
 
@@ -69,16 +57,16 @@ function getDefaultInitTags(): HeadTag[] {
 /* @__NO_SIDE_EFFECTS__ */
 export function createHead<T = ResolvableHead>(options: CreateServerHeadOptions = {}): ServerUnhead<T> {
   const tagWeight = options.tagWeight || capoTagWeight
+  const propResolvers = [...(options.propResolvers || [])]
   const render = createServerRenderer({ tagWeight, omitLineBreaks: options.omitLineBreaks })
   const core = createUnhead<T, SSRHeadPayload>(render, {
     _tagWeight: tagWeight,
     // @ts-expect-error untyped
     document: false,
     experimentalStreamKey: options.experimentalStreamKey,
-    propResolvers: [
-      ...(options.propResolvers || []),
-      serverPropResolver,
-    ],
+    propResolvers,
+    _eventHandlers: true,
+    _propResolver: { resolve: createPropResolver(propResolvers, true), source: propResolvers },
     init: [
       options.disableDefaults ? undefined : DEFAULT_INIT,
       ...(options.init || []),

--- a/packages/unhead/src/server/renderSSRHead.ts
+++ b/packages/unhead/src/server/renderSSRHead.ts
@@ -1,28 +1,54 @@
 import type { HeadRenderer, RenderSSRHeadOptions, ShouldRenderContext, SSRHeadPayload, SSRRenderContext, Unhead } from '../types'
-import { callHook } from '../utils/hooks'
 import { resolveTags } from '../utils/resolve'
 import { capoTagWeight } from './sort'
 import { ssrRenderTags } from './util'
+import { ssrRenderTagsTrusted } from './util/ssrRenderTags'
+
+const EMPTY_OPTIONS: RenderSSRHeadOptions = {}
+const UNSAFE_TAG_HOOK_RE = /^(?:entries:(?:resolve|normalize)|tags?:|ssr:render$)/
+
+function hasHook(head: Unhead<any>, name: string): boolean {
+  return Boolean((head.hooks as any)?._hooks?.[name]?.length)
+}
+
+function hasUnsafeTagHooks(head: Unhead<any>): boolean {
+  const hooks = (head.hooks as any)?._hooks || {}
+  for (const name in hooks) {
+    if (hooks[name]?.length && UNSAFE_TAG_HOOK_RE.test(name))
+      return true
+  }
+  return false
+}
+
+function renderServerHead(head: Unhead<any>, options: RenderSSRHeadOptions): SSRHeadPayload {
+  if (hasHook(head, 'ssr:beforeRender')) {
+    const beforeRenderCtx: ShouldRenderContext = { shouldRender: true }
+    head.hooks!.callHook('ssr:beforeRender', beforeRenderCtx)
+    if (!beforeRenderCtx.shouldRender)
+      return ssrRenderTags([])
+  }
+
+  const trusted = !options.resolvedTags && !hasUnsafeTagHooks(head)
+  let tags = options.resolvedTags || resolveTags(head, { tagWeight: options.tagWeight ?? capoTagWeight })
+  let renderOptions = options
+  if (hasHook(head, 'ssr:render')) {
+    const ctx = { tags, options: { ...options } }
+    head.hooks!.callHook('ssr:render', ctx)
+    tags = ctx.tags
+    renderOptions = ctx.options
+  }
+
+  const html = trusted ? ssrRenderTagsTrusted(tags, renderOptions) : ssrRenderTags(tags, renderOptions)
+  if (!hasHook(head, 'ssr:rendered'))
+    return html
+  const renderCtx: SSRRenderContext = { tags, html }
+  head.hooks!.callHook('ssr:rendered', renderCtx)
+  return renderCtx.html
+}
 
 /* @__NO_SIDE_EFFECTS__ */
 export function createServerRenderer(options: RenderSSRHeadOptions = {}): HeadRenderer<SSRHeadPayload> {
-  return (head: Unhead<any>) => {
-    const beforeRenderCtx: ShouldRenderContext = { shouldRender: true }
-    callHook(head, 'ssr:beforeRender', beforeRenderCtx)
-    if (!beforeRenderCtx.shouldRender)
-      return ssrRenderTags([])
-    // Fresh per-render options so plugins (e.g. MinifyPlugin) can override
-    // render behaviour like `omitLineBreaks` without leaking into the closure.
-    const ctx = {
-      tags: options.resolvedTags || resolveTags(head, { tagWeight: options.tagWeight ?? capoTagWeight }),
-      options: { ...options },
-    }
-    callHook(head, 'ssr:render', ctx)
-    const html: SSRHeadPayload = ssrRenderTags(ctx.tags, ctx.options)
-    const renderCtx: SSRRenderContext = { tags: ctx.tags, html }
-    callHook(head, 'ssr:rendered', renderCtx)
-    return renderCtx.html
-  }
+  return (head: Unhead<any>) => renderServerHead(head, options)
 }
 
 /**
@@ -30,5 +56,5 @@ export function createServerRenderer(options: RenderSSRHeadOptions = {}): HeadRe
  */
 /* @__NO_SIDE_EFFECTS__ */
 export function renderSSRHead(head: Unhead<any>, options?: RenderSSRHeadOptions): SSRHeadPayload {
-  return createServerRenderer(options)(head)
+  return renderServerHead(head, options || EMPTY_OPTIONS)
 }

--- a/packages/unhead/src/server/renderSSRHead.ts
+++ b/packages/unhead/src/server/renderSSRHead.ts
@@ -1,4 +1,5 @@
 import type { HeadRenderer, RenderSSRHeadOptions, ShouldRenderContext, SSRHeadPayload, SSRRenderContext, Unhead } from '../types'
+import { isPropsNormalizedHook } from '../utils/hooks'
 import { resolveTags } from '../utils/resolve'
 import { capoTagWeight } from './sort'
 import { ssrRenderTags } from './util'
@@ -14,8 +15,12 @@ function hasHook(head: Unhead<any>, name: string): boolean {
 function hasUnsafeTagHooks(head: Unhead<any>): boolean {
   const hooks = (head.hooks as any)?._hooks || {}
   for (const name in hooks) {
-    if (hooks[name]?.length && UNSAFE_TAG_HOOK_RE.test(name))
-      return true
+    if (UNSAFE_TAG_HOOK_RE.test(name)) {
+      for (const hook of hooks[name] || []) {
+        if (!isPropsNormalizedHook(hook))
+          return true
+      }
+    }
   }
   return false
 }

--- a/packages/unhead/src/server/util/propsToString.ts
+++ b/packages/unhead/src/server/util/propsToString.ts
@@ -13,7 +13,7 @@ function stringifyProps(props: Record<string, any>, validateNames: boolean) {
   let attrs = ''
 
   for (const key in props) {
-    if (validateNames && (!Object.hasOwn(props, key) || !key || INVALID_ATTR_NAME_RE.test(key)))
+    if (!Object.hasOwn(props, key) || (validateNames && (!key || INVALID_ATTR_NAME_RE.test(key))))
       continue
 
     let value = props[key]

--- a/packages/unhead/src/server/util/propsToString.ts
+++ b/packages/unhead/src/server/util/propsToString.ts
@@ -9,11 +9,11 @@ function encodeAttribute(value: string) {
 }
 
 /* @__PURE__ */
-export function propsToString(props: Record<string, any>) {
+function stringifyProps(props: Record<string, any>, validateNames: boolean) {
   let attrs = ''
 
   for (const key in props) {
-    if (!Object.hasOwn(props, key) || !key || INVALID_ATTR_NAME_RE.test(key))
+    if (validateNames && (!Object.hasOwn(props, key) || !key || INVALID_ATTR_NAME_RE.test(key)))
       continue
 
     let value = props[key]
@@ -38,4 +38,15 @@ export function propsToString(props: Record<string, any>) {
   }
 
   return attrs
+}
+
+/* @__PURE__ */
+export function propsToString(props: Record<string, any>) {
+  return stringifyProps(props, true)
+}
+
+/** @internal */
+/* @__PURE__ */
+export function propsToStringTrusted(props: Record<string, any>) {
+  return stringifyProps(props, false)
 }

--- a/packages/unhead/src/server/util/ssrRenderTags.ts
+++ b/packages/unhead/src/server/util/ssrRenderTags.ts
@@ -1,9 +1,9 @@
 import type { HeadTag, RenderSSRHeadOptions } from '../../types'
-import { propsToString } from './propsToString'
-import { tagToString } from './tagToString'
+import { propsToString, propsToStringTrusted } from './propsToString'
+import { tagToString, tagToStringTrusted } from './tagToString'
 
 /* @__PURE__ */
-export function ssrRenderTags<T extends HeadTag>(tags: T[], options?: RenderSSRHeadOptions) {
+function renderTags<T extends HeadTag>(tags: T[], options: RenderSSRHeadOptions | undefined, trusted: boolean) {
   const schema: {
     tags: Record<'head' | 'bodyClose' | 'bodyOpen', string>
     htmlAttrs: HeadTag['props']
@@ -17,7 +17,7 @@ export function ssrRenderTags<T extends HeadTag>(tags: T[], options?: RenderSSRH
       Object.assign(schema[tag.tag], tag.props)
       continue
     }
-    const s = tagToString(tag)
+    const s = trusted ? tagToStringTrusted(tag) : tagToString(tag)
     const tagPosition = tag.tagPosition || 'head'
     schema.tags[tagPosition] += schema.tags[tagPosition]
       ? `${lineBreaks}${s}`
@@ -28,7 +28,18 @@ export function ssrRenderTags<T extends HeadTag>(tags: T[], options?: RenderSSRH
     headTags: schema.tags.head,
     bodyTags: schema.tags.bodyClose,
     bodyTagsOpen: schema.tags.bodyOpen,
-    htmlAttrs: propsToString(schema.htmlAttrs),
-    bodyAttrs: propsToString(schema.bodyAttrs),
+    htmlAttrs: trusted ? propsToStringTrusted(schema.htmlAttrs) : propsToString(schema.htmlAttrs),
+    bodyAttrs: trusted ? propsToStringTrusted(schema.bodyAttrs) : propsToString(schema.bodyAttrs),
   }
+}
+
+/* @__PURE__ */
+export function ssrRenderTags<T extends HeadTag>(tags: T[], options?: RenderSSRHeadOptions) {
+  return renderTags(tags, options, false)
+}
+
+/** @internal */
+/* @__PURE__ */
+export function ssrRenderTagsTrusted<T extends HeadTag>(tags: T[], options?: RenderSSRHeadOptions) {
+  return renderTags(tags, options, true)
 }

--- a/packages/unhead/src/server/util/tagToString.ts
+++ b/packages/unhead/src/server/util/tagToString.ts
@@ -1,6 +1,6 @@
 import type { HeadTag } from '../../types'
 import { SelfClosingTags, TagsWithInnerContent } from '../../utils'
-import { propsToString } from './propsToString'
+import { propsToString, propsToStringTrusted } from './propsToString'
 
 const ESCAPE_HTML_RE = /[&<>"'/]/g
 const CLOSE_TAG_RE: Record<string, RegExp> = {}
@@ -12,8 +12,7 @@ export function escapeHtml(str: string) {
 }
 
 /* @__PURE__ */
-export function tagToString<T extends HeadTag>(tag: T) {
-  const attrs = propsToString(tag.props)
+function stringifyTag<T extends HeadTag>(tag: T, attrs: string) {
   const openTag = `<${tag.tag}${attrs}>`
   // self-closing (meta/link/base) is the common SSR tag: one Set lookup, no close tag.
   // SelfClosingTags and TagsWithInnerContent are disjoint, so the second SelfClosingTags.has()
@@ -25,6 +24,21 @@ export function tagToString<T extends HeadTag>(tag: T) {
 
   // dangerously using innerHTML, we don't encode this
   let content = String(tag.textContent ?? tag.innerHTML ?? '')
-  content = tag.tag === 'title' ? escapeHtml(content) : content.replace(CLOSE_TAG_RE[tag.tag] ||= new RegExp(`<\/${tag.tag}`, 'gi'), `<\\/${tag.tag}`)
+  if (tag.tag === 'title')
+    content = escapeHtml(content)
+  else if (content.includes('<'))
+    content = content.replace(CLOSE_TAG_RE[tag.tag] ||= new RegExp(`<\/${tag.tag}`, 'gi'), `<\\/${tag.tag}`)
   return `${openTag}${content}</${tag.tag}>`
+}
+
+/* @__PURE__ */
+export function tagToString<T extends HeadTag>(tag: T) {
+  return stringifyTag(tag, propsToString(tag.props))
+}
+
+/** @internal */
+/* @__PURE__ */
+export function tagToStringTrusted<T extends HeadTag>(tag: T) {
+  // Title object props do not pass through HTML attribute normalization.
+  return stringifyTag(tag, tag.tag === 'title' ? propsToString(tag.props) : propsToStringTrusted(tag.props))
 }

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -111,6 +111,19 @@ export interface CreateHeadOptions {
    * @internal
    */
   _tagWeight?: (tag: HeadTag) => number
+  /**
+   * Convert server event handlers to hydration markers during normalization.
+   * @internal
+   */
+  _eventHandlers?: boolean
+  /**
+   * Pre-composed property resolver chain.
+   * @internal
+   */
+  _propResolver?: {
+    resolve: PropResolver | undefined
+    source: PropResolver[]
+  }
 }
 
 export interface CreateServerHeadOptions extends CreateHeadOptions {

--- a/packages/unhead/src/utils/hooks.ts
+++ b/packages/unhead/src/utils/hooks.ts
@@ -2,6 +2,19 @@ import type { HookableCore } from 'hookable'
 import type { CoreHeadHooks, Unhead } from '../types'
 import { HookableCore as Hookable } from 'hookable'
 
+const normalizedPropsHooks = new WeakSet<(...args: any[]) => any>()
+const StaticHook = Symbol.for('unhead:static-hook')
+
+export function isPropsNormalizedHook(hook: (...args: any[]) => any) {
+  return normalizedPropsHooks.has(hook)
+}
+
+export function markStaticPropsNormalizedHook<T extends (...args: any[]) => any>(hook: T): T {
+  normalizedPropsHooks.add(hook)
+  Object.defineProperty(hook, StaticHook, { value: true })
+  return hook
+}
+
 export function createHooks<T extends CoreHeadHooks>(hooks?: Partial<T>): HookableCore<T> {
   const instance = new Hookable<T>()
   for (const key in hooks || {}) {

--- a/packages/unhead/src/utils/meta.ts
+++ b/packages/unhead/src/utils/meta.ts
@@ -1,5 +1,7 @@
 import type { MetaFlat, MetaGeneric, UnheadMeta } from '../types'
+import { INVALID_ATTR_NAME_RE } from './attrs'
 import { MetaTagsArrayable } from './const'
+import { isUnsafeKey } from './unsafeKey'
 
 export type MetaKeyType = 'name' | 'property' | 'http-equiv'
 
@@ -89,8 +91,8 @@ function fixKeyCase(key: string): string {
       )
 }
 
-function sanitizeObject(input: Record<string, any>) {
-  return Object.fromEntries(Object.entries(input).filter(([k, v]) => String(v) !== 'false' && k))
+function sanitizeObject<T extends Record<string, any>>(input: T): T {
+  return Object.fromEntries(Object.entries(input).filter(([k, v]) => String(v) !== 'false' && k && !INVALID_ATTR_NAME_RE.test(k) && !isUnsafeKey(k))) as T
 }
 
 function transformObject(obj: any): any {
@@ -178,7 +180,7 @@ export function unpackMeta<T extends MetaFlat>(input: T): UnheadMeta[] {
       if (key === 'themeColor') {
         value.forEach((v) => {
           if (typeof v === 'object' && v !== null) {
-            extras.push({ name: 'theme-color', ...v })
+            extras.push({ name: 'theme-color', ...sanitizeObject(v) })
           }
         })
         continue

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -36,7 +36,7 @@ function normalizeStyleClassProps(
   return store
 }
 
-export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTag {
+function normalizePropsInternal(tag: HeadTag, input: Record<string, any>, resolveValues = false, resolve?: PropResolver): HeadTag {
   tag.props = tag.props || {}
   if (!input)
     return tag
@@ -54,7 +54,7 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
     const key = isHtmlAttr && !isData ? prop.toLowerCase() : prop
     if (isHtmlAttr && (!key || INVALID_ATTR_NAME_RE.test(key)))
       continue
-    const value = input[prop]
+    const value = resolveValues ? walkResolver(input[prop], resolve, prop) : input[prop]
     if (value === null) {
       tag.props[key] = null as any
     }
@@ -84,25 +84,75 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
   return tag
 }
 
-export function resolveHeadInput(input: any, propResolvers: PropResolver[]): any {
-  let resolve: PropResolver | undefined
-  if (propResolvers.length) {
-    resolve = (key, val) => {
-      for (let i = 0; i < propResolvers.length; i++)
-        val = propResolvers[i](key, val)
-      return val
-    }
-    // Resolve the root before walking so ref-wrapped functions are unwrapped.
-    input = resolve(undefined, input)
+export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTag {
+  return normalizePropsInternal(tag, input)
+}
+
+function createResolver(propResolvers: PropResolver[]): PropResolver | undefined {
+  if (!propResolvers.length)
+    return
+  return (key, val) => {
+    for (let i = 0; i < propResolvers.length; i++)
+      val = propResolvers[i](key, val)
+    return val
   }
+}
+
+function resolveShallow(input: any, resolve?: PropResolver, key?: string): any {
+  if (key === '_resolver')
+    return input
+  if (typeof input === 'function' && (!key || (key !== 'titleTemplate' && !key.startsWith('on'))))
+    input = input()
+  return resolve ? resolve(key, input) : input
+}
+
+function resolveChildren(input: any, resolve?: PropResolver): any {
+  if (Array.isArray(input)) {
+    let next: any[] | undefined
+    for (let i = 0; i < input.length; i++) {
+      const value = walkResolver(input[i], resolve)
+      if (next)
+        next[i] = value
+      else if (value !== input[i])
+        next = [...input.slice(0, i), value]
+    }
+    return next || input
+  }
+  if (input?.constructor === Object) {
+    let next: Record<string, any> | undefined
+    for (const key in input) {
+      const unsafe = isUnsafeKey(key)
+      const value = unsafe ? undefined : walkResolver(input[key], resolve, key)
+      if (!next && (unsafe || value !== input[key])) {
+        next = {}
+        for (const previousKey in input) {
+          if (previousKey === key)
+            break
+          next[previousKey] = input[previousKey]
+        }
+      }
+      if (next && !unsafe)
+        next[key] = value
+    }
+    return next || input
+  }
+  return input
+}
+
+export function resolveHeadInput(input: any, propResolvers: PropResolver[]): any {
+  const resolve = createResolver(propResolvers)
+  // Resolve the root before walking so ref-wrapped functions are unwrapped.
+  if (resolve)
+    input = resolve(undefined, input)
   return walkResolver(input, resolve)
 }
 
-function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string): HeadTag | HeadTag[] {
-  const input = typeof _input === 'object' && typeof _input !== 'function'
+function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string, resolveValues = false, resolve?: PropResolver): HeadTag | HeadTag[] {
+  const isObjectInput = typeof _input === 'object' && typeof _input !== 'function'
+  const input = isObjectInput
     ? _input
     : { [(tagName === 'script' || tagName === 'noscript' || tagName === 'style') ? 'innerHTML' : 'textContent']: _input }
-  const tag = normalizeProps({ tag: tagName, props: {} }, input)
+  const tag = normalizePropsInternal({ tag: tagName, props: {} }, input, isObjectInput && resolveValues, resolve)
   if (tag.key && DupeableTags.has(tag.tag))
     tag.props['data-hid'] = tag._h = tag.key
   if (tag.tag === 'script' && typeof tag.innerHTML === 'object') {
@@ -128,23 +178,41 @@ function pushNormalizedTag(tags: HeadTag[], tag: HeadTag | HeadTag[]) {
   }
 }
 
+function normalizeResolvedTag(tags: HeadTag[], tagName: HeadTag['tag'], input: any, resolveValues: boolean, resolve?: PropResolver) {
+  if (resolveValues && (Array.isArray(input)
+    || (input?.constructor === Object && (tagName === 'templateParams' || 'innerHTML' in input || 'textContent' in input)))) {
+    input = resolveChildren(input, resolve)
+    resolveValues = false
+  }
+  pushNormalizedTag(tags, normalizeTag(tagName, input, resolveValues && input?.constructor === Object, resolve))
+}
+
 export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]): HeadTag[] {
   if (!input)
     return []
   if (typeof input === 'function')
     input = input()
+  const resolve = createResolver(propResolvers)
   // The root intentionally passes through the resolver chain twice. The first
-  // pass unwraps refs, then walkResolver invokes a function returned by a ref.
-  input = resolveHeadInput(input, propResolvers)
+  // pass unwraps refs, then the shallow pass invokes a function returned by a ref.
+  if (resolve)
+    input = resolve(undefined, input)
+  input = resolveShallow(input, resolve)
+  const resolveValues = input?.constructor === Object
   const tags: HeadTag[] = []
   for (const key in input) {
-    const value = input[key]
+    if (resolveValues && isUnsafeKey(key))
+      continue
+    const value = resolveValues ? resolveShallow(input[key], resolve, key) : input[key]
     if (value !== undefined) {
       if (Array.isArray(value)) {
-        for (const v of value) pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, v))
+        for (const v of value) {
+          const resolved = resolveValues ? resolveShallow(v, resolve) : v
+          normalizeResolvedTag(tags, key as keyof ResolvableHead, resolved, resolveValues, resolve)
+        }
       }
       else {
-        pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, value))
+        normalizeResolvedTag(tags, key as keyof ResolvableHead, value, resolveValues, resolve)
       }
     }
   }

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -45,7 +45,7 @@ function resolveShallowValue(value: any, key?: string, resolve?: PropResolver): 
 }
 
 function resolveServerEventHandler(key: string | undefined, value: any): any {
-  return key?.startsWith('on') && typeof value === 'function'
+  return typeof value === 'function' && key?.startsWith('on')
     ? `this.dataset.${key}fired = true`
     : value
 }
@@ -53,6 +53,8 @@ function resolveServerEventHandler(key: string | undefined, value: any): any {
 export function createPropResolver(propResolvers: PropResolver[], serverEventHandlers: boolean): PropResolver | undefined {
   if (!propResolvers.length && !serverEventHandlers)
     return
+  if (!propResolvers.length)
+    return resolveServerEventHandler
   return (key, value) => {
     for (let i = 0; i < propResolvers.length; i++)
       value = propResolvers[i](key, value)

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -36,12 +36,55 @@ function normalizeStyleClassProps(
   return store
 }
 
-export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTag {
+function resolveShallowValue(value: any, key?: string, resolve?: PropResolver): any {
+  if (key === '_resolver')
+    return value
+  if (typeof value === 'function' && (!key || (key !== 'titleTemplate' && !key.startsWith('on'))))
+    value = value()
+  return resolve ? resolve(key, value) : value
+}
+
+function resolveServerEventHandler(key: string | undefined, value: any): any {
+  return key?.startsWith('on') && typeof value === 'function'
+    ? `this.dataset.${key}fired = true`
+    : value
+}
+
+export function createPropResolver(propResolvers: PropResolver[], serverEventHandlers: boolean): PropResolver | undefined {
+  if (!propResolvers.length && !serverEventHandlers)
+    return
+  return (key, value) => {
+    for (let i = 0; i < propResolvers.length; i++)
+      value = propResolvers[i](key, value)
+    return serverEventHandlers ? resolveServerEventHandler(key, value) : value
+  }
+}
+
+function resolveObjectChildren(input: Record<string, any>, resolve?: PropResolver): Record<string, any> {
+  let output: Record<string, any> | undefined
+  for (const key in input) {
+    const unsafe = isUnsafeKey(key)
+    const value = unsafe ? undefined : walkResolver(input[key], resolve, key)
+    if (!output && (unsafe || value !== input[key])) {
+      output = {}
+      for (const previous in input) {
+        if (previous === key)
+          break
+        output[previous] = input[previous]
+      }
+    }
+    if (output && !unsafe)
+      output[key] = value
+  }
+  return output || input
+}
+
+export function normalizeProps(tag: HeadTag, input: Record<string, any>, serverEventHandlers = false, resolveFunctions = false, resolve?: PropResolver): HeadTag {
   tag.props = tag.props || {}
   if (!input)
     return tag
   if (tag.tag === 'templateParams') {
-    tag.props = input
+    tag.props = resolveFunctions ? resolveObjectChildren(input, resolve) : input
     return tag
   }
   const isHtmlTag = HasElementTags.has(tag.tag) || tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs'
@@ -54,12 +97,15 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
     const key = isHtmlAttr && !isData ? prop.toLowerCase() : prop
     if (isHtmlAttr && (!key || INVALID_ATTR_NAME_RE.test(key)))
       continue
-    const value = input[prop]
+    const value = resolveFunctions ? walkResolver(input[prop], resolve, prop) : input[prop]
     if (value === null) {
       tag.props[key] = null as any
     }
     else if (prop === 'class' || prop === 'style') {
       tag.props[prop] = normalizeStyleClassProps(prop, value) as any
+    }
+    else if (serverEventHandlers && prop.startsWith('on') && typeof value === 'function') {
+      tag.props[key] = `this.dataset.${prop}fired = true`
     }
     else if (TagConfigKeys.has(prop)) {
       if ((prop === 'textContent' || prop === 'innerHTML') && typeof value === 'object') {
@@ -84,25 +130,21 @@ export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTa
   return tag
 }
 
-export function resolveHeadInput(input: any, propResolvers: PropResolver[]): any {
-  let resolve: PropResolver | undefined
-  if (propResolvers.length) {
-    resolve = (key, val) => {
-      for (let i = 0; i < propResolvers.length; i++)
-        val = propResolvers[i](key, val)
-      return val
-    }
+export function resolveHeadInput(input: any, propResolvers: PropResolver[], serverEventHandlers = false): any {
+  const resolve = createPropResolver(propResolvers, serverEventHandlers)
+  if (resolve) {
     // Resolve the root before walking so ref-wrapped functions are unwrapped.
     input = resolve(undefined, input)
   }
   return walkResolver(input, resolve)
 }
 
-function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string): HeadTag | HeadTag[] {
-  const input = typeof _input === 'object' && typeof _input !== 'function'
-    ? _input
-    : { [(tagName === 'script' || tagName === 'noscript' || tagName === 'style') ? 'innerHTML' : 'textContent']: _input }
-  const tag = normalizeProps({ tag: tagName, props: {} }, input)
+function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string, serverEventHandlers: boolean, resolve?: PropResolver): HeadTag | HeadTag[] {
+  if (typeof _input !== 'object' || typeof _input === 'function') {
+    const content = (tagName === 'script' || tagName === 'noscript' || tagName === 'style') ? 'innerHTML' : 'textContent'
+    return { tag: tagName, props: {}, [content]: _input }
+  }
+  const tag = normalizeProps({ tag: tagName, props: {} }, _input, serverEventHandlers, true, resolve)
   if (tag.key && DupeableTags.has(tag.tag))
     tag.props['data-hid'] = tag._h = tag.key
   if (tag.tag === 'script' && typeof tag.innerHTML === 'object') {
@@ -128,23 +170,29 @@ function pushNormalizedTag(tags: HeadTag[], tag: HeadTag | HeadTag[]) {
   }
 }
 
-export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]): HeadTag[] {
+export function normalizeEntryToTags(input: any, propResolvers: PropResolver[], serverEventHandlers = false, _resolve?: PropResolver): HeadTag[] {
   if (!input)
     return []
   if (typeof input === 'function')
     input = input()
+  const resolve = _resolve || createPropResolver(propResolvers, serverEventHandlers)
   // The root intentionally passes through the resolver chain twice. The first
   // pass unwraps refs, then walkResolver invokes a function returned by a ref.
-  input = resolveHeadInput(input, propResolvers)
+  if (resolve) {
+    input = resolve(undefined, input)
+    input = resolveShallowValue(input, undefined, resolve)
+  }
   const tags: HeadTag[] = []
   for (const key in input) {
-    const value = input[key]
+    if (isUnsafeKey(key))
+      continue
+    const value = resolveShallowValue(input[key], key, resolve)
     if (value !== undefined) {
       if (Array.isArray(value)) {
-        for (const v of value) pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, v))
+        for (const v of value) pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, resolveShallowValue(v, undefined, resolve), serverEventHandlers, resolve))
       }
       else {
-        pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, value))
+        pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, value, serverEventHandlers, resolve))
       }
     }
   }

--- a/packages/unhead/src/utils/normalize.ts
+++ b/packages/unhead/src/utils/normalize.ts
@@ -36,7 +36,7 @@ function normalizeStyleClassProps(
   return store
 }
 
-function normalizePropsInternal(tag: HeadTag, input: Record<string, any>, resolveValues = false, resolve?: PropResolver): HeadTag {
+export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTag {
   tag.props = tag.props || {}
   if (!input)
     return tag
@@ -54,7 +54,7 @@ function normalizePropsInternal(tag: HeadTag, input: Record<string, any>, resolv
     const key = isHtmlAttr && !isData ? prop.toLowerCase() : prop
     if (isHtmlAttr && (!key || INVALID_ATTR_NAME_RE.test(key)))
       continue
-    const value = resolveValues ? walkResolver(input[prop], resolve, prop) : input[prop]
+    const value = input[prop]
     if (value === null) {
       tag.props[key] = null as any
     }
@@ -84,75 +84,25 @@ function normalizePropsInternal(tag: HeadTag, input: Record<string, any>, resolv
   return tag
 }
 
-export function normalizeProps(tag: HeadTag, input: Record<string, any>): HeadTag {
-  return normalizePropsInternal(tag, input)
-}
-
-function createResolver(propResolvers: PropResolver[]): PropResolver | undefined {
-  if (!propResolvers.length)
-    return
-  return (key, val) => {
-    for (let i = 0; i < propResolvers.length; i++)
-      val = propResolvers[i](key, val)
-    return val
-  }
-}
-
-function resolveShallow(input: any, resolve?: PropResolver, key?: string): any {
-  if (key === '_resolver')
-    return input
-  if (typeof input === 'function' && (!key || (key !== 'titleTemplate' && !key.startsWith('on'))))
-    input = input()
-  return resolve ? resolve(key, input) : input
-}
-
-function resolveChildren(input: any, resolve?: PropResolver): any {
-  if (Array.isArray(input)) {
-    let next: any[] | undefined
-    for (let i = 0; i < input.length; i++) {
-      const value = walkResolver(input[i], resolve)
-      if (next)
-        next[i] = value
-      else if (value !== input[i])
-        next = [...input.slice(0, i), value]
-    }
-    return next || input
-  }
-  if (input?.constructor === Object) {
-    let next: Record<string, any> | undefined
-    for (const key in input) {
-      const unsafe = isUnsafeKey(key)
-      const value = unsafe ? undefined : walkResolver(input[key], resolve, key)
-      if (!next && (unsafe || value !== input[key])) {
-        next = {}
-        for (const previousKey in input) {
-          if (previousKey === key)
-            break
-          next[previousKey] = input[previousKey]
-        }
-      }
-      if (next && !unsafe)
-        next[key] = value
-    }
-    return next || input
-  }
-  return input
-}
-
 export function resolveHeadInput(input: any, propResolvers: PropResolver[]): any {
-  const resolve = createResolver(propResolvers)
-  // Resolve the root before walking so ref-wrapped functions are unwrapped.
-  if (resolve)
+  let resolve: PropResolver | undefined
+  if (propResolvers.length) {
+    resolve = (key, val) => {
+      for (let i = 0; i < propResolvers.length; i++)
+        val = propResolvers[i](key, val)
+      return val
+    }
+    // Resolve the root before walking so ref-wrapped functions are unwrapped.
     input = resolve(undefined, input)
+  }
   return walkResolver(input, resolve)
 }
 
-function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string, resolveValues = false, resolve?: PropResolver): HeadTag | HeadTag[] {
-  const isObjectInput = typeof _input === 'object' && typeof _input !== 'function'
-  const input = isObjectInput
+function normalizeTag(tagName: HeadTag['tag'], _input: HeadTag['props'] | string): HeadTag | HeadTag[] {
+  const input = typeof _input === 'object' && typeof _input !== 'function'
     ? _input
     : { [(tagName === 'script' || tagName === 'noscript' || tagName === 'style') ? 'innerHTML' : 'textContent']: _input }
-  const tag = normalizePropsInternal({ tag: tagName, props: {} }, input, isObjectInput && resolveValues, resolve)
+  const tag = normalizeProps({ tag: tagName, props: {} }, input)
   if (tag.key && DupeableTags.has(tag.tag))
     tag.props['data-hid'] = tag._h = tag.key
   if (tag.tag === 'script' && typeof tag.innerHTML === 'object') {
@@ -178,41 +128,23 @@ function pushNormalizedTag(tags: HeadTag[], tag: HeadTag | HeadTag[]) {
   }
 }
 
-function normalizeResolvedTag(tags: HeadTag[], tagName: HeadTag['tag'], input: any, resolveValues: boolean, resolve?: PropResolver) {
-  if (resolveValues && (Array.isArray(input)
-    || (input?.constructor === Object && (tagName === 'templateParams' || 'innerHTML' in input || 'textContent' in input)))) {
-    input = resolveChildren(input, resolve)
-    resolveValues = false
-  }
-  pushNormalizedTag(tags, normalizeTag(tagName, input, resolveValues && input?.constructor === Object, resolve))
-}
-
 export function normalizeEntryToTags(input: any, propResolvers: PropResolver[]): HeadTag[] {
   if (!input)
     return []
   if (typeof input === 'function')
     input = input()
-  const resolve = createResolver(propResolvers)
   // The root intentionally passes through the resolver chain twice. The first
-  // pass unwraps refs, then the shallow pass invokes a function returned by a ref.
-  if (resolve)
-    input = resolve(undefined, input)
-  input = resolveShallow(input, resolve)
-  const resolveValues = input?.constructor === Object
+  // pass unwraps refs, then walkResolver invokes a function returned by a ref.
+  input = resolveHeadInput(input, propResolvers)
   const tags: HeadTag[] = []
   for (const key in input) {
-    if (resolveValues && isUnsafeKey(key))
-      continue
-    const value = resolveValues ? resolveShallow(input[key], resolve, key) : input[key]
+    const value = input[key]
     if (value !== undefined) {
       if (Array.isArray(value)) {
-        for (const v of value) {
-          const resolved = resolveValues ? resolveShallow(v, resolve) : v
-          normalizeResolvedTag(tags, key as keyof ResolvableHead, resolved, resolveValues, resolve)
-        }
+        for (const v of value) pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, v))
       }
       else {
-        normalizeResolvedTag(tags, key as keyof ResolvableHead, value, resolveValues, resolve)
+        pushNormalizedTag(tags, normalizeTag(key as keyof ResolvableHead, value))
       }
     }
   }

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -74,6 +74,7 @@ function valuesToTags(ctx: ResolveTagsContext, sortFlatMeta: boolean) {
 
 export function dedupeTags(ctx: ResolveTagsContext): boolean {
   let hasFlatMeta = false
+  let ownedMergeProps: Set<string> | undefined
   for (const next of ctx.tags.sort(sortTags)) {
     const k = next._d || hashTag(next)
     if (!k)
@@ -85,17 +86,41 @@ export function dedupeTags(ctx: ResolveTagsContext): boolean {
     }
     const strategy = next.tagDuplicateStrategy || (UsesMergeStrategy.has(next.tag) ? 'merge' : null) || (next.key && next.key === prev.key ? 'merge' : null)
     if (strategy === 'merge') {
-      const props = { ...prev.props }
+      let props: Record<string, any> = prev.props
+      if (!ownedMergeProps?.has(k)) {
+        props = { ...props }
+        if (props.style instanceof Map)
+          props.style = new Map(props.style)
+        if (props.class instanceof Set)
+          props.class = new Set(props.class)
+        ownedMergeProps ||= new Set()
+        ownedMergeProps.add(k)
+      }
       for (const p in next.props) {
-        // @ts-expect-error untyped - style is Map, class is Set at runtime
-        props[p] = p === 'style'
-          ? new Map([...(prev.props.style || new Map()) as any, ...next.props[p] as any])
-          : p === 'class' ? new Set([...(prev.props.class || []) as any, ...next.props[p] as any]) : next.props[p]
+        if (p === 'style') {
+          const style = props.style ||= new Map()
+          for (const [key, value] of next.props.style as unknown as Map<string, string>)
+            style.set(key, value)
+        }
+        else if (p === 'class') {
+          const classes = props.class ||= new Set()
+          for (const value of next.props.class as unknown as Set<string>)
+            classes.add(value)
+        }
+        else {
+          props[p] = next.props[p]
+        }
       }
       ctx.tagMap.set(k, { ...next, props })
     }
     else if ((next._p! >> 10) === (prev._p! >> 10) && next.tag === 'meta' && isMetaArrayDupeKey(k)) {
-      ctx.tagMap.set(k, Object.assign([...(Array.isArray(prev) ? prev : [prev]), next], next))
+      if (Array.isArray(prev)) {
+        prev.push(next)
+        Object.assign(prev, next)
+      }
+      else {
+        ctx.tagMap.set(k, Object.assign([prev, next], next))
+      }
       hasFlatMeta = true
     }
     // @ts-expect-error untyped

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -2,7 +2,7 @@ import type { HeadEntry, HeadTag, Unhead } from '../types'
 import { hasContent, UsesMergeStrategy, ValidHeadTags } from './const'
 import { dedupeKey, hashTag, isMetaArrayDupeKey } from './dedupe'
 import { callHook } from './hooks'
-import { normalizeEntryToTags } from './normalize'
+import { createPropResolver, normalizeEntryToTags } from './normalize'
 import { isUnsafeKey } from './unsafeKey'
 
 const LT_RE = /</g
@@ -77,7 +77,7 @@ export function dedupeTags(ctx: ResolveTagsContext): boolean {
   let hasFlatMeta = false
   let ownedMergeProps: Set<string> | undefined
   for (const next of ctx.tags.sort(sortTags)) {
-    const k = next._d || hashTag(next)
+    const k = next._d || next._h || hashTag(next)
     if (!k)
       continue
     const prev = ctx.tagMap.get(k)
@@ -241,7 +241,15 @@ export function resolveTags(head: Unhead<any>, options?: ResolveTagsOptions): He
         tags = e._precomputedTags
       }
       else {
-        tags = normalizeEntryToTags(e.input, head.resolvedOptions.propResolvers || [])
+        const propResolvers = head.resolvedOptions.propResolvers || []
+        let compiled = head.resolvedOptions._propResolver
+        if (compiled?.source !== propResolvers) {
+          compiled = head.resolvedOptions._propResolver = {
+            resolve: createPropResolver(propResolvers, Boolean(head.resolvedOptions._eventHandlers)),
+            source: propResolvers,
+          }
+        }
+        tags = normalizeEntryToTags(e.input, propResolvers, head.resolvedOptions._eventHandlers, compiled.resolve)
         if (e.options && !isEmptyProps(e.options)) {
           for (const t of tags)
             Object.assign(t, e.options)

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -3,6 +3,7 @@ import { hasContent, UsesMergeStrategy, ValidHeadTags } from './const'
 import { dedupeKey, hashTag, isMetaArrayDupeKey } from './dedupe'
 import { callHook } from './hooks'
 import { normalizeEntryToTags } from './normalize'
+import { isUnsafeKey } from './unsafeKey'
 
 const LT_RE = /</g
 const SCRIPT_END_RE = /<\/script/g
@@ -97,6 +98,8 @@ export function dedupeTags(ctx: ResolveTagsContext): boolean {
         ownedMergeProps.add(k)
       }
       for (const p in next.props) {
+        if (!Object.hasOwn(next.props, p) || isUnsafeKey(p))
+          continue
         if (p === 'style') {
           const style = props.style ||= new Map()
           for (const [key, value] of next.props.style as unknown as Map<string, string>)

--- a/packages/unhead/src/utils/templateParams.ts
+++ b/packages/unhead/src/utils/templateParams.ts
@@ -4,6 +4,7 @@ const BACKSLASH_RE = /\\/g
 const LT_RE = /</g
 const DOUBLE_QUOTE_RE = /"/g
 const TOKEN_RE = /%\w+(?:\.\w+)?/g
+const ENCODED_PERCENT_RE = /%[\da-f]{2}/i
 
 const SepSub = '%separator'
 
@@ -37,11 +38,13 @@ export function processTemplateParams(s: string, p: TemplateParams, sep?: string
     return s
   // need to avoid replacing url encoded values
   let decoded = s
-  try {
-    decoded = decodeURI(s)
-  }
-  catch {
-    // Malformed encoded input should fall back to token matching against the original string.
+  if (ENCODED_PERCENT_RE.test(s)) {
+    try {
+      decoded = decodeURI(s)
+    }
+    catch {
+      // Malformed encoded input should fall back to token matching against the original string.
+    }
   }
   // find all tokens in decoded
   const tokens = decoded.match(TOKEN_RE)

--- a/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
+++ b/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
@@ -31,4 +31,58 @@ describe('tag-mutating hooks', () => {
     expect(second.htmlAttrs).not.toContain('render-1')
     expect(second.htmlAttrs).toContain('render-2')
   })
+
+  it('filters invalid attributes added by render hooks', () => {
+    const head = createHead({
+      disableDefaults: true,
+      hooks: {
+        'ssr:render': ({ tags }) => {
+          tags[0].props['invalid name'] = 'hidden'
+        },
+      },
+    })
+    head.push({ meta: [{ name: 'description', content: 'visible' }] })
+
+    expect(renderSSRHead(head).headTags).toBe('<meta name="description" content="visible">')
+  })
+
+  it('filters invalid attributes from resolved tags', () => {
+    const head = createHead({ disableDefaults: true })
+    const result = renderSSRHead(head, {
+      resolvedTags: [{
+        tag: 'meta',
+        props: { 'name': 'description', 'content': 'visible', 'invalid name': 'hidden' },
+      }],
+    })
+
+    expect(result.headTags).toBe('<meta name="description" content="visible">')
+  })
+
+  it('filters invalid attributes from object titles', () => {
+    const head = createHead({ disableDefaults: true })
+    head.push({
+      title: {
+        'textContent': 'visible',
+        'invalid name': 'hidden',
+      },
+    } as any)
+
+    expect(renderSSRHead(head).headTags).toBe('<title>visible</title>')
+  })
+
+  it('sees render hooks registered before rendering starts', () => {
+    const head = createHead({
+      disableDefaults: true,
+      hooks: {
+        'ssr:beforeRender': () => {
+          head.hooks.hook('ssr:render', ({ tags }) => {
+            tags[0].props['invalid name'] = 'hidden'
+          })
+        },
+      },
+    })
+    head.push({ meta: [{ name: 'description', content: 'visible' }] })
+
+    expect(renderSSRHead(head).headTags).toBe('<meta name="description" content="visible">')
+  })
 })

--- a/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
+++ b/packages/unhead/test/unit/hooks/mutating-hooks.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { useSeoMeta } from '../../../src'
 import { createHead, renderSSRHead } from '../../../src/server'
 
 describe('tag-mutating hooks', () => {
@@ -84,5 +85,14 @@ describe('tag-mutating hooks', () => {
     head.push({ meta: [{ name: 'description', content: 'visible' }] })
 
     expect(renderSSRHead(head).headTags).toBe('<meta name="description" content="visible">')
+  })
+
+  it('filters invalid attributes produced by flat metadata', () => {
+    const head = createHead({ disableDefaults: true })
+    useSeoMeta(head, {
+      themeColor: [{ 'content': '#fff', 'media': '(prefers-color-scheme: light)', 'invalid name': 'hidden' }] as any,
+    })
+
+    expect(renderSSRHead(head).headTags).toBe('<meta name="theme-color" content="#fff" media="(prefers-color-scheme: light)">')
   })
 })

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -78,6 +78,34 @@ describe('dedupe', () => {
     `)
   })
 
+  it('preserves repeated arrayable metadata across renders', () => {
+    const head = createServerHeadWithContext()
+    useHead(head, {
+      meta: [
+        { property: 'og:image', content: '/first.png' },
+        { property: 'og:image', content: '/second.png' },
+        { property: 'og:image', content: '/third.png' },
+      ],
+    })
+
+    for (let i = 0; i < 2; i++) {
+      const contents = [...renderSSRHead(head).headTags.matchAll(/<meta property="og:image" content="([^"]+)">/g)]
+        .map(match => match[1])
+      expect(contents).toEqual(['/first.png', '/second.png', '/third.png'])
+    }
+  })
+
+  it('merges repeated attributes without mutating cached entries', () => {
+    const head = createServerHeadWithContext()
+    head.push({ htmlAttrs: { 'class': 'first', 'style': { color: 'red' }, 'data-first': '1' } })
+    head.push({ htmlAttrs: { 'class': 'second', 'style': { color: 'blue', display: 'block' }, 'data-second': '2' } })
+    head.push({ htmlAttrs: { 'class': 'third', 'style': { display: 'grid' }, 'data-third': '3' } })
+
+    for (let i = 0; i < 2; i++) {
+      expect(renderSSRHead(head).htmlAttrs).toBe(' class="first second third" style="color:blue;display:grid" data-first="1" data-second="2" data-third="3"')
+    }
+  })
+
   it ('arrays two', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/eventHandlers.test.ts
+++ b/packages/unhead/test/unit/server/eventHandlers.test.ts
@@ -29,4 +29,19 @@ describe('ssr event handlers', () => {
       }
     `)
   })
+
+  it('converts handlers nested inside JSON content', () => {
+    const head = createServerHeadWithContext()
+    useHead(head, {
+      script: [{
+        type: 'application/json',
+        innerHTML: {
+          onReady: () => true,
+        },
+      }],
+    })
+
+    const ctx = renderSSRHead(head)
+    expect(ctx.headTags).toContain('{"onReady":"this.dataset.onReadyfired = true"}')
+  })
 })

--- a/packages/unhead/test/unit/server/eventHandlers.test.ts
+++ b/packages/unhead/test/unit/server/eventHandlers.test.ts
@@ -30,6 +30,20 @@ describe('ssr event handlers', () => {
     `)
   })
 
+  it('does not execute handlers during normalization', () => {
+    const head = createServerHeadWithContext()
+    useHead(head, {
+      script: [{
+        src: '/handler.js',
+        onload: () => {
+          throw new Error('handler executed during SSR')
+        },
+      }],
+    })
+
+    expect(renderSSRHead(head).headTags).toContain('onload="this.dataset.onloadfired = true"')
+  })
+
   it('converts handlers nested inside JSON content', () => {
     const head = createServerHeadWithContext()
     useHead(head, {

--- a/packages/unhead/test/unit/server/prototype-pollution.test.ts
+++ b/packages/unhead/test/unit/server/prototype-pollution.test.ts
@@ -100,4 +100,27 @@ describe('prototype pollution', () => {
     await renderSSRHead(head)
     expect(({} as any).polluted).toBeUndefined()
   })
+
+  it('strips __proto__ from merged attributes replaced by hooks', () => {
+    let normalizeCount = 0
+    let inheritedOnload: unknown
+    const head = createServerHeadWithContext({
+      hooks: {
+        'entries:normalize': ({ tags }) => {
+          if (++normalizeCount === 2)
+            tags[0].props = JSON.parse('{"lang":"en","__proto__":{"onload":"alert(1)"}}')
+        },
+        'tags:beforeResolve': ({ tags }) => {
+          inheritedOnload = tags.find(tag => tag.tag === 'htmlAttrs')?.props.onload
+        },
+      },
+    })
+    head.push({ htmlAttrs: { class: 'first' } })
+    head.push({ htmlAttrs: { class: 'second' } })
+
+    const result = renderSSRHead(head)
+
+    expect(inheritedOnload).toBeUndefined()
+    expect(result.htmlAttrs).not.toContain('onload')
+  })
 })

--- a/packages/unhead/test/unit/server/prototype-pollution.test.ts
+++ b/packages/unhead/test/unit/server/prototype-pollution.test.ts
@@ -102,13 +102,14 @@ describe('prototype pollution', () => {
   })
 
   it('strips __proto__ from merged attributes replaced by hooks', () => {
-    let normalizeCount = 0
     let inheritedOnload: unknown
     const head = createServerHeadWithContext({
       hooks: {
         'entries:normalize': ({ tags }) => {
-          if (++normalizeCount === 2)
-            tags[0].props = JSON.parse('{"lang":"en","__proto__":{"onload":"alert(1)"}}')
+          const htmlAttrs = tags.find(tag => tag.tag === 'htmlAttrs')
+          const classes = htmlAttrs?.props.class as unknown
+          if (htmlAttrs && classes instanceof Set && classes.has('second'))
+            htmlAttrs.props = JSON.parse('{"lang":"en","__proto__":{"onload":"alert(1)"}}')
         },
         'tags:beforeResolve': ({ tags }) => {
           inheritedOnload = tags.find(tag => tag.tag === 'htmlAttrs')?.props.onload
@@ -121,6 +122,7 @@ describe('prototype pollution', () => {
     const result = renderSSRHead(head)
 
     expect(inheritedOnload).toBeUndefined()
+    expect(result.htmlAttrs).toContain('lang="en"')
     expect(result.htmlAttrs).not.toContain('onload')
   })
 })

--- a/packages/unhead/test/unit/templateParams.test.ts
+++ b/packages/unhead/test/unit/templateParams.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { processTemplateParams } from '../../src/utils/templateParams'
+
+describe('processTemplateParams', () => {
+  it('preserves encoded percent sequences while resolving template tokens', () => {
+    expect(processTemplateParams('https://example.com/a%20b/%siteName', { siteName: 'Unhead' }))
+      .toBe('https://example.com/a%20b/Unhead')
+  })
+
+  it('resolves tokens that are not encoded percent sequences', () => {
+    expect(processTemplateParams('%s %separator %siteName', {
+      pageTitle: 'Page',
+      siteName: 'Unhead',
+    }, '|')).toBe('Page | Unhead')
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

This removes work from each SSR pipeline stage:

- Input resolution and property normalization now share one traversal. Resolver chains compile once and refresh when plugins change them.
- Built-in hooks carry private provenance, so normalized attributes use the faster serializer. Custom hooks and `resolvedTags` keep full validation.
- Duplicate merges use request-owned accumulators. Repeated meta values append without copying the full array.
- Stable Schema.org graphs reuse serialized JSON. Mutations, Vue refs, callbacks, custom resolvers, and custom tag hooks disable or invalidate reuse.
- Schema cache state is isolated per head. Cache validation inspects graph dependencies instead of unrelated static entries.
- Template token processing avoids repeated URI errors. The default server event resolver skips its empty chain.
- CI includes a duplicate-heavy renderer and uses the combined 95% confidence interval once. It also reports noisy deltas and fails on missing SSR metrics.

Local shipped-output comparisons against current main show:

- Duplicate-heavy cached SSR: 66% less CPU and 88% less allocation.
- Cached Schema.org SSR: 54% less CPU and 37% less allocation.
- Fresh Vue SSR e2e: 6% to 24% faster across repeated samples.

All 1,980 tests pass, with 8 skipped. Lint, typecheck, full build, and local performance reporting pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered metadata handling for duplicate tags and merged attributes.
  * Prevented cached metadata and attributes from changing unexpectedly across renders.
  * Blocked invalid, unsafe, inherited, and unintended event-handler attributes.
  * Ensured render-time changes are applied immediately.
  * Preserved encoded template parameters while continuing to resolve regular tokens.
  * Prevented server-side event handlers from executing during rendering.

* **Performance**
  * Optimized trusted server-side rendering and schema.org output caching.
  * Added benchmarks for duplicate-tag and repeated-attribute scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
