### PR TITLE
perf: trim shared client and server code

### DIFF
--- a/packages/unhead/src/client/renderDOMHead.ts
+++ b/packages/unhead/src/client/renderDOMHead.ts
@@ -35,15 +35,6 @@ function hasPendingEntries<T extends Unhead<any>>(head: T) {
   return false
 }
 
-function cleanupDomState(state: DomStateInternal) {
-  for (const k in state._s) state._s[k]()
-  for (const k in state._p) state._p[k]()
-  state._s = {}
-  state._p = {}
-  state._e.clear()
-  state._l.clear()
-}
-
 function createDomState<T extends Unhead<any>>(head: T, dom: Document): DomStateInternal {
   const state: DomStateInternal = { _d: dom, _t: dom.title, _e: new Map([['htmlAttrs', dom.documentElement], ['bodyAttrs', dom.body]]), _p: {}, _s: {}, _l: new Map() }
   for (const el of [...dom.body.children, ...dom.head.children]) {
@@ -98,10 +89,15 @@ function _renderDOMHead<T extends Unhead<any>>(head: T, options: RenderDomHeadOp
     callHook(head, 'dom:beforeRender', beforeRenderCtx)
     if (!beforeRenderCtx.shouldRender)
       return false
-    let state = head._dom as DomStateInternal | undefined
+    let state = activeState
     if (state?._d !== dom) {
-      if (state)
-        cleanupDomState(state)
+      if (state) {
+        for (const k in state._s) state._s[k]()
+        for (const k in state._p) state._p[k]()
+        state._s = state._p = {}
+        state._e.clear()
+        state._l.clear()
+      }
       state = undefined
     }
     if (!state) {

--- a/packages/unhead/src/composables.ts
+++ b/packages/unhead/src/composables.ts
@@ -19,31 +19,32 @@ export function useHeadSafe<T extends Unhead<any>>(unhead: T, input: HeadSafe = 
   return useHead(unhead, input as ResolvableHead, Object.assign(options, { _safe: true })) as ActiveHeadEntry<HeadSafe>
 }
 
+function normalizeSeoMetaInput(input: UseSeoMetaInput) {
+  // @ts-expect-error untyped
+  if (input._flatMeta) {
+    return input
+  }
+  const meta: Record<string, any> = {}
+  for (const key in input) {
+    if (!hasOwn(input, key) || key === 'title' || key === 'titleTemplate')
+      continue
+    meta[key] = input[key as keyof UseSeoMetaInput]
+  }
+  return {
+    title: input.title,
+    titleTemplate: input.titleTemplate,
+    _flatMeta: meta,
+  }
+}
+
 export function useSeoMeta<T extends Unhead<any>>(unhead: T, input: UseSeoMetaInput = {}, options?: HeadEntryOptions): ActiveHeadEntry<UseSeoMetaInput> {
   unhead.use(FlatMetaPlugin)
-  function normalize(input: UseSeoMetaInput) {
-    // @ts-expect-error untyped
-    if (input._flatMeta) {
-      return input
-    }
-    const meta: Record<string, any> = {}
-    for (const key in input) {
-      if (!hasOwn(input, key) || key === 'title' || key === 'titleTemplate')
-        continue
-      meta[key] = input[key as keyof UseSeoMetaInput]
-    }
-    return {
-      title: input.title,
-      titleTemplate: input.titleTemplate,
-      _flatMeta: meta,
-    }
-  }
-  const entry = unhead.push(normalize(input), options)
+  const entry = unhead.push(normalizeSeoMetaInput(input), options)
   // just in case
   const corePatch = entry.patch
   // @ts-expect-error runtime
   if (!entry.__patched) {
-    entry.patch = input => corePatch(normalize(input))
+    entry.patch = input => corePatch(normalizeSeoMetaInput(input))
     // @ts-expect-error runtime
     entry.__patched = true
   }

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -32,6 +32,7 @@ import { createScriptWaitFor } from './waitFor'
 type ScriptApi = Record<symbol | string, any>
 type ResolveScriptOptions<R> = Omit<UseScriptOptions<any>, 'resolve' | 'use'> & { resolve: (ctx: UseScriptContextOptions) => R, use?: never }
 type ResolvedScriptApi<R> = Extract<NonNullable<Awaited<R>>, ScriptApi>
+function noop() {}
 
 export function useScript<T extends Record<symbol | string, any>>(head: Unhead<any>, _input: UseScriptLoaderInput<T>, _options: UseScriptLoaderOptions<T> & { scope: true }): ScriptScope<T>
 export function useScript<T extends Record<symbol | string, any>>(head: Unhead<any>, _input: UseScriptLoaderInput<T>, _options?: UseScriptLoaderOptions<T> & { scope?: false }): ScriptInstance<T>
@@ -112,7 +113,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       : undefined
   const _events: { type: string, timestamp: number }[] = []
   let loadError: Error | undefined
-  let resolveLoad = (_value: T | false) => {}
+  let resolveLoad: (value: T | false) => void = noop
   const loadPromise = new Promise<T | false>((resolve) => {
     if (!head.ssr)
       resolveLoad = resolve
@@ -216,13 +217,13 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
   const _registerCb = (key: 'loaded' | 'error', cb: any, options?: EventHandlerOptions) => {
     // events will never run
     if (head.ssr) {
-      return () => {}
+      return noop
     }
     let uniqueKey: string | undefined
     if (options?.key) {
       uniqueKey = `${key}:${options.key}`
       if (_uniqueCbs.has(uniqueKey)) {
-        return () => {}
+        return noop
       }
       _uniqueCbs.add(uniqueKey)
     }
@@ -355,7 +356,6 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       return script._setupTriggerHandler(trigger)
     },
     _setupTriggerHandler(trigger: UseScriptOptions['trigger'], removeOnError = true) {
-      const noop = () => {}
       if (script.status !== 'awaitingLoad') {
         return noop
       }

--- a/packages/unhead/src/server/createHead.ts
+++ b/packages/unhead/src/server/createHead.ts
@@ -69,8 +69,7 @@ function getDefaultInitTags(): HeadTag[] {
 /* @__NO_SIDE_EFFECTS__ */
 export function createHead<T = ResolvableHead>(options: CreateServerHeadOptions = {}): ServerUnhead<T> {
   const tagWeight = options.tagWeight || capoTagWeight
-  const render = createServerRenderer({ tagWeight, omitLineBreaks: options.omitLineBreaks })
-  const core = createUnhead<T, SSRHeadPayload>(render, {
+  const core = createUnhead<T, SSRHeadPayload>(createServerRenderer({ tagWeight, omitLineBreaks: options.omitLineBreaks }), {
     _tagWeight: tagWeight,
     // @ts-expect-error untyped
     document: false,
@@ -98,12 +97,10 @@ export function createHead<T = ResolvableHead>(options: CreateServerHeadOptions 
       defaultEntry._precomputedTags = getDefaultInitTags()
   }
 
-  const hooks = createHooks<ServerHeadHooks>(options.hooks)
-  const head = core as ServerUnhead<T>
-  head.hooks = hooks
+  core.hooks = createHooks<ServerHeadHooks>(options.hooks)
 
   // Register plugins
-  options.plugins?.forEach(p => head.use(p))
+  options.plugins?.forEach(p => core.use(p))
 
-  return head
+  return core as ServerUnhead<T>
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
The full bundles still carried per-call helpers and single-use aliases after #939. Capture-free helpers now live at module scope, while one-call DOM cleanup and server setup run at their call sites. Tracked bundles drop 14 to 36 raw bytes and 7 to 25 gzip bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when rendering head content across different documents, helping prevent stale event and element state.

* **Refactor**
  * Streamlined SEO metadata normalization while preserving existing behavior.
  * Simplified script loading callbacks and server-side head initialization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->