### PR TITLE
fix(devtools): connect bridge through RPC client

### DIFF
--- a/packages/bundler/src/devtools/bridge.ts
+++ b/packages/bundler/src/devtools/bridge.ts
@@ -338,7 +338,7 @@ function connectBridge(head: any) {
 
   async function init() {
     const { getDevToolsRpcClient } = await import('@vitejs/devtools-kit/client')
-    const rpc = await getDevToolsRpcClient()
+    const rpc = await getDevToolsRpcClient({ baseURL: '/__devtools/' })
 
     sharedState = await rpc.sharedState.get('unhead:state', {
       initialValue: serializeHeadState(head, wasSSR, ssrPayload),

--- a/packages/bundler/src/devtools/bridge.ts
+++ b/packages/bundler/src/devtools/bridge.ts
@@ -337,30 +337,10 @@ function connectBridge(head: any) {
   }
 
   async function init() {
-    const { getDevToolsClientContext } = await import('@vitejs/devtools-kit/client')
+    const { getDevToolsRpcClient } = await import('@vitejs/devtools-kit/client')
+    const rpc = await getDevToolsRpcClient()
 
-    // Retry until DevTools client context is available
-    let ctx = getDevToolsClientContext()
-    if (!ctx) {
-      let retries = 0
-      await new Promise<void>((resolve) => {
-        const timer = globalThis.setInterval(() => {
-          ctx = getDevToolsClientContext()
-          if (ctx || ++retries > 50) {
-            globalThis.clearInterval(timer)
-            if (!ctx)
-              console.warn('[unhead bridge] gave up waiting for DevTools context after 50 retries')
-            resolve()
-          }
-        }, 100)
-      })
-    }
-    if (!ctx) {
-      console.warn('[unhead bridge] no DevTools client context, aborting')
-      return
-    }
-
-    sharedState = await (ctx.rpc.sharedState as any).get('unhead:state', {
+    sharedState = await rpc.sharedState.get('unhead:state', {
       initialValue: serializeHeadState(head, wasSSR, ssrPayload),
     })
 

--- a/packages/bundler/src/devtools/vite.ts
+++ b/packages/bundler/src/devtools/vite.ts
@@ -42,6 +42,20 @@ function findPkgRoot(fromUrl: string): string {
   return dir
 }
 
+function resolveDevToolsKitClient(root: string, pkgDir: string): string | undefined {
+  try {
+    const projectRequire = createRequire(resolve(root, 'package.json'))
+    const devtoolsEntry = projectRequire.resolve('@vitejs/devtools')
+    return createRequire(devtoolsEntry).resolve('@vitejs/devtools-kit/client')
+  }
+  catch {
+    // The DevTools plugin may be enabled by Vite config without a project-local package.
+    const fallbackPath = resolve(pkgDir, 'node_modules/@vitejs/devtools-kit/dist/client.js')
+    if (existsSync(fallbackPath))
+      return fallbackPath
+  }
+}
+
 const UNHEAD_ICON = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23FBBF24'/%3E%3Cstop offset='100%25' stop-color='%23f0db4f'/%3E%3C/linearGradient%3E%3Cmask id='m'%3E%3Crect width='100%25' height='100%25' fill='white'/%3E%3Cpath d='M12 32 L1 32 L15 15 Z' fill='black'/%3E%3C/mask%3E%3C/defs%3E%3Cpath fill='none' stroke='url(%23g)' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 4v14a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4' mask='url(%23m)'/%3E%3C/svg%3E`
 
 const DEVTOOLS_UI_ROUTE = '/__unhead/'
@@ -184,9 +198,9 @@ export function unheadDevtools(options?: UnheadDevtoolsInternalOptions): Plugin 
       if (unheadVersion)
 
         code = code.replace(UNHEAD_VERSION_RE, `__UNHEAD_VERSION__ = '${unheadVersion}'`)
-      const kitClientPath = resolve(pkgDir, 'node_modules/@vitejs/devtools-kit/dist/client.js')
-      if (existsSync(kitClientPath))
-        return code.replace(`'@vitejs/devtools-kit/client'`, `'${kitClientPath}'`)
+      const kitClientPath = resolveDevToolsKitClient(root, pkgDir)
+      if (kitClientPath)
+        return code.replace(`'@vitejs/devtools-kit/client'`, JSON.stringify(kitClientPath))
       return code
     },
 

--- a/packages/bundler/test/devtoolsBridge.test.ts
+++ b/packages/bundler/test/devtoolsBridge.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it, vi } from 'vitest'
+
+const devtoolsClient = vi.hoisted(() => ({
+  getClient: vi.fn(),
+}))
+
+vi.mock('@vitejs/devtools-kit/client', () => ({
+  getDevToolsRpcClient: devtoolsClient.getClient,
+}))
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetModules()
+  vi.clearAllMocks()
+  delete (window as any).__unhead_devtools__
+})
+
+it('connects head state through the DevTools RPC client', async () => {
+  vi.useFakeTimers()
+  const getSharedState = vi.fn().mockResolvedValue({ mutate: vi.fn() })
+  devtoolsClient.getClient.mockResolvedValue({
+    sharedState: { get: getSharedState },
+  })
+  ;(window as any).__unhead_devtools__ = {
+    entries: new Map([[1, {
+      input: { title: 'Home' },
+      _tags: [{ tag: 'title', props: {}, textContent: 'Home' }],
+    }]]),
+    hooks: { hook: vi.fn() },
+  }
+
+  await import('../src/devtools/bridge')
+  await vi.advanceTimersByTimeAsync(0)
+
+  expect(devtoolsClient.getClient).toHaveBeenCalledOnce()
+  expect(getSharedState).toHaveBeenCalledWith('unhead:state', {
+    initialValue: expect.objectContaining({
+      tags: [expect.objectContaining({ tag: 'title', textContent: 'Home' })],
+    }),
+  })
+})

--- a/packages/bundler/test/devtoolsBridge.test.ts
+++ b/packages/bundler/test/devtoolsBridge.test.ts
@@ -33,7 +33,7 @@ it('connects head state through the DevTools RPC client', async () => {
   await import('../src/devtools/bridge')
   await vi.advanceTimersByTimeAsync(0)
 
-  expect(devtoolsClient.getClient).toHaveBeenCalledOnce()
+  expect(devtoolsClient.getClient).toHaveBeenCalledWith({ baseURL: '/__devtools/' })
   expect(getSharedState).toHaveBeenCalledWith('unhead:state', {
     initialValue: expect.objectContaining({
       tags: [expect.objectContaining({ tag: 'title', textContent: 'Home' })],

--- a/packages/devtools-app/app/composables/rpc.ts
+++ b/packages/devtools-app/app/composables/rpc.ts
@@ -3,12 +3,13 @@ import { getDevToolsRpcClient } from '@vitejs/devtools-kit/client'
 import { isConnected, syncState } from './state'
 
 export const colorMode = ref<'dark' | 'light'>('dark')
+const DEVTOOLS_RPC_BASE_URL = '/__devtools/'
 
 export async function useDevtoolsConnection(): Promise<void> {
   if (typeof window === 'undefined')
     return
 
-  await getDevToolsRpcClient()
+  await getDevToolsRpcClient({ baseURL: DEVTOOLS_RPC_BASE_URL })
     .then(async (client) => {
       const sharedState = await client.sharedState.get('unhead:state')
       if (!sharedState)
@@ -33,7 +34,7 @@ export async function useDevtoolsConnection(): Promise<void> {
 }
 
 export async function callRpc<T = any>(name: string, ...args: any[]): Promise<T> {
-  const client: any = await getDevToolsRpcClient()
+  const client: any = await getDevToolsRpcClient({ baseURL: DEVTOOLS_RPC_BASE_URL })
   if (!client?.call)
     throw new Error('[unhead] DevTools RPC client unavailable')
   return await client.call(name, ...args) as T


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Resolves #938

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

The bridge waited for whichever global Vite DevTools context initialized first, so plugin order could leave the Unhead panel with no tag state. Connect through `getDevToolsRpcClient()` and cover the state sync boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DevTools bridge initialization by connecting more reliably to the DevTools service.
  * Ensured shared state, including document metadata, is correctly synchronized with DevTools.
  * Improved DevTools client resolution across project setups.
  * Updated DevTools communication to use the correct service path for connections and requests.

* **Tests**
  * Added coverage verifying DevTools connections and shared-state synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

