### PR TITLE
ci: cover duplicate-heavy SSR rendering

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -61,7 +61,7 @@ jobs:
           cp -r bench/bundle/dist /tmp/base-dist
           # measure base perf with the PR's harness against the base-built packages;
           # run from /tmp so the working tree stays clean across the checkout back
-          node --expose-gc /tmp/perf-ci.mjs > /tmp/base-perf.json || echo '{}' > /tmp/base-perf.json
+          node --expose-gc /tmp/perf-ci.mjs > /tmp/base-perf.json
           pnpm exec vitest bench bench/unplugin-transform.bench.ts --config bench/vitest.config.ts --run --outputJson /tmp/base-transform-perf.json
           # the base pnpm install may have rewritten the lockfile; discard before switching back
           git checkout -f -
@@ -75,7 +75,7 @@ jobs:
           pnpm test:vue-bundle-size
           pnpm test:react-bundle-size
           pnpm test:schema-org-bundle-size
-          node --expose-gc bench/perf-ci.mjs > /tmp/pr-perf.json || echo '{}' > /tmp/pr-perf.json
+          node --expose-gc bench/perf-ci.mjs > /tmp/pr-perf.json
           pnpm exec vitest bench bench/unplugin-transform.bench.ts --config bench/vitest.config.ts --run --outputJson /tmp/pr-transform-perf.json
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/bench/bundle/perf-report.test.ts
+++ b/bench/bundle/perf-report.test.ts
@@ -44,7 +44,26 @@ describe('parseVitestBenchmarks', () => {
 })
 
 describe('renderPerfReport allocation noise gate', () => {
-  it('keeps allocation changes within the combined RME out of the verdict', () => {
+  it('keeps allocation changes within the combined 95% confidence interval out of the verdict', () => {
+    const report = renderPerfReport(
+      {
+        benches: [
+          { id: 'alloc', name: 'Allocated / render', kind: 'alloc', value: 100_000, rme: 8 },
+        ],
+      },
+      {
+        benches: [
+          { id: 'alloc', name: 'Allocated / render', kind: 'alloc', value: 108_000, rme: 8 },
+        ],
+      },
+    )
+
+    expect(report).toContain('No significant change')
+    expect(report).toContain('~ +8.0%')
+    expect(report).not.toContain('slower')
+  })
+
+  it('does not double an RME that already represents a 95% confidence interval', () => {
     const report = renderPerfReport(
       {
         benches: [
@@ -58,9 +77,8 @@ describe('renderPerfReport allocation noise gate', () => {
       },
     )
 
-    expect(report).toContain('No significant change')
-    expect(report).toContain('~ noise')
-    expect(report).not.toContain('slower')
+    expect(report).toContain('1 slower')
+    expect(report).toContain('+11.7 KiB (+12.0%)')
   })
 
   it('reports allocation changes that exceed the absolute and RME gates', () => {

--- a/bench/bundle/perf-report.ts
+++ b/bench/bundle/perf-report.ts
@@ -1,8 +1,8 @@
 // Renders the directional Performance section. A change is only surfaced past a gate:
-//  - time:  |Δ| > max(5%, 2× combined relative margin of error). Wall/CPU time is
-//           noisy on shared runners, so the gate is RME-bound; small gains stay hidden.
-//  - alloc: |Δ| > max(2%, 1 KiB). Synchronous bytes allocated per render is
-//           near-deterministic, so a tight gate surfaces gains time can't show.
+//  - time:  |Δ| > max(5% of base, combined 95% confidence interval). Wall/CPU
+//           time is noisy on shared runners, so the gate is confidence-bound.
+//  - alloc: |Δ| > max(2% of base, 1 KiB, combined 95% confidence interval).
+//           Synchronous allocated bytes are stable enough for a tight gate.
 //  - count: |Δ| > max(2%, 0.5). DOM mutations per CSR navigation; deterministic,
 //           so a half-op change is real (a renderer touching more of the DOM).
 // Noisy metrics are `informational`: shown for reference but excluded from the verdict.
@@ -108,18 +108,19 @@ function classify(pr: PerfBench, base?: PerfBench): Row {
     return { bench: pr, base, status: 'new', deltaPct: 0 }
   const delta = pr.value - base.value
   const deltaPct = base.value !== 0 ? (delta / Math.abs(base.value)) * 100 : 0
+  const baseCi = Math.abs(base.value) * (base.rme || 0) / 100
+  const prCi = Math.abs(pr.value) * (pr.rme || 0) / 100
+  const combinedCi = Math.hypot(baseCi, prCi)
   let significant: boolean
   if (pr.kind === 'time') {
-    const threshold = Math.max(TIME_FLOOR_PCT, 2 * ((base.rme || 0) + (pr.rme || 0)))
-    significant = Math.abs(deltaPct) > threshold
+    significant = Math.abs(delta) > Math.max(Math.abs(base.value) * TIME_FLOOR_PCT / 100, combinedCi)
   }
   else if (pr.kind === 'count') {
     // a zero baseline (0 -> N) has no meaningful percentage; fall back to the absolute floor
     significant = Math.abs(delta) > COUNT_FLOOR_UNITS && (base.value === 0 || Math.abs(deltaPct) > COUNT_FLOOR_PCT)
   }
   else {
-    const threshold = Math.max(ALLOC_FLOOR_PCT, 2 * ((base.rme || 0) + (pr.rme || 0)))
-    significant = Math.abs(delta) > ALLOC_FLOOR_BYTES && (base.value === 0 || Math.abs(deltaPct) > threshold)
+    significant = Math.abs(delta) > Math.max(ALLOC_FLOOR_BYTES, Math.abs(base.value) * ALLOC_FLOOR_PCT / 100, combinedCi)
   }
   if (!significant)
     return { bench: pr, base, status: 'same', deltaPct }
@@ -132,9 +133,9 @@ function deltaCell(row: Row): string {
     return '🆕 new'
   // informational metrics report their delta neutrally, never as slower/faster
   if (row.bench.informational)
-    return row.status === 'same' ? '~ noise' : `ℹ️ ${fmtPct(row.deltaPct)}`
+    return row.status === 'same' ? `~ ${fmtPct(row.deltaPct)}` : `ℹ️ ${fmtPct(row.deltaPct)}`
   if (row.status === 'same')
-    return '~ noise'
+    return `~ ${fmtPct(row.deltaPct)}`
   const emoji = row.status === 'slower' ? '🔴' : '🟢'
   if (row.bench.kind === 'time')
     return `${emoji} ${fmtPct(row.deltaPct)}`

--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -51,6 +51,28 @@ function renderMediumSsrHead() {
   return renderSSRHead(head, { omitLineBreaks: true })
 }
 
+function createCachedDuplicateHeavyRenderer() {
+  const head = createHead({ disableDefaults: true })
+  for (let i = 0; i < 100; i++) {
+    head.push({
+      htmlAttrs: {
+        class: `theme-${i}`,
+        [`data-benchmark-${i}`]: `${i}`,
+      },
+    })
+  }
+  head.push({
+    meta: Array.from({ length: 100 }, (_, i) => ({
+      property: 'og:image',
+      content: `/images/${i}.png`,
+    })),
+  })
+
+  const options = { omitLineBreaks: true }
+  renderSSRHead(head, options)
+  return () => renderSSRHead(head, options)
+}
+
 function createCachedSchemaOrgRenderer() {
   const head = createHead({ disableDefaults: true })
   head.push({
@@ -391,6 +413,9 @@ async function csrBenches() {
 
 const times = measureTimes(renderMediumSsrHead)
 const alloc = await measureAlloc(renderMediumSsrHead)
+const renderCachedDuplicateHeavyHead = createCachedDuplicateHeavyRenderer()
+const duplicateHeavyTimes = measureTimes(renderCachedDuplicateHeavyHead, { reps: 30, runs: 250 })
+const duplicateHeavyAlloc = await measureAlloc(renderCachedDuplicateHeavyHead)
 const renderCachedSchemaOrgHead = createCachedSchemaOrgRenderer()
 const schemaOrgTimes = measureTimes(renderCachedSchemaOrgHead, { reps: 30, runs: 120 })
 const schemaOrgAlloc = await measureAlloc(renderCachedSchemaOrgHead)
@@ -400,6 +425,9 @@ const result = {
     { id: 'ssr-medium-cpu', name: 'SSR render (CPU)', kind: 'time', value: times.cpu.value, rme: times.cpu.rme },
     { id: 'ssr-medium-wall', name: 'SSR render (wall)', kind: 'time', value: times.wall.value, rme: times.wall.rme, informational: true },
     { id: 'ssr-medium-alloc', name: 'SSR allocated / render', kind: 'alloc', value: alloc.value, rme: alloc.rme },
+    { id: 'ssr-duplicate-heavy-cached-cpu', name: 'Duplicate-heavy cached render (CPU)', kind: 'time', value: duplicateHeavyTimes.cpu.value, rme: duplicateHeavyTimes.cpu.rme },
+    { id: 'ssr-duplicate-heavy-cached-wall', name: 'Duplicate-heavy cached render (wall)', kind: 'time', value: duplicateHeavyTimes.wall.value, rme: duplicateHeavyTimes.wall.rme, informational: true },
+    { id: 'ssr-duplicate-heavy-cached-alloc', name: 'Duplicate-heavy cached allocated / render', kind: 'alloc', value: duplicateHeavyAlloc.value, rme: duplicateHeavyAlloc.rme },
     { id: 'schema-org-cached-cpu', name: 'Schema.org cached render (CPU)', kind: 'time', value: schemaOrgTimes.cpu.value, rme: schemaOrgTimes.cpu.rme },
     { id: 'schema-org-cached-wall', name: 'Schema.org cached render (wall)', kind: 'time', value: schemaOrgTimes.wall.value, rme: schemaOrgTimes.wall.rme, informational: true },
     { id: 'schema-org-cached-alloc', name: 'Schema.org cached allocated / render', kind: 'alloc', value: schemaOrgAlloc.value, rme: schemaOrgAlloc.rme },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

The bundle job did not measure duplicate-heavy SSR end to end, and its performance gate doubled margins that already represented 95% confidence intervals.

Add a cached case with 100 merged `htmlAttrs` entries and 100 arrayable `og:image` values. The report now combines confidence intervals once, shows noisy deltas, and fails when the SSR harness does not produce metrics.
