### PR TITLE
perf(unhead): scale duplicate tag resolution

### DIFF
--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -46,9 +46,9 @@ export interface ResolveTagsOptions {
 // are containers and need their own copies
 function cloneTag(tag: HeadTag): HeadTag {
   const props: Record<string, any> = { ...tag.props }
-  if (props.class instanceof Set)
+  if (props.class)
     props.class = new Set(props.class)
-  if (props.style instanceof Map)
+  if (props.style)
     props.style = new Map(props.style)
   return { ...tag, props }
 }

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -77,7 +77,7 @@ function valuesToTags(ctx: ResolveTagsContext, sortFlatMeta: boolean) {
 
 export function dedupeTags(ctx: ResolveTagsContext): boolean {
   let hasFlatMeta = false
-  let ownedMergeProps: Set<string> | undefined
+  let ownedMergeProps: WeakSet<Record<string, any>> | undefined
   for (const next of ctx.tags.sort(sortTags)) {
     const k = next._d || hashTag(next)
     if (!k)
@@ -93,10 +93,10 @@ export function dedupeTags(ctx: ResolveTagsContext): boolean {
       : UsesMergeStrategy.has(next.tag) || Boolean(next.key && next.key === prevTag.key)
     if (merge) {
       let props: Record<string, any> = prevTag.props
-      if (!ownedMergeProps?.has(k)) {
+      if (!ownedMergeProps?.has(props)) {
         props = cloneTag(prevTag).props
-        ownedMergeProps ||= new Set()
-        ownedMergeProps.add(k)
+        ownedMergeProps ||= new WeakSet()
+        ownedMergeProps.add(props)
       }
       for (const p in next.props) {
         if (Object.hasOwn(next.props, p) && !isUnsafeKey(p)) {

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -46,10 +46,8 @@ export interface ResolveTagsOptions {
 // are containers and need their own copies
 function cloneTag(tag: HeadTag): HeadTag {
   const props: Record<string, any> = { ...tag.props }
-  if (props.class)
-    props.class = new Set(props.class)
-  if (props.style)
-    props.style = new Map(props.style)
+  props.style &&= new Map(props.style)
+  props.class &&= new Set(props.class)
   return { ...tag, props }
 }
 

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -3,6 +3,7 @@ import { hasContent, UsesMergeStrategy, ValidHeadTags } from './const'
 import { dedupeKey, hashTag, isMetaArrayDupeKey } from './dedupe'
 import { callHook } from './hooks'
 import { normalizeEntryToTags } from './normalize'
+import { isUnsafeKey } from './unsafeKey'
 
 const LT_RE = /</g
 const SCRIPT_END_RE = /<\/script/g
@@ -74,8 +75,9 @@ function valuesToTags(ctx: ResolveTagsContext, sortFlatMeta: boolean) {
 
 export function dedupeTags(ctx: ResolveTagsContext): boolean {
   let hasFlatMeta = false
+  let ownedMergeProps: Set<string> | undefined
   for (const next of ctx.tags.sort(sortTags)) {
-    const k = next._d || hashTag(next)
+    const k = next._d || next._h || hashTag(next)
     if (!k)
       continue
     const prev = ctx.tagMap.get(k)
@@ -85,17 +87,43 @@ export function dedupeTags(ctx: ResolveTagsContext): boolean {
     }
     const strategy = next.tagDuplicateStrategy || (UsesMergeStrategy.has(next.tag) ? 'merge' : null) || (next.key && next.key === prev.key ? 'merge' : null)
     if (strategy === 'merge') {
-      const props = { ...prev.props }
+      let props: Record<string, any> = prev.props
+      if (!ownedMergeProps?.has(k)) {
+        props = { ...props }
+        if (props.style instanceof Map)
+          props.style = new Map(props.style)
+        if (props.class instanceof Set)
+          props.class = new Set(props.class)
+        ownedMergeProps ||= new Set()
+        ownedMergeProps.add(k)
+      }
       for (const p in next.props) {
-        // @ts-expect-error untyped - style is Map, class is Set at runtime
-        props[p] = p === 'style'
-          ? new Map([...(prev.props.style || new Map()) as any, ...next.props[p] as any])
-          : p === 'class' ? new Set([...(prev.props.class || []) as any, ...next.props[p] as any]) : next.props[p]
+        if (!Object.hasOwn(next.props, p) || isUnsafeKey(p))
+          continue
+        if (p === 'style') {
+          const style = props.style ||= new Map()
+          for (const [key, value] of next.props.style as unknown as Map<string, string>)
+            style.set(key, value)
+        }
+        else if (p === 'class') {
+          const classes = props.class ||= new Set()
+          for (const value of next.props.class as unknown as Set<string>)
+            classes.add(value)
+        }
+        else {
+          props[p] = next.props[p]
+        }
       }
       ctx.tagMap.set(k, { ...next, props })
     }
     else if ((next._p! >> 10) === (prev._p! >> 10) && next.tag === 'meta' && isMetaArrayDupeKey(k)) {
-      ctx.tagMap.set(k, Object.assign([...(Array.isArray(prev) ? prev : [prev]), next], next))
+      if (Array.isArray(prev)) {
+        prev.push(next)
+        Object.assign(prev, next)
+      }
+      else {
+        ctx.tagMap.set(k, Object.assign([prev, next], next))
+      }
       hasFlatMeta = true
     }
     // @ts-expect-error untyped

--- a/packages/unhead/src/utils/resolve.ts
+++ b/packages/unhead/src/utils/resolve.ts
@@ -44,16 +44,18 @@ export interface ResolveTagsOptions {
 
 // clone each resolved tag so hooks can't mutate the entry cache; class/style
 // are containers and need their own copies
+function cloneTag(tag: HeadTag): HeadTag {
+  const props: Record<string, any> = { ...tag.props }
+  if (props.class instanceof Set)
+    props.class = new Set(props.class)
+  if (props.style instanceof Map)
+    props.style = new Map(props.style)
+  return { ...tag, props }
+}
+
 function cloneTagsInPlace(tags: HeadTag[]) {
-  for (let i = 0; i < tags.length; i++) {
-    const t = tags[i]
-    const props: Record<string, any> = { ...t.props }
-    if (props.class instanceof Set)
-      props.class = new Set(props.class)
-    if (props.style instanceof Map)
-      props.style = new Map(props.style)
-    tags[i] = { ...t, props }
-  }
+  for (let i = 0; i < tags.length; i++)
+    tags[i] = cloneTag(tags[i])
 }
 
 function valuesToTags(ctx: ResolveTagsContext, sortFlatMeta: boolean) {
@@ -77,7 +79,7 @@ export function dedupeTags(ctx: ResolveTagsContext): boolean {
   let hasFlatMeta = false
   let ownedMergeProps: Set<string> | undefined
   for (const next of ctx.tags.sort(sortTags)) {
-    const k = next._d || next._h || hashTag(next)
+    const k = next._d || hashTag(next)
     if (!k)
       continue
     const prev = ctx.tagMap.get(k)
@@ -85,49 +87,45 @@ export function dedupeTags(ctx: ResolveTagsContext): boolean {
       ctx.tagMap.set(k, next)
       continue
     }
-    const strategy = next.tagDuplicateStrategy || (UsesMergeStrategy.has(next.tag) ? 'merge' : null) || (next.key && next.key === prev.key ? 'merge' : null)
-    if (strategy === 'merge') {
-      let props: Record<string, any> = prev.props
+    const prevTag = Array.isArray(prev) ? prev[prev.length - 1] : prev
+    const merge = next.tagDuplicateStrategy
+      ? next.tagDuplicateStrategy === 'merge'
+      : UsesMergeStrategy.has(next.tag) || Boolean(next.key && next.key === prevTag.key)
+    if (merge) {
+      let props: Record<string, any> = prevTag.props
       if (!ownedMergeProps?.has(k)) {
-        props = { ...props }
-        if (props.style instanceof Map)
-          props.style = new Map(props.style)
-        if (props.class instanceof Set)
-          props.class = new Set(props.class)
+        props = cloneTag(prevTag).props
         ownedMergeProps ||= new Set()
         ownedMergeProps.add(k)
       }
       for (const p in next.props) {
-        if (!Object.hasOwn(next.props, p) || isUnsafeKey(p))
-          continue
-        if (p === 'style') {
-          const style = props.style ||= new Map()
-          for (const [key, value] of next.props.style as unknown as Map<string, string>)
-            style.set(key, value)
-        }
-        else if (p === 'class') {
-          const classes = props.class ||= new Set()
-          for (const value of next.props.class as unknown as Set<string>)
-            classes.add(value)
-        }
-        else {
-          props[p] = next.props[p]
+        if (Object.hasOwn(next.props, p) && !isUnsafeKey(p)) {
+          if (p === 'style') {
+            const style = props.style ||= new Map()
+            for (const [key, value] of next.props.style as unknown as Map<string, string>)
+              style.set(key, value)
+          }
+          else if (p === 'class') {
+            const classes = props.class ||= new Set()
+            for (const value of next.props.class as unknown as Set<string>)
+              classes.add(value)
+          }
+          else {
+            props[p] = next.props[p]
+          }
         }
       }
       ctx.tagMap.set(k, { ...next, props })
     }
-    else if ((next._p! >> 10) === (prev._p! >> 10) && next.tag === 'meta' && isMetaArrayDupeKey(k)) {
-      if (Array.isArray(prev)) {
+    else if ((next._p! >> 10) === (prevTag._p! >> 10) && next.tag === 'meta' && isMetaArrayDupeKey(k)) {
+      if (Array.isArray(prev))
         prev.push(next)
-        Object.assign(prev, next)
-      }
-      else {
-        ctx.tagMap.set(k, Object.assign([prev, next], next))
-      }
+      else
+        ctx.tagMap.set(k, [prev, next] as unknown as HeadTag)
       hasFlatMeta = true
     }
     // @ts-expect-error untyped
-    else if (next._w === prev._w ? next._p! > prev._p! : next._w < prev._w) {
+    else if (next._w === prevTag._w ? next._p! > prevTag._p! : next._w < prevTag._w) {
       ctx.tagMap.set(k, next)
     }
   }

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -95,6 +95,17 @@ describe('dedupe', () => {
     }
   })
 
+  it('replaces arrayable metadata from earlier entries', () => {
+    const head = createServerHeadWithContext()
+    head.push({ meta: [
+      { property: 'og:image', content: '/first.png' },
+      { property: 'og:image', content: '/second.png' },
+    ] })
+    head.push({ meta: [{ property: 'og:image', content: '/latest.png' }] })
+
+    expect(renderSSRHead(head).headTags).toBe('<meta property="og:image" content="/latest.png">')
+  })
+
   it('merges repeated attributes without mutating cached entries', () => {
     const head = createServerHeadWithContext()
     head.push({ htmlAttrs: { 'class': 'first', 'style': { color: 'red' }, 'data-first': '1' } })

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -78,6 +78,34 @@ describe('dedupe', () => {
     `)
   })
 
+  it('preserves repeated arrayable metadata across renders', () => {
+    const head = createServerHeadWithContext()
+    useHead(head, {
+      meta: [
+        { property: 'og:image', content: '/first.png' },
+        { property: 'og:image', content: '/second.png' },
+        { property: 'og:image', content: '/third.png' },
+      ],
+    })
+
+    for (let i = 0; i < 2; i++) {
+      const contents = [...renderSSRHead(head).headTags.matchAll(/<meta property="og:image" content="([^"]+)">/g)]
+        .map(match => match[1])
+      expect(contents).toEqual(['/first.png', '/second.png', '/third.png'])
+    }
+  })
+
+  it('merges repeated attributes without mutating cached entries', () => {
+    const head = createServerHeadWithContext()
+    head.push({ htmlAttrs: { 'class': 'first', 'style': { color: 'red' }, 'data-first': '1' } })
+    head.push({ htmlAttrs: { 'class': 'second', 'style': { color: 'blue', display: 'block' }, 'data-second': '2' } })
+    head.push({ htmlAttrs: { 'class': 'third', 'style': { display: 'grid' }, 'data-third': '3' } })
+
+    for (let i = 0; i < 2; i++) {
+      expect(renderSSRHead(head).htmlAttrs).toBe(' class="first second third" style="color:blue;display:grid" data-first="1" data-second="2" data-third="3"')
+    }
+  })
+
   it ('arrays two', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -117,6 +117,24 @@ describe('dedupe', () => {
     }
   })
 
+  it('merges iterable attributes produced by hooks', () => {
+    const head = createServerHeadWithContext({
+      hooks: {
+        'entries:normalize': ({ tags }) => {
+          const attrs = tags.find(tag => tag.tag === 'htmlAttrs')
+          if (attrs?.props.id === 'first') {
+            attrs.props.class = ['hooked'] as any
+            attrs.props.style = [['color', 'red']] as any
+          }
+        },
+      },
+    })
+    head.push({ htmlAttrs: { id: 'first' } })
+    head.push({ htmlAttrs: { class: 'second', style: { display: 'block' } } })
+
+    expect(renderSSRHead(head).htmlAttrs).toBe(' id="first" class="hooked second" style="color:red;display:block"')
+  })
+
   it ('arrays two', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/deduping.test.ts
+++ b/packages/unhead/test/unit/server/deduping.test.ts
@@ -135,6 +135,18 @@ describe('dedupe', () => {
     expect(renderSSRHead(head).htmlAttrs).toBe(' id="first" class="hooked second" style="color:red;display:block"')
   })
 
+  it('does not mutate a replacement before a later merge', () => {
+    const head = createServerHeadWithContext()
+    head.push({ htmlAttrs: { 'data-first': '1' } })
+    head.push({ htmlAttrs: { 'data-second': '2' } })
+    head.push({ htmlAttrs: { 'data-replacement': '3', 'tagDuplicateStrategy': 'replace' } })
+    const merged = head.push({ htmlAttrs: { 'data-merged': '4' } })
+
+    expect(renderSSRHead(head).htmlAttrs).toContain('data-merged="4"')
+    merged.dispose()
+    expect(renderSSRHead(head).htmlAttrs).toBe(' data-replacement="3"')
+  })
+
   it ('arrays two', async () => {
     const head = createServerHeadWithContext()
 

--- a/packages/unhead/test/unit/server/prototype-pollution.test.ts
+++ b/packages/unhead/test/unit/server/prototype-pollution.test.ts
@@ -100,4 +100,29 @@ describe('prototype pollution', () => {
     await renderSSRHead(head)
     expect(({} as any).polluted).toBeUndefined()
   })
+
+  it('strips __proto__ from merged attributes replaced by hooks', () => {
+    let inheritedOnload: unknown
+    const head = createServerHeadWithContext({
+      hooks: {
+        'entries:normalize': ({ tags }) => {
+          const htmlAttrs = tags.find(tag => tag.tag === 'htmlAttrs')
+          const classes = htmlAttrs?.props.class as unknown
+          if (htmlAttrs && classes instanceof Set && classes.has('second'))
+            htmlAttrs.props = JSON.parse('{"lang":"en","__proto__":{"onload":"alert(1)"}}')
+        },
+        'tags:beforeResolve': ({ tags }) => {
+          inheritedOnload = tags.find(tag => tag.tag === 'htmlAttrs')?.props.onload
+        },
+      },
+    })
+    head.push({ htmlAttrs: { class: 'first' } })
+    head.push({ htmlAttrs: { class: 'second' } })
+
+    const result = renderSSRHead(head)
+
+    expect(inheritedOnload).toBeUndefined()
+    expect(result.htmlAttrs).toContain('lang="en"')
+    expect(result.htmlAttrs).not.toContain('onload')
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Stacked on #943.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Repeated merge tags copied a growing props object for every duplicate. Arrayable metadata also copied its growing accumulator.

Reuse render-owned accumulators after one copy. Keep cached entry props immutable, and reject unsafe inherited keys while merging.

The benchmark in #943 measures 100 merged `htmlAttrs` entries and 100 arrayable `og:image` values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metadata and attribute merging across repeated renders, including array-based and iterable values.
  - Preserved valid `class`, `style`, and language attributes while preventing unsafe properties from being rendered.
  - Prevented cached metadata from being unintentionally modified during deduplication.
  - Added protection against prototype-polluting attributes.

- **Performance**
  - Added coverage for duplicate-heavy server rendering scenarios.
  - Improved performance change detection with confidence-aware thresholds and clearer percentage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->