### PR TITLE
fix(bundler): transform .mts, .cts, and IDs with queries

### DIFF
--- a/bench/unplugin-transform.bench.ts
+++ b/bench/unplugin-transform.bench.ts
@@ -83,8 +83,26 @@ function transformHandler(plugin: any) {
   return typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
 }
 
+function idFilterMatches(plugin: any, id: string) {
+  const filter = typeof plugin.transform === 'function' ? undefined : plugin.transform?.filter?.id
+  if (!filter)
+    return true
+  if (filter instanceof RegExp)
+    return filter.test(id)
+  if (filter.exclude && toArray(filter.exclude).some((pattern: RegExp) => pattern.test(id)))
+    return false
+  const include = toArray(filter.include)
+  return include.length === 0 || include.some((pattern: RegExp) => pattern.test(id))
+}
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined)
+    return []
+  return Array.isArray(value) ? value : [value]
+}
+
 async function runPluginTransform(plugin: any, code: string, id: string, context: any = {}) {
-  if (plugin.transformInclude && !plugin.transformInclude(id))
+  if (!idFilterMatches(plugin, id))
     return undefined
   const transform = plugin.transform
   const codeFilter = typeof transform === 'function' ? undefined : transform?.filter?.code
@@ -109,17 +127,17 @@ function assertTransformResult(result: unknown, name: string) {
 }
 
 describe('unplugin transform CPU', () => {
-  bench('transformInclude mixed ids', () => {
+  bench('transform id filter mixed ids', () => {
     const seo = UseSeoMetaTransform.vite({}) as any
     const minify = MinifyTransform.vite({ js: mockJSMinifier, css: mockCSSMinifier }) as any
     const treeshake = TreeshakeServerComposables.vite({}) as any
     let included = 0
     for (const id of ids) {
-      if (seo.transformInclude(id))
+      if (idFilterMatches(seo, id))
         included++
-      if (minify.transformInclude(id))
+      if (idFilterMatches(minify, id))
         included++
-      if (treeshake.transformInclude(id))
+      if (idFilterMatches(treeshake, id))
         included++
     }
     return included

--- a/packages/bundler/src/devtools/filter.ts
+++ b/packages/bundler/src/devtools/filter.ts
@@ -1,0 +1,9 @@
+/**
+ * Transform filter shared by the devtools plugin and its lazy proxy.
+ *
+ * The proxy declares the hook filter that actually gates the real plugin's
+ * handler, so both sides must agree. Keeping one copy here removes the drift.
+ */
+export const HEAD_COMPOSABLES = ['useHead', 'useSeoMeta', 'useHeadSafe', 'useScript']
+
+export const HEAD_COMPOSABLE_RE = new RegExp(`\\b(?:${HEAD_COMPOSABLES.join('|')})\\b`)

--- a/packages/bundler/src/devtools/lazy.ts
+++ b/packages/bundler/src/devtools/lazy.ts
@@ -1,9 +1,9 @@
 import type { Plugin } from 'vite'
 import type { HeadTransformContext } from '../unplugin/CreateHeadTransform'
 import type { UnheadDevtoolsOptions } from '../unplugin/types'
+import { SOURCE_FILE_RE } from '../unplugin/utils'
+import { HEAD_COMPOSABLE_RE } from './filter'
 
-const HEAD_COMPOSABLE_RE = /\b(?:useHead|useSeoMeta|useHeadSafe|useScript)\b/
-const FILE_RE = /\.(vue|tsx?|jsx?|svelte)$/
 const DEVTOOLS_KIT_PACKAGE = '@vitejs/devtools-kit'
 
 interface LazyUnheadDevtoolsOptions extends UnheadDevtoolsOptions {
@@ -118,7 +118,7 @@ export function lazyUnheadDevtools(options?: LazyUnheadDevtoolsOptions): Plugin 
     },
 
     transform: {
-      filter: { id: FILE_RE, code: HEAD_COMPOSABLE_RE },
+      filter: { id: SOURCE_FILE_RE, code: HEAD_COMPOSABLE_RE },
       async handler(code, id, options) {
         return callEnabledHook('transform', this, [code, id, options])
       },

--- a/packages/bundler/src/devtools/vite.ts
+++ b/packages/bundler/src/devtools/vite.ts
@@ -8,11 +8,10 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import MagicString from 'magic-string'
 import { parseAndWalkSource } from '../unplugin/parser'
+import { SOURCE_FILE_RE } from '../unplugin/utils'
+import { HEAD_COMPOSABLE_RE, HEAD_COMPOSABLES } from './filter'
 import { getConfigRpc, runLintRpc } from './rpc'
 
-const HEAD_COMPOSABLES = ['useHead', 'useSeoMeta', 'useHeadSafe', 'useScript']
-const HEAD_COMPOSABLE_RE = new RegExp(`\\b(?:${HEAD_COMPOSABLES.join('|')})\\b`)
-const FILE_RE = /\.(vue|tsx?|jsx?|svelte)$/
 const LEADING_SLASH_RE = /^\//
 const UNHEAD_VERSION_RE = /__UNHEAD_VERSION__ = ['"]'?["']/
 
@@ -64,9 +63,6 @@ const DEVTOOLS_UI_ROUTE = '/__unhead/'
  * Transforms source code to inject `_source` metadata into head composable calls.
  */
 function transformSourceLocations(code: string, id: string, root: string): { code: string, map: any } | undefined {
-  if (!HEAD_COMPOSABLE_RE.test(code))
-    return
-
   const s = new MagicString(code)
   let transformed = false
 
@@ -205,7 +201,7 @@ export function unheadDevtools(options?: UnheadDevtoolsInternalOptions): Plugin 
     },
 
     transform: {
-      filter: { id: FILE_RE, code: HEAD_COMPOSABLE_RE },
+      filter: { id: SOURCE_FILE_RE, code: HEAD_COMPOSABLE_RE },
       handler(code, id) {
         if (!enabled)
           return

--- a/packages/bundler/src/unplugin/CreateHeadTransform.ts
+++ b/packages/bundler/src/unplugin/CreateHeadTransform.ts
@@ -1,8 +1,8 @@
 import type { Plugin } from 'vite'
 import MagicString from 'magic-string'
 import { parseAndWalkSource } from './parser'
+import { SOURCE_FILE_RE } from './utils'
 
-const FILE_RE = /\.(vue|tsx?|jsx?|svelte)$/
 const CREATE_HEAD_RE = /\bcreateHead\b/
 const UNHEAD_SOURCE_RE = /^(?:@unhead\/[^/]+|unhead)(?:\/[^?]*)?$/
 
@@ -44,12 +44,10 @@ export function CreateHeadTransform(ctx: HeadTransformContext): Plugin {
     },
 
     transform: {
-      filter: { id: FILE_RE, code: CREATE_HEAD_RE },
+      filter: { id: SOURCE_FILE_RE, code: CREATE_HEAD_RE },
       handler(code, id) {
         const registrations = ctx.getRegistrations()
         if (!registrations.length)
-          return
-        if (!CREATE_HEAD_RE.test(code))
           return
 
         const isServer = this.environment?.config?.consumer === 'server'

--- a/packages/bundler/src/unplugin/MinifyTransform.ts
+++ b/packages/bundler/src/unplugin/MinifyTransform.ts
@@ -190,11 +190,11 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
     if (NODE_MODULES_RE.test(pathname))
       return false
 
-    if (options.filter?.include?.some(pattern => id.match(pattern)))
-      return true
-
     if (options.filter?.exclude?.some(pattern => id.match(pattern)))
       return false
+
+    if (options.filter?.include?.some(pattern => id.match(pattern)))
+      return true
 
     // vue files
     if (isVueScriptRequest(pathname, query))

--- a/packages/bundler/src/unplugin/MinifyTransform.ts
+++ b/packages/bundler/src/unplugin/MinifyTransform.ts
@@ -6,9 +6,8 @@ import { ScopeTracker, ScopeTrackerImport } from 'oxc-walker'
 import { minifyJSON } from 'unhead/minify'
 import { createUnplugin } from 'unplugin'
 import { isMissingParserError, parseAndWalkSource } from './parser'
-import { createJsVueTransformIdFilter, isVueScriptRequest, NODE_MODULES_RE, splitTransformId } from './utils'
+import { createJsVueTransformIdFilter, isVueScriptRequest, JS_EXT_RE, NODE_MODULES_RE, splitTransformId } from './utils'
 
-const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
 const HEAD_RE = /\buse(?:Server)?Head\b/
 
 const JSON_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
@@ -202,20 +201,15 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
       return true
 
     // js/ts files
-    if (TRANSFORM_RE.test(pathname))
+    if (JS_EXT_RE.test(pathname))
       return true
 
     return false
   }
 
-  function shouldTransformCode(code: string): boolean {
-    return HEAD_RE.test(code)
-  }
-
   return {
     name: 'unhead:minify-transform',
     enforce: 'post',
-    transformInclude: shouldTransformId,
 
     vite: jsTranspiler
       ? {
@@ -231,10 +225,10 @@ export const MinifyTransform = createUnplugin<MinifyTransformOptions, false>((op
         id: createJsVueTransformIdFilter(options.filter?.include),
       },
       async handler(code, id) {
+        // `filter.id` admits `.vue` sub-requests of any block type, and it
+        // cannot express the caller's `filter.exclude`, so the id still needs
+        // a second look. `filter.code` already guaranteed `useHead`.
         if (!shouldTransformId(id))
-          return
-
-        if (!shouldTransformCode(code))
           return
 
         // Escaped identifiers still need parsing because their source does not

--- a/packages/bundler/src/unplugin/SSRStaticReplace.ts
+++ b/packages/bundler/src/unplugin/SSRStaticReplace.ts
@@ -29,18 +29,9 @@ export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() 
   // `head.ssr` is left dynamic in the source.
   let fallbackConsumer: BuildConsumer | undefined
 
-  function shouldTransformId(id: string): boolean {
-    return UNHEAD_JS_MODULE_RE.test(id)
-  }
-
-  function shouldTransformCode(code: string): boolean {
-    return HEAD_SSR_FILTER_RE.test(code)
-  }
-
   return {
     name: 'unhead:ssr-static-replace',
     enforce: 'pre',
-    transformInclude: shouldTransformId,
 
     transform: {
       filter: {
@@ -52,12 +43,6 @@ export const SSRStaticReplace = createUnplugin<Record<string, never>, false>(() 
         // Unknown build target: retain `head.ssr` so runtime detection keeps
         // working instead of hard-coding the wrong branch.
         if (!consumer)
-          return
-
-        if (!shouldTransformId(id))
-          return
-
-        if (!shouldTransformCode(code))
           return
 
         const ssr = consumer === 'server'

--- a/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
+++ b/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
@@ -48,13 +48,13 @@ export const TreeshakeServerComposables = createUnplugin<TreeshakeServerComposab
     if (NODE_MODULES_RE.test(pathname))
       return false
 
-    // Included
-    if (options.filter?.include?.some(pattern => id.match(pattern)))
-      return true
-
     // Excluded
     if (options.filter?.exclude?.some(pattern => id.match(pattern)))
       return false
+
+    // Included
+    if (options.filter?.include?.some(pattern => id.match(pattern)))
+      return true
 
     // vue files
     if (isVueScriptRequest(pathname, query))

--- a/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
+++ b/packages/bundler/src/unplugin/TreeshakeServerComposables.ts
@@ -5,9 +5,8 @@ import MagicString from 'magic-string'
 import { ScopeTracker, ScopeTrackerImport, walk } from 'oxc-walker'
 import { createUnplugin } from 'unplugin'
 import { parseAndWalkSource } from './parser'
-import { createJsVueTransformIdFilter, isVueScriptRequest, NODE_MODULES_RE, resolveBuildConsumer, splitTransformId } from './utils'
+import { createJsVueTransformIdFilter, isVueScriptRequest, JS_EXT_RE, NODE_MODULES_RE, resolveBuildConsumer, splitTransformId } from './utils'
 
-const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
 const SERVER_COMPOSABLE_RE = /\b(?:useServerHead|useServerHeadSafe|useServerSeoMeta|useSchemaOrg)\b/
 
 const functionNames = new Set([
@@ -62,20 +61,15 @@ export const TreeshakeServerComposables = createUnplugin<TreeshakeServerComposab
       return true
 
     // js files
-    if (TRANSFORM_RE.test(pathname))
+    if (JS_EXT_RE.test(pathname))
       return true
 
     return false
   }
 
-  function shouldTransformCode(code: string): boolean {
-    return SERVER_COMPOSABLE_RE.test(code)
-  }
-
   return {
     name: 'unhead:remove-server-composables',
     enforce: 'post',
-    transformInclude: shouldTransformId,
 
     transform: {
       filter: {
@@ -89,12 +83,11 @@ export const TreeshakeServerComposables = createUnplugin<TreeshakeServerComposab
         if (resolveBuildConsumer(this, fallbackConsumer) !== 'client')
           return
 
+        // `filter.id` admits `.vue` sub-requests of any block type, and it
+        // cannot express the caller's `filter.exclude`, so the id still needs
+        // a second look. `filter.code` already guaranteed the composables.
         if (!shouldTransformId(id))
           return
-
-        if (!shouldTransformCode(code)) {
-          return
-        }
 
         const scopeTracker = new ScopeTracker({ preserveExitedScopes: true })
         const ast = parseAndWalkSource(code, id, { scopeTracker })

--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -64,13 +64,13 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
     if (NODE_MODULES_RE.test(pathname))
       return false
 
-    // Included
-    if (options.filter?.include?.some(pattern => id.match(pattern)))
-      return true
-
     // Excluded
     if (options.filter?.exclude?.some(pattern => id.match(pattern)))
       return false
+
+    // Included
+    if (options.filter?.include?.some(pattern => id.match(pattern)))
+      return true
 
     // vue files
     if (isVueScriptRequest(pathname, query))

--- a/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
+++ b/packages/bundler/src/unplugin/UseSeoMetaTransform.ts
@@ -9,9 +9,8 @@ import {
 } from 'unhead/utils'
 import { createUnplugin } from 'unplugin'
 import { parseAndWalkSource } from './parser'
-import { createJsVueTransformIdFilter, isVueScriptRequest, NODE_MODULES_RE, splitTransformId } from './utils'
+import { createJsVueTransformIdFilter, isVueScriptRequest, JS_EXT_RE, NODE_MODULES_RE, splitTransformId } from './utils'
 
-const TRANSFORM_RE = /\.(?:(?:c|m)?j|t)sx?$/
 const SEO_META_RE = /\buse(?:Server)?SeoMeta\b/
 
 export interface UseSeoMetaTransformOptions extends BaseTransformerTypes {
@@ -78,20 +77,15 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
       return true
 
     // js files
-    if (TRANSFORM_RE.test(pathname))
+    if (JS_EXT_RE.test(pathname))
       return true
 
     return false
   }
 
-  function shouldTransformCode(code: string): boolean {
-    return SEO_META_RE.test(code)
-  }
-
   return {
     name: 'unhead:use-seo-meta-transform',
     enforce: 'post',
-    transformInclude: shouldTransformId,
 
     transform: {
       filter: {
@@ -99,10 +93,10 @@ export const UseSeoMetaTransform = createUnplugin<UseSeoMetaTransformOptions, fa
         id: createJsVueTransformIdFilter(options.filter?.include),
       },
       async handler(code, id) {
+        // `filter.id` admits `.vue` sub-requests of any block type, and it
+        // cannot express the caller's `filter.exclude`, so the id still needs
+        // a second look. `filter.code` already guaranteed `useSeoMeta`.
         if (!shouldTransformId(id))
-          return
-
-        if (!shouldTransformCode(code))
           return
 
         const scopeTracker = new ScopeTracker({ preserveExitedScopes: true })

--- a/packages/bundler/src/unplugin/utils.ts
+++ b/packages/bundler/src/unplugin/utils.ts
@@ -22,7 +22,27 @@ export function resolveBuildConsumer(ctx: unknown, fallback: BuildConsumer | und
     return consumer
   return fallback
 }
-export const JS_VUE_RE = /\.(?:(?:c|m)?j|t)sx?(?:$|\?)|\.vue(?:$|\?)/
+/**
+ * Script extensions the transforms understand, matched against a `pathname`
+ * with any query already stripped by `splitTransformId`.
+ *
+ * Covers every JS/TS extension pair: `.js`, `.cjs`, `.mjs`, `.jsx`, `.ts`,
+ * `.cts`, `.mts`, `.tsx`.
+ */
+export const JS_EXT_RE = /\.[cm]?[jt]sx?$/
+
+/**
+ * Same extensions as `JS_EXT_RE` plus `.vue`, matched against a raw module id.
+ * Ids carry a query in dev and for SFC sub-requests (`App.vue?vue&type=script`),
+ * so the pattern ends at `?` as well as at the end of the string.
+ */
+export const JS_VUE_RE = /\.(?:[cm]?[jt]sx?|vue)(?:$|\?)/
+
+/**
+ * Same extensions as `JS_VUE_RE` plus `.svelte`, for the plugins that inspect
+ * any authored source file rather than only script modules.
+ */
+export const SOURCE_FILE_RE = /\.(?:[cm]?[jt]sx?|vue|svelte)(?:$|\?)/
 
 export function createJsVueTransformIdFilter(include?: RegExp[]): HookFilter['id'] {
   return {

--- a/packages/bundler/test/createHeadTransform.test.ts
+++ b/packages/bundler/test/createHeadTransform.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { CreateHeadTransform, createHeadTransformContext } from '../src/unplugin/CreateHeadTransform'
+import { passesTransformFilter } from './utils'
 
 function createPlugin(registrations: Parameters<ReturnType<typeof createHeadTransformContext>['addRuntimePlugin']>[0][], consumer: 'client' | 'server' = 'client') {
   const ctx = createHeadTransformContext()
@@ -20,6 +21,34 @@ function createPlugin(registrations: Parameters<ReturnType<typeof createHeadTran
 }
 
 describe('createHeadTransform', () => {
+  it.each([
+    '/src/main.ts',
+    '/src/main.mts',
+    '/src/main.cts',
+    '/src/main.mjs',
+    '/src/main.tsx',
+    '/src/App.vue',
+    // dev ids and SFC sub-requests carry a query
+    '/src/main.ts?t=1730000000',
+    '/src/App.vue?vue&type=script&setup=true',
+    '/src/App.svelte?svelte&type=script&lang.ts',
+  ])('runs on %s', (id) => {
+    const { plugin } = createPlugin([{
+      import: { name: 'ValidatePlugin', source: '@unhead/vue/plugins', as: '__validate' },
+      client: '_h.use(__validate())',
+    }])
+    expect(passesTransformFilter(plugin, id, 'const head = createHead()')).toBe(true)
+  })
+
+  it('skips ids and sources that cannot hold a createHead call', () => {
+    const { plugin } = createPlugin([{
+      import: { name: 'ValidatePlugin', source: '@unhead/vue/plugins', as: '__validate' },
+      client: '_h.use(__validate())',
+    }])
+    expect(passesTransformFilter(plugin, '/src/style.css', 'const head = createHead()')).toBe(false)
+    expect(passesTransformFilter(plugin, '/src/main.ts', 'const x = 1')).toBe(false)
+  })
+
   it('ignores files without createHead', async () => {
     const { transform } = createPlugin([{
       import: { name: 'ValidatePlugin', source: '@unhead/vue/plugins', as: '__validate' },

--- a/packages/bundler/test/devtoolsFilter.test.ts
+++ b/packages/bundler/test/devtoolsFilter.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { lazyUnheadDevtools } from '../src/devtools/lazy'
+import { passesTransformFilter } from './utils'
+
+// The lazy proxy declares the hook filter that gates the real devtools
+// plugin's transform, so its filter is the one that decides which sources get
+// `_source` metadata.
+const plugin = lazyUnheadDevtools() as any
+const code = `useHead({ title: 'Home' })`
+
+describe('devtools transform filter', () => {
+  it.each([
+    '/src/main.ts',
+    '/src/main.mts',
+    '/src/main.cts',
+    '/src/main.mjs',
+    '/src/main.cjs',
+    '/src/Page.tsx',
+    '/src/App.vue',
+    '/src/App.svelte',
+    // dev ids and SFC sub-requests carry a query
+    '/src/main.ts?t=1730000000',
+    '/src/App.vue?vue&type=script&setup=true',
+  ])('runs on %s', (id) => {
+    expect(passesTransformFilter(plugin, id, code)).toBe(true)
+  })
+
+  it('skips ids and sources that cannot hold a head composable', () => {
+    expect(passesTransformFilter(plugin, '/src/style.css', code)).toBe(false)
+    expect(passesTransformFilter(plugin, '/src/main.ts', 'const x = 1')).toBe(false)
+  })
+})

--- a/packages/bundler/test/fixtures/vite-build/entry.mts
+++ b/packages/bundler/test/fixtures/vite-build/entry.mts
@@ -1,0 +1,7 @@
+// `.mts` entry: the transforms must treat it exactly like `entry.ts`.
+
+// @ts-ignore Nuxt-style auto-import
+useServerSeoMeta({ description: 'SERVER_ONLY_MARKER' })
+
+// @ts-ignore Nuxt-style auto-import
+useSeoMeta({ title: 'CLIENT_MARKER' })

--- a/packages/bundler/test/minifyTransform.test.ts
+++ b/packages/bundler/test/minifyTransform.test.ts
@@ -1,6 +1,7 @@
 import type { MinifyFn } from '../src/unplugin/MinifyTransform'
 import { describe, expect, it } from 'vitest'
 import { MinifyTransform } from '../src/unplugin/MinifyTransform'
+import { runTransform } from './utils'
 
 const mockJSMinifier: MinifyFn = async (code: string) => {
   // simple mock: strip comments and collapse whitespace
@@ -18,14 +19,7 @@ async function transform(code: string | string[], opts: { js?: false | MinifyFn,
 }
 
 async function transformWithPlugin(plugin: any, code: string | string[], id = '/app/some-id.js') {
-  if (plugin.transformInclude && !plugin.transformInclude(id))
-    return undefined
-  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
-  return handler.call(
-    {},
-    Array.isArray(code) ? code.join('\n') : code,
-    id,
-  )
+  return runTransform(plugin, Array.isArray(code) ? code.join('\n') : code, id)
 }
 
 describe('minifyTransform', () => {
@@ -244,6 +238,21 @@ describe('minifyTransform', () => {
 
     expect(code).toBeUndefined()
   })
+
+  it.each(['/app/test.ts', '/app/test.mts', '/app/test.cts', '/app/test.mjs', '/app/test.cjs', '/app/test.tsx'])(
+    'minifies inside %s modules',
+    async (id) => {
+      const code = await transform([
+        `import { useHead } from 'unhead'`,
+        `useHead({`,
+        `  script: [{ innerHTML: '// comment\\nvar x = 1;  var y = 2;' }]`,
+        `})`,
+      ], { js: mockJSMinifier }, id)
+
+      expect(code).toBeDefined()
+      expect(code).not.toContain('// comment')
+    },
+  )
 
   it('handles template literal without expressions', async () => {
     const code = await transform([

--- a/packages/bundler/test/minifyTransform.test.ts
+++ b/packages/bundler/test/minifyTransform.test.ts
@@ -23,6 +23,21 @@ async function transformWithPlugin(plugin: any, code: string | string[], id = '/
 }
 
 describe('minifyTransform', () => {
+  it('does not transform files matched by both include and exclude', async () => {
+    const plugin = MinifyTransform.vite({
+      js: mockJSMinifier,
+      filter: {
+        include: [/excluded/],
+        exclude: [/excluded/],
+      },
+    }) as any
+    const code = await transformWithPlugin(plugin, [
+      `import { useHead } from 'unhead'`,
+      `useHead({ script: [{ innerHTML: 'var x = 1;  var y = 2;' }] })`,
+    ], '/src/excluded.ts')
+    expect(code).toBeUndefined()
+  })
+
   it('minifies inline script innerHTML with provided js minifier', async () => {
     const code = await transform([
       `import { useHead } from 'unhead'`,

--- a/packages/bundler/test/ssrStaticReplace.test.ts
+++ b/packages/bundler/test/ssrStaticReplace.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { SSRStaticReplace } from '../src/unplugin/SSRStaticReplace'
+import { passesTransformFilter, runTransform } from './utils'
 
 function createPlugin(env: { isSsrBuild?: boolean, command?: string } = {}) {
   const plugin = SSRStaticReplace.vite({}) as any
@@ -13,10 +14,7 @@ function environmentContext(consumer: 'client' | 'server') {
 }
 
 function transform(plugin: any, code: string, id: string, ctx: any = {}) {
-  if (plugin.transformInclude && !plugin.transformInclude(id))
-    return undefined
-  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
-  return handler.call(ctx, code, id)
+  return runTransform(plugin, code, id, ctx)
 }
 
 const UNHEAD_MODULE_ID = '/node_modules/@unhead/vue/dist/index.mjs'
@@ -25,10 +23,11 @@ const USER_MODULE_ID = '/src/app.js'
 describe('ssrStaticReplace', () => {
   it('only transforms unhead modules', () => {
     const plugin = createPlugin()
-    expect(plugin.transformInclude(UNHEAD_MODULE_ID)).toBe(true)
-    expect(plugin.transformInclude(USER_MODULE_ID)).toBe(false)
-    expect(plugin.transformInclude('/node_modules/unhead/dist/index.mjs')).toBe(true)
-    expect(plugin.transformInclude('/src/components/Head.vue')).toBe(false)
+    const code = 'if (head.ssr) {}'
+    expect(passesTransformFilter(plugin, UNHEAD_MODULE_ID, code)).toBe(true)
+    expect(passesTransformFilter(plugin, USER_MODULE_ID, code)).toBe(false)
+    expect(passesTransformFilter(plugin, '/node_modules/unhead/dist/index.mjs', code)).toBe(true)
+    expect(passesTransformFilter(plugin, '/src/components/Head.vue', code)).toBe(false)
   })
 
   it('replaces head.ssr with false for client builds', () => {

--- a/packages/bundler/test/treeshakeServerComposables.test.ts
+++ b/packages/bundler/test/treeshakeServerComposables.test.ts
@@ -27,6 +27,16 @@ describe('treeshakeServerComposables', () => {
     expect(await transform(couldTransform, 'test.css')).toBeUndefined()
   })
 
+  it('does not transform files matched by both include and exclude', async () => {
+    const plugin = TreeshakeServerComposables.vite({
+      filter: {
+        include: [/excluded/],
+        exclude: [/excluded/],
+      },
+    }) as any
+    expect(await transformWith(plugin, couldTransform, '/src/excluded.ts')).toBeUndefined()
+  })
+
   it.each(['test.ts', 'test.mts', 'test.cts', 'test.js', 'test.mjs', 'test.cjs', 'test.tsx', 'test.jsx'])(
     'transforms %s modules',
     async (id) => {

--- a/packages/bundler/test/treeshakeServerComposables.test.ts
+++ b/packages/bundler/test/treeshakeServerComposables.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { TreeshakeServerComposables } from '../src/unplugin/TreeshakeServerComposables'
+import { runTransform } from './utils'
 
 const USE_SERVER_HEAD_RE = /useServerHead/
 
@@ -8,14 +9,7 @@ function environmentContext(consumer: 'client' | 'server') {
 }
 
 async function transformWith(plugin: any, code: string | string[], id = 'some-id.js', ctx: any = environmentContext('client')) {
-  if (plugin.transformInclude && !plugin.transformInclude(id))
-    return
-  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
-  const res = await handler.call(
-    ctx,
-    Array.isArray(code) ? code.join('\n') : code,
-    id,
-  )
+  const res = await runTransform(plugin, Array.isArray(code) ? code.join('\n') : code, id, ctx)
   return res?.code
 }
 
@@ -31,6 +25,17 @@ describe('treeshakeServerComposables', () => {
 
   it('ignores non-JS files', async () => {
     expect(await transform(couldTransform, 'test.css')).toBeUndefined()
+  })
+
+  it.each(['test.ts', 'test.mts', 'test.cts', 'test.js', 'test.mjs', 'test.cjs', 'test.tsx', 'test.jsx'])(
+    'transforms %s modules',
+    async (id) => {
+      expect(await transform(couldTransform, id)).toBeDefined()
+    },
+  )
+
+  it('transforms ids that carry a query', async () => {
+    expect(await transform(couldTransform, '/src/app.mts?t=1730000000')).toBeDefined()
   })
 
   it('transforms vue script blocks', async () => {

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -1,17 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 import { UseSeoMetaTransform } from '../src/unplugin/UseSeoMetaTransform'
+import { runTransform } from './utils'
 
 const USE_SERVER_HEAD_RE = /useServerHead/
 const TITLE_RE = /title:/
 
 async function transform(code: string | string[], id = 'some-id.js', opts: any = {}) {
   const plugin = UseSeoMetaTransform.vite(opts) as any
-  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
-  const res = await handler.call(
-    {},
-    Array.isArray(code) ? code.join('\n') : code,
-    id,
-  )
+  const res = await runTransform(plugin, Array.isArray(code) ? code.join('\n') : code, id)
   return res?.code
 }
 
@@ -48,6 +44,13 @@ describe('useSeoMetaTransform', () => {
   it('ignores non-JS files', async () => {
     expect(await transform(couldTransform, 'test.css')).toBeUndefined()
   })
+
+  it.each(['test.ts', 'test.mts', 'test.cts', 'test.js', 'test.mjs', 'test.cjs', 'test.tsx', 'test.jsx'])(
+    'transforms %s modules',
+    async (id) => {
+      expect(await transform(couldTransform, id)).toBeDefined()
+    },
+  )
 
   it('transforms vue script blocks', async () => {
     expect(await transform(couldTransform, 'test.vue?type=script')).toBeDefined()

--- a/packages/bundler/test/useSeoMetaTransform.test.ts
+++ b/packages/bundler/test/useSeoMetaTransform.test.ts
@@ -45,6 +45,15 @@ describe('useSeoMetaTransform', () => {
     expect(await transform(couldTransform, 'test.css')).toBeUndefined()
   })
 
+  it('does not transform files matched by both include and exclude', async () => {
+    expect(await transform(couldTransform, '/src/excluded.ts', {
+      filter: {
+        include: [/excluded/],
+        exclude: [/excluded/],
+      },
+    })).toBeUndefined()
+  })
+
   it.each(['test.ts', 'test.mts', 'test.cts', 'test.js', 'test.mjs', 'test.cjs', 'test.tsx', 'test.jsx'])(
     'transforms %s modules',
     async (id) => {

--- a/packages/bundler/test/utils.ts
+++ b/packages/bundler/test/utils.ts
@@ -1,0 +1,62 @@
+import type { HookFilter } from 'unplugin'
+
+/**
+ * Applies a transform hook's declared `filter` the way unplugin and the
+ * bundlers do, then calls the handler. Tests must go through this so a filter
+ * that is too narrow shows up as a skipped transform instead of passing on a
+ * hand-rolled include check.
+ *
+ * Mirrors unplugin's `createFilterForTransform`: `exclude` wins over
+ * `include`, and a non-empty `include` list that matches nothing rejects.
+ * Only `RegExp` patterns are supported, which is all the plugins use.
+ */
+function matchesPattern(pattern: unknown, value: string): boolean {
+  if (!(pattern instanceof RegExp))
+    throw new TypeError(`test filter helper only supports RegExp patterns, got ${String(pattern)}`)
+  return pattern.test(value)
+}
+
+function normalize(filter: unknown): { include: unknown[], exclude: unknown[] } | undefined {
+  if (!filter)
+    return
+  if (filter instanceof RegExp || typeof filter === 'string')
+    return { include: [filter], exclude: [] }
+  if (Array.isArray(filter))
+    return { include: filter, exclude: [] }
+  const { include, exclude } = filter as { include?: unknown, exclude?: unknown }
+  return {
+    include: include === undefined ? [] : Array.isArray(include) ? include : [include],
+    exclude: exclude === undefined ? [] : Array.isArray(exclude) ? exclude : [exclude],
+  }
+}
+
+function passes(filter: unknown, value: string): boolean {
+  const normalized = normalize(filter)
+  if (!normalized)
+    return true
+  if (normalized.exclude.some(pattern => matchesPattern(pattern, value)))
+    return false
+  if (normalized.include.length === 0)
+    return true
+  return normalized.include.some(pattern => matchesPattern(pattern, value))
+}
+
+/** Whether the bundler would call this plugin's transform handler at all. */
+export function passesTransformFilter(plugin: any, id: string, code: string): boolean {
+  const hook = plugin.transform
+  const filter: HookFilter | undefined = typeof hook === 'function' ? undefined : hook?.filter
+  if (!filter)
+    return true
+  return passes(filter.id, id) && passes(filter.code, code)
+}
+
+/**
+ * Runs a plugin's transform hook through its declared filter. Returns whatever
+ * the handler returns, so callers of a synchronous hook stay synchronous.
+ */
+export function runTransform(plugin: any, code: string, id: string, ctx: any = {}): any {
+  if (!passesTransformFilter(plugin, id, code))
+    return undefined
+  const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform.handler
+  return handler.call(ctx, code, id)
+}

--- a/packages/bundler/test/viteBuild.integration.test.ts
+++ b/packages/bundler/test/viteBuild.integration.test.ts
@@ -6,6 +6,7 @@ import { Unhead } from '../src/unplugin/vite'
 
 const fixtureDir = fileURLToPath(new URL('./fixtures/vite-build', import.meta.url))
 const entry = fileURLToPath(new URL('./fixtures/vite-build/entry.ts', import.meta.url))
+const mtsEntry = fileURLToPath(new URL('./fixtures/vite-build/entry.mts', import.meta.url))
 const dataBlockEntry = fileURLToPath(new URL('./fixtures/vite-build/data-block.ts', import.meta.url))
 const quotedPropertiesEntry = fileURLToPath(new URL('./fixtures/vite-build/quoted-properties.ts', import.meta.url))
 
@@ -29,6 +30,23 @@ describe('vite build integration', () => {
         write: false,
         minify: false,
         lib: { entry, formats: ['es'], fileName: 'entry' },
+      },
+    })
+    const code = outputCode(result)
+    expect(code).toContain('CLIENT_MARKER')
+    expect(code).not.toContain('SERVER_ONLY_MARKER')
+  })
+
+  it('client build drops server-only composables from a .mts entry', async () => {
+    const result = await build({
+      root: fixtureDir,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: Unhead({ devtools: false }) as any,
+      build: {
+        write: false,
+        minify: false,
+        lib: { entry: mtsEntry, formats: ['es'], fileName: 'entry-mts' },
       },
     })
     const code = outputCode(result)

--- a/packages/react/src/stream/plugin.ts
+++ b/packages/react/src/stream/plugin.ts
@@ -134,9 +134,8 @@ export const unheadReactStreamingPlugin = /* @__PURE__ */ createUnplugin<UnheadR
     codeFilter: HEAD_COMPOSABLE_RE,
     mode: options.mode,
     transform(code, id, opts) {
-      if (!hasHeadComposable(code))
-        return null
-
+      // `codeFilter` above is declared as the hook's `filter.code`, so the
+      // bundler already skipped sources without a head composable.
       const s = new MagicString(code)
       if (!transform(code, id, opts?.ssr ?? false, s))
         return null

--- a/packages/solid-js/src/stream/plugin.ts
+++ b/packages/solid-js/src/stream/plugin.ts
@@ -119,9 +119,8 @@ export const unheadSolidStreamingPlugin = createUnplugin<UnheadSolidStreamingOpt
     codeFilter: HEAD_COMPOSABLE_RE,
     mode: options.mode,
     transform(code, id, opts) {
-      if (!hasHeadComposable(code))
-        return null
-
+      // `codeFilter` above is declared as the hook's `filter.code`, so the
+      // bundler already skipped sources without a head composable.
       const s = new MagicString(code)
       if (!transform(code, id, opts?.ssr ?? false, s))
         return null

--- a/packages/svelte/src/stream/plugin.ts
+++ b/packages/svelte/src/stream/plugin.ts
@@ -76,9 +76,8 @@ export const unheadSvelteStreamingPlugin = createUnplugin<UnheadSvelteStreamingO
     codeFilter: HEAD_COMPOSABLE_RE,
     mode: options.mode,
     transform(code, id, opts) {
-      if (!hasHeadComposable(code))
-        return null
-
+      // `codeFilter` above is declared as the hook's `filter.code`, so the
+      // bundler already skipped sources without a head composable.
       const s = new MagicString(code)
       if (!transform(code, id, opts?.ssr ?? false, s))
         return null


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

`.mts` and `.cts` files skipped several Unhead transforms. Module IDs with query strings also skipped validation and devtools transforms.

Client builds could keep server-only composables. Vue SFCs could miss validation injection. Devtools could miss source locations.

The filters now cover all supported JavaScript and TypeScript extensions. They also accept IDs with query strings.

Explicit exclusions now win when include and exclude patterns overlap.

The mixed ID benchmark measured 0.197 ms on CI, within noise at ±0.5%. This PR makes no speed claim.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved transformation support across JavaScript, TypeScript, JSX/TSX, Vue, Svelte, and query-string module variants.
  * Devtools and build-time transformations now consistently target supported source files and skip unrelated files.
  * Client builds better preserve client-only code while removing server-only code.

* **Bug Fixes**
  * Improved handling of overlapping include/exclude filters, head-related transformations, SEO processing, and minification.

* **Tests**
  * Added coverage for file extensions, query parameters, filtering, and client build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->