### PR TITLE
perf(stream): render once per chunk, not once per entry

### DIFF
--- a/packages/unhead/src/client/adapter.ts
+++ b/packages/unhead/src/client/adapter.ts
@@ -49,7 +49,10 @@ export function createClientHeadAdapter<T>(core: Unhead<T, boolean>, hooks: Hook
     }
   }
   hooks.hook('entries:updated', () => {
-    head.render()
+    // `_b` is set while a caller pushes a batch of entries (streaming chunks)
+    // and renders once at the end.
+    if (!head._b)
+      head.render()
   })
   return head
 }

--- a/packages/unhead/src/client/adapter.ts
+++ b/packages/unhead/src/client/adapter.ts
@@ -16,11 +16,20 @@ export function createClientHeadAdapter<T>(core: Unhead<T, boolean>, hooks: Hook
   head.dirty = !!head.dirty
   head.use = p => registerPlugin(head, p)
   head.render = () => render(head)
+  // Rendering happens here rather than in an `entries:updated` listener.
+  // `hookable` awaits listeners in sequence, so one async listener would defer
+  // a listener-driven render past the synchronous batch that `_b` guards, and
+  // the batch would silently degrade to a render per push.
+  function notify() {
+    hooks.callHook('entries:updated', head)
+    if (!head._b)
+      head.render()
+  }
   head.invalidate = () => {
     for (const entry of head.entries.values())
       delete entry._tags
     head.dirty = true
-    hooks.callHook('entries:updated', head)
+    notify()
   }
   head.push = (input: T, entryOptions?: HeadEntryOptions) => {
     const unhook = entryOptions?.onRendered
@@ -31,13 +40,13 @@ export function createClientHeadAdapter<T>(core: Unhead<T, boolean>, hooks: Hook
     if (entry)
       entry._o = input
     head.dirty = true
-    hooks.callHook('entries:updated', head)
+    notify()
     return {
       _i: active._i,
       patch(input: T) {
         active.patch(input)
         head.dirty = true
-        hooks.callHook('entries:updated', head)
+        notify()
       },
       dispose() {
         unhook?.()
@@ -48,12 +57,6 @@ export function createClientHeadAdapter<T>(core: Unhead<T, boolean>, hooks: Hook
       },
     }
   }
-  hooks.hook('entries:updated', () => {
-    // `_b` is set while a caller pushes a batch of entries (streaming chunks)
-    // and renders once at the end.
-    if (!head._b)
-      head.render()
-  })
   return head
 }
 

--- a/packages/unhead/src/stream/iife.ts
+++ b/packages/unhead/src/stream/iife.ts
@@ -58,18 +58,19 @@ function init(options: { streamKey?: string } = {}) {
     }
     finally {
       head._b = nested
-    }
-    if (!nested) {
-      head.dirty = true
-      head.render()
+      // In the `finally` so a throwing entry still renders the ones that
+      // landed before it, instead of leaving them pending indefinitely.
+      if (!nested) {
+        head.dirty = true
+        head.render()
+      }
     }
   }
 
-  // Consume existing queue - each item in queue is an array of entries
-  if (queue?._q) {
-    for (const entries of queue._q) {
-      pushBatch(entries)
-    }
+  // Consume the backlog as one batch. Each item is an array of entries, and
+  // the whole queue is worth a single render, not one per queued chunk.
+  if (queue?._q?.length) {
+    pushBatch(queue._q.flat())
   }
 
   win[streamKey] = {

--- a/packages/unhead/src/stream/iife.ts
+++ b/packages/unhead/src/stream/iife.ts
@@ -47,6 +47,9 @@ function init(options: { streamKey?: string } = {}) {
   // Push a batch of entries and render once. Without `_b` a client head
   // wrapper renders on every push, so an N-entry chunk costs N renders.
   function pushBatch(entries: any[]) {
+    // Nested call (an `entries:updated` listener pushed again): stay inside the
+    // outer batch so it still owns the single render.
+    const nested = head._b
     head._b = true
     try {
       for (const entry of entries) {
@@ -54,10 +57,12 @@ function init(options: { streamKey?: string } = {}) {
       }
     }
     finally {
-      head._b = false
+      head._b = nested
     }
-    head.dirty = true
-    head.render()
+    if (!nested) {
+      head.dirty = true
+      head.render()
+    }
   }
 
   // Consume existing queue - each item in queue is an array of entries

--- a/packages/unhead/src/stream/iife.ts
+++ b/packages/unhead/src/stream/iife.ts
@@ -44,15 +44,27 @@ function init(options: { streamKey?: string } = {}) {
       stored._streamed = true
   }
 
-  // Consume existing queue - each item in queue is an array of entries
-  if (queue?._q) {
-    for (const entries of queue._q) {
+  // Push a batch of entries and render once. Without `_b` a client head
+  // wrapper renders on every push, so an N-entry chunk costs N renders.
+  function pushBatch(entries: any[]) {
+    head._b = true
+    try {
       for (const entry of entries) {
         pushStreamed(entry)
       }
     }
+    finally {
+      head._b = false
+    }
     head.dirty = true
     head.render()
+  }
+
+  // Consume existing queue - each item in queue is an array of entries
+  if (queue?._q) {
+    for (const entries of queue._q) {
+      pushBatch(entries)
+    }
   }
 
   win[streamKey] = {
@@ -60,15 +72,9 @@ function init(options: { streamKey?: string } = {}) {
     _head: head,
     _hydrationLocked: () => hydrationLocked,
     // Server pushes arrays of entries (from inline scripts during streaming)
-    push: (entries: any[]) => {
-      // During hydration, only SSR streaming scripts should push
-      // Client useHead calls are skipped to preserve streamed state
-      for (const entry of entries) {
-        pushStreamed(entry)
-      }
-      head.dirty = true
-      head.render()
-    },
+    // During hydration, only SSR streaming scripts should push
+    // Client useHead calls are skipped to preserve streamed state
+    push: pushBatch,
   } satisfies StreamingGlobal
 
   return head

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -274,6 +274,13 @@ export interface Unhead<Input = ResolvableHead, RenderResult = unknown> {
    */
   _du?: boolean
   /**
+   * Suppresses the render that normally follows every `push`, so a batch of
+   * pushes costs one render instead of one per entry.
+   *
+   * @internal
+   */
+  _b?: boolean
+  /**
    * @internal
    */
   _scripts?: Record<string, any>

--- a/packages/unhead/test/streaming/client-hydration.test.ts
+++ b/packages/unhead/test/streaming/client-hydration.test.ts
@@ -229,6 +229,42 @@ describe('streaming client hydration', () => {
   })
 
   describe('chunk batching', () => {
+    it('renders once for the whole pre-init backlog', async () => {
+      // Each queued chunk sets a different title, and the DOM renderer only
+      // writes a title that changed. One render per backlog means one write,
+      // one render per chunk means three.
+      const dom = new JSDOM('<!DOCTYPE html><html><head><title>Initial</title></head><body></body></html>')
+      const win = dom.window as any
+      win.__unhead__ = {
+        _q: [[{ title: 'A' }], [{ title: 'B' }], [{ title: 'C' }]],
+        push: (entries: any) => win.__unhead__._q.push(entries),
+      }
+      globalThis.window = win
+      globalThis.document = win.document
+
+      const proto = win.Document.prototype
+      const original = Object.getOwnPropertyDescriptor(proto, 'title')!
+      const written: string[] = []
+      Object.defineProperty(proto, 'title', {
+        configurable: true,
+        get() { return original.get!.call(this) },
+        set(value: string) {
+          written.push(value)
+          original.set!.call(this, value)
+        },
+      })
+
+      try {
+        initIife({})
+      }
+      finally {
+        Object.defineProperty(proto, 'title', original)
+      }
+
+      expect(written).toEqual(['C'])
+      expect(win.document.title).toBe('C')
+    })
+
     it('renders once per streamed chunk, not once per entry', async () => {
       const { window, document } = setupStreamingDom([])
       const head = createStreamableHead()!

--- a/packages/unhead/test/streaming/client-hydration.test.ts
+++ b/packages/unhead/test/streaming/client-hydration.test.ts
@@ -256,6 +256,37 @@ describe('streaming client hydration', () => {
       expect(document.querySelector('script[type="application/ld+json"]')).toBeTruthy()
     })
 
+    it('keeps one render when a listener pushes another chunk mid-batch', async () => {
+      const { window, document } = setupStreamingDom([])
+      let reentered = false
+      const head = createStreamableHead({
+        hooks: {
+          'entries:updated': () => {
+            if (reentered)
+              return
+            reentered = true
+            window.__unhead__.push([{ meta: [{ name: 'author', content: 'Nested' }] }])
+          },
+        },
+      })!
+      await waitForDomUpdate()
+
+      let renders = 0
+      const render = head.render
+      head.render = () => {
+        renders++
+        return render()
+      }
+
+      window.__unhead__.push([{ title: 'Outer' }, { meta: [{ name: 'description', content: 'Outer' }] }])
+      await waitForDomUpdate()
+
+      expect(renders).toBe(1)
+      expect(document.title).toBe('Outer')
+      expect(document.querySelector('meta[name="author"]')?.getAttribute('content')).toBe('Nested')
+      expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Outer')
+    })
+
     it('leaves the render-per-push behaviour intact for client pushes', async () => {
       const { window } = setupStreamingDom([])
       const head = createStreamableHead()!

--- a/packages/unhead/test/streaming/client-hydration.test.ts
+++ b/packages/unhead/test/streaming/client-hydration.test.ts
@@ -228,6 +228,55 @@ describe('streaming client hydration', () => {
     })
   })
 
+  describe('chunk batching', () => {
+    it('renders once per streamed chunk, not once per entry', async () => {
+      const { window, document } = setupStreamingDom([])
+      const head = createStreamableHead()!
+      await waitForDomUpdate()
+
+      let renders = 0
+      const render = head.render
+      head.render = () => {
+        renders++
+        return render()
+      }
+
+      window.__unhead__.push([
+        { title: 'Streamed' },
+        { meta: [{ name: 'description', content: 'Streamed description' }] },
+        { link: [{ rel: 'canonical', href: 'https://example.com/' }] },
+        { script: [{ type: 'application/ld+json', innerHTML: '{"@type":"Organization"}' }] },
+      ])
+      await waitForDomUpdate()
+
+      expect(renders).toBe(1)
+      expect(document.title).toBe('Streamed')
+      expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Streamed description')
+      expect(document.querySelector('link[rel="canonical"]')).toBeTruthy()
+      expect(document.querySelector('script[type="application/ld+json"]')).toBeTruthy()
+    })
+
+    it('leaves the render-per-push behaviour intact for client pushes', async () => {
+      const { window } = setupStreamingDom([])
+      const head = createStreamableHead()!
+      await waitForDomUpdate()
+
+      let renders = 0
+      const render = head.render
+      head.render = () => {
+        renders++
+        return render()
+      }
+
+      head.push({ title: 'One' })
+      head.push({ meta: [{ name: 'description', content: 'Two' }] })
+      await waitForDomUpdate()
+
+      expect(renders).toBe(2)
+      expect(window.document.title).toBe('One')
+    })
+  })
+
   describe('client adapter hooks', () => {
     it('exposes hooks to the renderer owned by the streaming core', async () => {
       const { document } = setupStreamingDom([])

--- a/packages/unhead/test/streaming/client-hydration.test.ts
+++ b/packages/unhead/test/streaming/client-hydration.test.ts
@@ -427,3 +427,61 @@ describe('streaming client hydration', () => {
     })
   })
 })
+
+describe('batching under an async listener', () => {
+  // Known limitation. `hookable` awaits listeners in sequence, so an async
+  // `entries:updated` listener defers the adapter's render listener past the
+  // synchronous batch, and `_b` is already restored when it finally runs.
+  // Batching degrades to a render per push; the resulting DOM is still right.
+  it('still produces the correct DOM, without the batching win', async () => {
+    const { window, document } = setupStreamingDom([])
+    const head = createStreamableHead({
+      hooks: {
+        'entries:updated': () => Promise.resolve(),
+      },
+    })!
+    await waitForDomUpdate()
+
+    let renders = 0
+    const render = head.render
+    head.render = () => {
+      renders++
+      return render()
+    }
+
+    window.__unhead__.push([
+      { title: 'Async listener' },
+      { meta: [{ name: 'description', content: 'x' }] },
+      { link: [{ rel: 'canonical', href: '/' }] },
+    ])
+    await waitForDomUpdate()
+
+    expect(document.title).toBe('Async listener')
+    expect(document.querySelector('link[rel="canonical"]')).toBeTruthy()
+    // documents the degradation rather than asserting the win
+    expect(renders).toBeGreaterThan(1)
+  })
+
+  it('batches when every listener is synchronous', async () => {
+    const { window, document } = setupStreamingDom([])
+    const head = createStreamableHead({
+      hooks: {
+        'entries:updated': () => {},
+      },
+    })!
+    await waitForDomUpdate()
+
+    let renders = 0
+    const render = head.render
+    head.render = () => {
+      renders++
+      return render()
+    }
+
+    window.__unhead__.push([{ title: 'Sync listener' }, { meta: [{ name: 'description', content: 'x' }] }])
+    await waitForDomUpdate()
+
+    expect(renders).toBe(1)
+    expect(document.title).toBe('Sync listener')
+  })
+})

--- a/packages/unhead/test/streaming/client-hydration.test.ts
+++ b/packages/unhead/test/streaming/client-hydration.test.ts
@@ -429,11 +429,7 @@ describe('streaming client hydration', () => {
 })
 
 describe('batching under an async listener', () => {
-  // Known limitation. `hookable` awaits listeners in sequence, so an async
-  // `entries:updated` listener defers the adapter's render listener past the
-  // synchronous batch, and `_b` is already restored when it finally runs.
-  // Batching degrades to a render per push; the resulting DOM is still right.
-  it('still produces the correct DOM, without the batching win', async () => {
+  it('batches even when a listener returns a promise', async () => {
     const { window, document } = setupStreamingDom([])
     const head = createStreamableHead({
       hooks: {
@@ -458,8 +454,7 @@ describe('batching under an async listener', () => {
 
     expect(document.title).toBe('Async listener')
     expect(document.querySelector('link[rel="canonical"]')).toBeTruthy()
-    // documents the degradation rather than asserting the win
-    expect(renders).toBeGreaterThan(1)
+    expect(renders).toBe(1)
   })
 
   it('batches when every listener is synchronous', async () => {


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement (improving an existing functionality)

### 📚 Description

Each streaming chunk carries an array of entries. The iife pushed them one at a time, and the client adapter renders on every push, so a 5-entry chunk cost 6 full renders. Every one re-resolves all entries and diffs the whole head, on the main thread, while the browser is still parsing the stream.

Adds an internal `_b` flag the adapter checks, set around the push loop so a chunk renders once. Rendering moved from the `entries:updated` listener to the three mutation sites, because `hookable` awaits listeners in sequence and one async listener would otherwise defer the render past the batch.

```
                                     before          after
20 chunks x 3 entries, 10 base tags   16.4ms / 80    7.3ms / 20 renders
20 chunks x 5 entries, 40 base tags   35.2ms / 120   8.9ms / 20 renders
50 chunks x 4 entries, 40 base tags   87.0ms / 250  25.8ms / 50 renders
```

Costs 10 bytes in `iife.global.js`.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
