### PR TITLE
fix(stream): drop the hydration lock that swallowed early pushes

### DIFF
--- a/packages/unhead/src/client/adapter.ts
+++ b/packages/unhead/src/client/adapter.ts
@@ -1,5 +1,5 @@
 import type { HookableCore } from 'hookable'
-import type { ActiveHeadEntry, ClientHeadHooks, HeadEntryOptions, HeadRenderer, ResolvableHead, Unhead } from '../types'
+import type { ClientHeadHooks, HeadEntryOptions, HeadRenderer, ResolvableHead, Unhead } from '../types'
 import { registerPlugin } from '../unhead'
 
 export interface ClientUnhead<T = ResolvableHead> extends Unhead<T, boolean> {
@@ -56,25 +56,6 @@ export function createClientHeadAdapter<T>(core: Unhead<T, boolean>, hooks: Hook
         }
       },
     }
-  }
-  return head
-}
-
-export function createStreamClientHeadAdapter<T>(core: Unhead<T, boolean>, hooks: HookableCore<ClientHeadHooks>, render: HeadRenderer<boolean>, locked: () => boolean): ClientUnhead<T> {
-  const head = createClientHeadAdapter(core, hooks, render)
-  const push = head.push
-  head.push = (input, options) => {
-    if (locked()) {
-      return {
-        _i: -1,
-        patch: () => {},
-        dispose: () => {},
-      } as ActiveHeadEntry<T>
-    }
-    const active = push(input, options)
-    const patch = active.patch
-    active.patch = input => !locked() && patch(input)
-    return active
   }
   return head
 }

--- a/packages/unhead/src/stream/client.ts
+++ b/packages/unhead/src/stream/client.ts
@@ -1,7 +1,7 @@
 import type { ClientUnhead } from '../client/adapter'
 import type { ClientHeadHooks, CreateClientHeadOptions, ResolvableHead, Unhead } from '../types'
 import type { StreamingGlobal, UnheadStreamQueue } from './types'
-import { createStreamClientHeadAdapter } from '../client/adapter'
+import { createClientHeadAdapter } from '../client/adapter'
 import { createHooks } from '../utils/hooks'
 
 export type { StreamingGlobal, UnheadStreamQueue }
@@ -19,7 +19,7 @@ export interface CreateStreamableClientHeadOptions extends Omit<CreateClientHead
 export function createStreamableHead<T = ResolvableHead>(options: CreateStreamableClientHeadOptions = {}): ClientUnhead<T> | undefined {
   const { streamKey = DEFAULT_STREAM_KEY, ...rest } = options
   const win = typeof window !== 'undefined' ? window as any : undefined
-  const streamQueue = win?.[streamKey] as UnheadStreamQueue & { _hydrationLocked?: () => boolean } | undefined
+  const streamQueue = win?.[streamKey] as UnheadStreamQueue | undefined
   const core = streamQueue?._head as Unhead<T> | undefined
 
   if (!core)
@@ -38,11 +38,9 @@ export function createStreamableHead<T = ResolvableHead>(options: CreateStreamab
     return wrapped
   }
 
-  // Check if hydration is locked (client pushes should be skipped during hydration)
-  const isHydrationLocked = () => streamQueue?._hydrationLocked?.() ?? false
   const coreRender = core.render
   const hooks = createHooks<ClientHeadHooks>(rest.hooks)
-  const head = createStreamClientHeadAdapter(core as Unhead<T, boolean>, hooks, () => coreRender() as boolean, isHydrationLocked)
+  const head = createClientHeadAdapter(core as Unhead<T, boolean>, hooks, () => coreRender() as boolean)
 
   // Mark as wrapped to avoid double-wrapping
   ;(head as any)._wrapped = true

--- a/packages/unhead/src/stream/iife.ts
+++ b/packages/unhead/src/stream/iife.ts
@@ -63,7 +63,10 @@ function init(options: { streamKey?: string } = {}) {
   }
 
   win[streamKey] = {
-    _q: queue?._q || [],
+    // Replayed batches are dropped rather than carried over. Nothing reads
+    // `_q` after init, and in `async` mode it can hold the whole page's
+    // streamed head until the tab closes.
+    _q: [],
     _head: head,
     // Server pushes arrays of entries (from inline scripts during streaming)
     push: pushBatch,

--- a/packages/unhead/src/stream/iife.ts
+++ b/packages/unhead/src/stream/iife.ts
@@ -24,17 +24,6 @@ function init(options: { streamKey?: string } = {}) {
   const doc = typeof document !== 'undefined' ? document : undefined
   const head = createUnhead(createDomRenderer(), { document: doc })
 
-  // Hydration lock - ignore client pushes until hydration completes
-  // SSR streaming pushes (from inline scripts) happen before hydration starts
-  // After IIFE init, hydration begins and components re-call useHead
-  // We skip those during hydration to preserve the SSR-streamed state
-  let hydrationLocked = true
-
-  // Unlock after microtask - hydration should be complete by then
-  queueMicrotask(() => {
-    hydrationLocked = false
-  })
-
   // Push an entry and tag it as streamed so devtools can distinguish
   // entries that arrived via inline streaming scripts from client pushes.
   function pushStreamed(entry: any) {
@@ -76,10 +65,7 @@ function init(options: { streamKey?: string } = {}) {
   win[streamKey] = {
     _q: queue?._q || [],
     _head: head,
-    _hydrationLocked: () => hydrationLocked,
     // Server pushes arrays of entries (from inline scripts during streaming)
-    // During hydration, only SSR streaming scripts should push
-    // Client useHead calls are skipped to preserve streamed state
     push: pushBatch,
   } satisfies StreamingGlobal
 

--- a/packages/unhead/src/stream/types.ts
+++ b/packages/unhead/src/stream/types.ts
@@ -14,8 +14,6 @@ export interface StreamingGlobal {
   _q: SerializableHead[][]
   /** Resolved Unhead instance, populated once the IIFE initialises. */
   _head?: Unhead<any>
-  /** True while framework hydration is in progress (client push suppression). */
-  _hydrationLocked?: () => boolean
   /** Push an entry batch onto the queue (pre-init) or the head (post-init). */
   push: (entries: SerializableHead[]) => void
 }

--- a/packages/unhead/test/streaming/client-hydration.test.ts
+++ b/packages/unhead/test/streaming/client-hydration.test.ts
@@ -228,6 +228,41 @@ describe('streaming client hydration', () => {
     })
   })
 
+  describe('same-tick pushes', () => {
+    it('keeps a client push made in the tick the iife initialised', async () => {
+      const { document } = setupStreamingDom([])
+      const head = createStreamableHead()!
+
+      const active = head.push({ title: 'Client title', meta: [{ name: 'description', content: 'Client' }] })
+      await waitForDomUpdate()
+
+      expect(active._i).toBeGreaterThan(0)
+      expect(document.title).toBe('Client title')
+      expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Client')
+    })
+
+    it('keeps a streamed chunk that arrives in the tick the iife initialised', async () => {
+      const { window, document } = setupStreamingDom([])
+      createStreamableHead()
+
+      window.__unhead__.push([{ title: 'Streamed title' }])
+      await waitForDomUpdate()
+
+      expect(document.title).toBe('Streamed title')
+    })
+
+    it('keeps a patch applied in the tick the iife initialised', async () => {
+      const { document } = setupStreamingDom([])
+      const head = createStreamableHead()!
+
+      const active = head.push({ title: 'First' })
+      active.patch({ title: 'Patched' })
+      await waitForDomUpdate()
+
+      expect(document.title).toBe('Patched')
+    })
+  })
+
   describe('chunk batching', () => {
     it('renders once for the whole pre-init backlog', async () => {
       // Each queued chunk sets a different title, and the DOM renderer only

--- a/packages/unhead/test/streaming/client-hydration.test.ts
+++ b/packages/unhead/test/streaming/client-hydration.test.ts
@@ -201,7 +201,7 @@ describe('streaming client hydration', () => {
 
       const head = createStreamableHead()
       expect(head).toBeDefined()
-      await waitForDomUpdate() // wait for hydration lock to release
+      await waitForDomUpdate()
       head!.push({ title: 'After Iife' })
       await waitForDomUpdate()
 

--- a/packages/unhead/test/streaming/client-hydration.test.ts
+++ b/packages/unhead/test/streaming/client-hydration.test.ts
@@ -228,6 +228,28 @@ describe('streaming client hydration', () => {
     })
   })
 
+  describe('queue handoff', () => {
+    it('drops replayed batches instead of retaining them', async () => {
+      const { window, document } = setupStreamingDom([
+        { title: 'Queued' },
+        { meta: [{ name: 'description', content: 'Queued' }] },
+      ])
+      await waitForDomUpdate()
+
+      expect(document.title).toBe('Queued')
+      expect(window.__unhead__._q).toEqual([])
+    })
+
+    it('does not accumulate batches pushed after init', async () => {
+      const { window } = setupStreamingDom([])
+      createStreamableHead()
+      window.__unhead__.push([{ title: 'Live' }])
+      await waitForDomUpdate()
+
+      expect(window.__unhead__._q).toEqual([])
+    })
+  })
+
   describe('same-tick pushes', () => {
     it('keeps a client push made in the tick the iife initialised', async () => {
       const { document } = setupStreamingDom([])


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

A hydration lock made the client adapter swallow every push in the iife's init tick and hand back a fake `{_i: -1}` entry. Your `useHead` calls and the server's own streamed chunks, both gone, no error either way.

It never did the job it was written for. The lock released after one microtask, long before hydration starts. Removed, along with `createStreamClientHeadAdapter` and `_hydrationLocked`.

Second, smaller one: `_q` was carried onto the replacement global after replay. Nothing reads it again, and in `async` mode the iife can load late enough that it pins the whole page's streamed head until the tab closes.

`iife.global.js` -134 bytes, `stream/client.mjs` -109 bytes.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming head updates during client hydration, ensuring updates are no longer unintentionally suppressed.
  - Fixed initialization and queue handoff behavior so updates made during startup are preserved and applied correctly.
  - Ensured same-tick updates consistently refresh rendered page metadata, including titles.
- **Refactor**
  - Simplified streaming update handling by removing the separate hydration-lock mechanism and related public state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->