### PR TITLE
fix(stream): module mode lost every streamed head tag

### DIFF
--- a/packages/unhead/src/stream/client.ts
+++ b/packages/unhead/src/stream/client.ts
@@ -25,9 +25,18 @@ export function createStreamableHead<T = ResolvableHead>(options: CreateStreamab
   if (!core)
     return undefined
 
-  // Check if already wrapped
-  if ((core as any)._wrapped)
-    return core as ClientUnhead<T>
+  // Already wrapped, by an earlier call or by a client bundle that built the
+  // head itself. Re-wrapping would double every push, so apply what this call
+  // brought and hand the existing head back. The old early return dropped
+  // `hooks`, `plugins`, and `init` on the floor.
+  if ((core as any)._wrapped) {
+    const wrapped = core as ClientUnhead<T>
+    for (const name in rest.hooks || {})
+      wrapped.hooks?.hook(name as any, (rest.hooks as any)[name])
+    ;(rest.plugins || []).forEach(p => wrapped.use(p))
+    rest.init?.forEach(e => e && wrapped.push(e as T))
+    return wrapped
+  }
 
   // Check if hydration is locked (client pushes should be skipped during hydration)
   const isHydrationLocked = () => streamQueue?._hydrationLocked?.() ?? false

--- a/packages/unhead/src/stream/unplugin.ts
+++ b/packages/unhead/src/stream/unplugin.ts
@@ -103,8 +103,10 @@ function buildClientStub(framework: string, streamKey: string, warnOnMissing: bo
   // so each batch is spread into individual `h.push` calls. Pushing the batch
   // array itself normalizes its indexes into tags named `0`, `1`, ... and
   // every streamed tag is lost.
+  // Entries are marked `_streamed` to match the iife, so devtools can tell
+  // them apart from client pushes.
   return `import{createHead}from'${framework}/client'
-const s=window[${key}];if(s){const q=s._q;s._q=[];const h=createHead({document});const p=b=>{for(const e of b)h.push(e)};q.forEach(p);s.push=p;s._head=h}${warnBranch}`
+const s=window[${key}];if(s){const q=s._q;s._q=[];const h=createHead({document});const p=b=>{for(const e of b){const a=h.push(e),t=h.entries.get(a._i);if(t)t._streamed=!0}};q.forEach(p);s.push=p;s._head=h}${warnBranch}`
 }
 
 /**

--- a/packages/unhead/src/stream/unplugin.ts
+++ b/packages/unhead/src/stream/unplugin.ts
@@ -99,8 +99,12 @@ function buildClientStub(framework: string, streamKey: string, warnOnMissing: bo
   const warnBranch = warnOnMissing
     ? `else{console.warn('[unhead] streaming client loaded but window['+${key}+'] is undefined; did the server call wrapStream()/renderSSRHeadShell()?')}`
     : ''
+  // `_q` items and the server's live `push` argument are BATCHES of entries,
+  // so each batch is spread into individual `h.push` calls. Pushing the batch
+  // array itself normalizes its indexes into tags named `0`, `1`, ... and
+  // every streamed tag is lost.
   return `import{createHead}from'${framework}/client'
-const s=window[${key}];if(s){const q=s._q;s._q=[];const h=createHead({document});q.forEach(e=>h.push(e));s.push=e=>h.push(e);s._head=h}${warnBranch}`
+const s=window[${key}];if(s){const q=s._q;s._q=[];const h=createHead({document});const p=b=>{for(const e of b)h.push(e)};q.forEach(p);s.push=p;s._head=h}${warnBranch}`
 }
 
 /**

--- a/packages/unhead/src/stream/unplugin.ts
+++ b/packages/unhead/src/stream/unplugin.ts
@@ -105,8 +105,11 @@ function buildClientStub(framework: string, streamKey: string, warnOnMissing: bo
   // every streamed tag is lost.
   // Entries are marked `_streamed` to match the iife, so devtools can tell
   // them apart from client pushes.
+  // `_wrapped` is set because `createHead` here is already the adapter-wrapped
+  // client head; without it `createStreamableHead` wraps it a second time and
+  // every client push renders twice.
   return `import{createHead}from'${framework}/client'
-const s=window[${key}];if(s){const q=s._q;s._q=[];const h=createHead({document});const p=b=>{for(const e of b){const a=h.push(e),t=h.entries.get(a._i);if(t)t._streamed=!0}};q.forEach(p);s.push=p;s._head=h}${warnBranch}`
+const s=window[${key}];if(s){const q=s._q;s._q=[];const h=createHead({document});h._wrapped=!0;const p=b=>{for(const e of b){const a=h.push(e),t=h.entries.get(a._i);if(t)t._streamed=!0}};q.forEach(p);s.push=p;s._head=h}${warnBranch}`
 }
 
 /**

--- a/packages/unhead/test/streaming/module-client-stub.test.ts
+++ b/packages/unhead/test/streaming/module-client-stub.test.ts
@@ -83,7 +83,7 @@ describe('module-mode client stub', () => {
     expect(globalThis.globalThis.document.querySelectorAll('meta[name="a"], meta[name="b"]')).toHaveLength(2)
   })
 
-  it('marks streamed entries so devtools can tell them apart', () => {
+  it('marks live-pushed entries so devtools can tell them apart', () => {
     const win = setupDom()
     runStub()
     win.__unhead__.push([{ title: 'Streamed' }])
@@ -91,6 +91,16 @@ describe('module-mode client stub', () => {
     const entries = [...win.__unhead__._head.entries.values()]
     expect(entries).toHaveLength(1)
     expect(entries[0]._streamed).toBe(true)
+  })
+
+  it('marks replayed entries so devtools can tell them apart', () => {
+    const win = setupDom()
+    win.__unhead__.push([{ title: 'Queued' }, { meta: [{ name: 'description', content: 'Queued' }] }])
+    runStub()
+
+    const entries = [...win.__unhead__._head.entries.values()]
+    expect(entries).toHaveLength(2)
+    expect(entries.map((entry: any) => entry._streamed)).toEqual([true, true])
   })
 
   it('exposes the head instance for the framework client to adopt', () => {

--- a/packages/unhead/test/streaming/module-client-stub.test.ts
+++ b/packages/unhead/test/streaming/module-client-stub.test.ts
@@ -46,12 +46,8 @@ function runStub(streamKey = '__unhead__') {
   return new Function('createHead', 'window', 'document', 'console', body)(createHead, globalThis.window, globalThis.document, console)
 }
 
-function settle() {
-  return new Promise(resolve => setTimeout(resolve, 20))
-}
-
 describe('module-mode client stub', () => {
-  it('applies a batch queued before the client loaded', async () => {
+  it('applies a batch queued before the client loaded', () => {
     const win = setupDom()
     win.__unhead__.push([
       { title: 'Streamed' },
@@ -59,13 +55,12 @@ describe('module-mode client stub', () => {
     ])
 
     runStub()
-    await settle()
 
     expect(globalThis.document.title).toBe('Streamed')
     expect(globalThis.document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Streamed description')
   })
 
-  it('applies a batch that arrives after the client loaded', async () => {
+  it('applies a batch that arrives after the client loaded', () => {
     const win = setupDom()
 
     runStub()
@@ -73,24 +68,32 @@ describe('module-mode client stub', () => {
       { link: [{ rel: 'canonical', href: 'https://example.com/' }] },
       { script: [{ type: 'application/ld+json', innerHTML: '{"@type":"Organization"}' }] },
     ])
-    await settle()
 
     expect(globalThis.document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe('https://example.com/')
     expect(globalThis.document.querySelector('script[type="application/ld+json"]')).toBeTruthy()
   })
 
-  it('never emits a tag named after a batch index', async () => {
+  it('never emits a tag named after a batch index', () => {
     const win = setupDom()
 
     runStub()
     win.__unhead__.push([{ meta: [{ name: 'a', content: '1' }] }, { meta: [{ name: 'b', content: '2' }] }])
-    await settle()
 
     expect(globalThis.document.head.innerHTML).not.toMatch(/<0|<1/)
     expect(globalThis.globalThis.document.querySelectorAll('meta[name="a"], meta[name="b"]')).toHaveLength(2)
   })
 
-  it('exposes the head instance for the framework client to adopt', async () => {
+  it('marks streamed entries so devtools can tell them apart', () => {
+    const win = setupDom()
+    runStub()
+    win.__unhead__.push([{ title: 'Streamed' }])
+
+    const entries = [...win.__unhead__._head.entries.values()]
+    expect(entries).toHaveLength(1)
+    expect(entries[0]._streamed).toBe(true)
+  })
+
+  it('exposes the head instance for the framework client to adopt', () => {
     const win = setupDom()
     runStub()
     expect(win.__unhead__._head).toBeDefined()

--- a/packages/unhead/test/streaming/module-client-stub.test.ts
+++ b/packages/unhead/test/streaming/module-client-stub.test.ts
@@ -1,0 +1,98 @@
+import { JSDOM } from 'jsdom'
+import { createHead } from 'unhead/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createStreamingPlugin, VIRTUAL_CLIENT_ID } from '../../src/stream/unplugin'
+
+let originalWindow: any
+let originalDocument: any
+
+beforeEach(() => {
+  originalWindow = globalThis.window
+  originalDocument = globalThis.document
+})
+
+afterEach(() => {
+  globalThis.window = originalWindow
+  globalThis.document = originalDocument
+})
+
+function setupDom(streamKey = '__unhead__') {
+  const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>')
+  const win = dom.window as any
+  win[streamKey] = {
+    _q: [] as any[],
+    push(entries: any) {
+      this._q.push(entries)
+    },
+  }
+  globalThis.window = win
+  globalThis.document = win.document
+  return win
+}
+
+const RESOLVED_CLIENT_ID = `\0${VIRTUAL_CLIENT_ID}`
+
+/**
+ * Runs the emitted client stub against a real client head. The `import` line
+ * is stripped and `createHead` handed in, so the rest of the stub body is
+ * exercised exactly as the browser would run it.
+ */
+function runStub(streamKey = '__unhead__') {
+  const plugin = createStreamingPlugin.vite({ framework: '@unhead/test', mode: 'module', streamKey }) as any
+  const hook = plugin.load
+  const loaded = typeof hook === 'function' ? hook.call({}, RESOLVED_CLIENT_ID) : hook.handler.call({}, RESOLVED_CLIENT_ID)
+  const body = loaded.code.split('\n').filter((line: string) => !line.startsWith('import')).join('\n')
+  // eslint-disable-next-line no-new-func
+  return new Function('createHead', 'window', 'document', 'console', body)(createHead, globalThis.window, globalThis.document, console)
+}
+
+function settle() {
+  return new Promise(resolve => setTimeout(resolve, 20))
+}
+
+describe('module-mode client stub', () => {
+  it('applies a batch queued before the client loaded', async () => {
+    const win = setupDom()
+    win.__unhead__.push([
+      { title: 'Streamed' },
+      { meta: [{ name: 'description', content: 'Streamed description' }] },
+    ])
+
+    runStub()
+    await settle()
+
+    expect(globalThis.document.title).toBe('Streamed')
+    expect(globalThis.document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Streamed description')
+  })
+
+  it('applies a batch that arrives after the client loaded', async () => {
+    const win = setupDom()
+
+    runStub()
+    win.__unhead__.push([
+      { link: [{ rel: 'canonical', href: 'https://example.com/' }] },
+      { script: [{ type: 'application/ld+json', innerHTML: '{"@type":"Organization"}' }] },
+    ])
+    await settle()
+
+    expect(globalThis.document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe('https://example.com/')
+    expect(globalThis.document.querySelector('script[type="application/ld+json"]')).toBeTruthy()
+  })
+
+  it('never emits a tag named after a batch index', async () => {
+    const win = setupDom()
+
+    runStub()
+    win.__unhead__.push([{ meta: [{ name: 'a', content: '1' }] }, { meta: [{ name: 'b', content: '2' }] }])
+    await settle()
+
+    expect(globalThis.document.head.innerHTML).not.toMatch(/<0|<1/)
+    expect(globalThis.globalThis.document.querySelectorAll('meta[name="a"], meta[name="b"]')).toHaveLength(2)
+  })
+
+  it('exposes the head instance for the framework client to adopt', async () => {
+    const win = setupDom()
+    runStub()
+    expect(win.__unhead__._head).toBeDefined()
+  })
+})

--- a/packages/unhead/test/streaming/module-client-stub.test.ts
+++ b/packages/unhead/test/streaming/module-client-stub.test.ts
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom'
 import { createHead } from 'unhead/client'
+import { createStreamableHead } from 'unhead/stream/client'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createStreamingPlugin, VIRTUAL_CLIENT_ID } from '../../src/stream/unplugin'
 
@@ -107,5 +108,38 @@ describe('module-mode client stub', () => {
     const win = setupDom()
     runStub()
     expect(win.__unhead__._head).toBeDefined()
+  })
+})
+
+describe('adopting the stub head', () => {
+  it('does not double-wrap, so one push is one render', async () => {
+    const win = setupDom()
+    runStub()
+    const head = createStreamableHead()!
+
+    let renders = 0
+    const render = head.render
+    head.render = () => {
+      renders++
+      return render()
+    }
+    head.push({ title: 'Client' })
+
+    expect(renders).toBe(1)
+    expect(win.document.title).toBe('Client')
+  })
+
+  it('still applies plugins, hooks and init when adopting', async () => {
+    setupDom()
+    runStub()
+    const seen: string[] = []
+    const head = createStreamableHead({
+      hooks: { 'entries:updated': () => { seen.push('hook') } },
+      init: [{ meta: [{ name: 'from-init', content: 'yes' }] }],
+    })!
+
+    expect(seen).toContain('hook')
+    expect(globalThis.document.querySelector('meta[name="from-init"]')).toBeTruthy()
+    expect(head).toBeDefined()
   })
 })

--- a/packages/vue/test/module-stub-real-client.test.ts
+++ b/packages/vue/test/module-stub-real-client.test.ts
@@ -1,0 +1,79 @@
+import { createHead } from '@unhead/vue/client'
+import { JSDOM } from 'jsdom'
+import { createStreamingPlugin, VIRTUAL_CLIENT_ID } from 'unhead/stream/unplugin'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+let originalWindow: any
+let originalDocument: any
+
+beforeEach(() => {
+  originalWindow = globalThis.window
+  originalDocument = globalThis.document
+})
+
+afterEach(() => {
+  globalThis.window = originalWindow
+  globalThis.document = originalDocument
+})
+
+/**
+ * Runs the module-mode stub the plugin emits against Vue's REAL client head,
+ * which renders on a debounce rather than synchronously.
+ */
+function runStub() {
+  const dom = new JSDOM('<!DOCTYPE html><html><head><title>Initial</title></head><body></body></html>')
+  const win = dom.window as any
+  win.__unhead__ = {
+    _q: [] as any[],
+    push(entries: any) {
+      this._q.push(entries)
+    },
+  }
+  globalThis.window = win
+  globalThis.document = win.document
+
+  const plugin = createStreamingPlugin.vite({ framework: '@unhead/vue', mode: 'module' }) as any
+  const hook = plugin.load
+  const loaded = typeof hook === 'function' ? hook.call({}, `\0${VIRTUAL_CLIENT_ID}`) : hook.handler.call({}, `\0${VIRTUAL_CLIENT_ID}`)
+  const body = loaded.code.split('\n').filter((line: string) => !line.startsWith('import')).join('\n')
+  // eslint-disable-next-line no-new-func
+  new Function('createHead', 'window', 'document', 'console', body)(createHead, win, win.document, console)
+  return win
+}
+
+function settle() {
+  return new Promise(resolve => setTimeout(resolve, 30))
+}
+
+describe('module stub against the real Vue client head', () => {
+  it('applies a queued batch through the debounced renderer', async () => {
+    const win = runStub()
+    win.__unhead__.push([
+      { title: 'Streamed' },
+      { meta: [{ name: 'description', content: 'Streamed description' }] },
+    ])
+    await settle()
+
+    expect(win.document.title).toBe('Streamed')
+    expect(win.document.querySelector('meta[name="description"]')?.getAttribute('content'))
+      .toBe('Streamed description')
+  })
+
+  it('never emits a tag named after a batch index', async () => {
+    const win = runStub()
+    win.__unhead__.push([{ meta: [{ name: 'a', content: '1' }] }, { meta: [{ name: 'b', content: '2' }] }])
+    await settle()
+
+    expect(win.document.head.innerHTML).not.toMatch(/<0|<1/)
+    expect(win.document.querySelectorAll('meta[name="a"], meta[name="b"]')).toHaveLength(2)
+  })
+
+  it('marks the entries as streamed for devtools', async () => {
+    const win = runStub()
+    win.__unhead__.push([{ title: 'Streamed' }])
+    await settle()
+
+    const entries = [...win.__unhead__._head.entries.values()]
+    expect(entries.map((e: any) => e._streamed)).toEqual([true])
+  })
+})

--- a/packages/vue/test/module-stub-real-client.test.ts
+++ b/packages/vue/test/module-stub-real-client.test.ts
@@ -20,11 +20,11 @@ afterEach(() => {
  * Runs the module-mode stub the plugin emits against Vue's REAL client head,
  * which renders on a debounce rather than synchronously.
  */
-function runStub() {
+function runStub(queued: any[][] = []) {
   const dom = new JSDOM('<!DOCTYPE html><html><head><title>Initial</title></head><body></body></html>')
   const win = dom.window as any
   win.__unhead__ = {
-    _q: [] as any[],
+    _q: [...queued] as any[],
     push(entries: any) {
       this._q.push(entries)
     },
@@ -57,6 +57,25 @@ describe('module stub against the real Vue client head', () => {
     expect(win.document.title).toBe('Streamed')
     expect(win.document.querySelector('meta[name="description"]')?.getAttribute('content'))
       .toBe('Streamed description')
+  })
+
+  it('applies a batch queued before the stub ran', async () => {
+    const win = runStub([
+      [{ title: 'Queued' }, { meta: [{ name: 'description', content: 'Queued description' }] }],
+    ])
+    await settle()
+
+    expect(win.document.title).toBe('Queued')
+    expect(win.document.querySelector('meta[name="description"]')?.getAttribute('content'))
+      .toBe('Queued description')
+  })
+
+  it('marks replayed entries as streamed', async () => {
+    const win = runStub([[{ title: 'Queued' }, { meta: [{ name: 'a', content: '1' }] }]])
+    await settle()
+
+    const entries = [...win.__unhead__._head.entries.values()]
+    expect(entries.map((e: any) => e._streamed)).toEqual([true, true])
   })
 
   it('never emits a tag named after a batch index', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #953

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`mode: 'module'` lost every streamed head tag. `_q` items and the server's live `push` argument are *batches*, but the client stub pushed each batch array as one head input, so `[{ title: 'x' }]` normalized into a tag called `0` and the real one vanished.

Batches now spread through a single function shared by the replay and the live push, and entries carry `_streamed` like the iife's do, so devtools can still tell them apart.

While in there: the stub built its head with `${framework}/client`'s `createHead`, which is already adapter-wrapped, so `createStreamableHead` wrapped it again and every client push rendered twice. The stub marks it `_wrapped` now. Adopting an already-wrapped head also applies your `hooks`, `plugins` and `init` rather than returning early and throwing them away, which is why marking it alone wasn't enough.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
