### PR TITLE
fix(stream): stop wrapStream dropping late head entries

### DIFF
--- a/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
@@ -191,7 +191,7 @@ declare function wrapStream(
 ): ReadableStream<Uint8Array>
 ```
 
-Without `flushChunk`, `wrapStream()` emits entries registered after the shell as an inline patch script of its own, guarded so it is inert if the template never received the bootstrap. Pass `flushChunk` to control that wrapper yourself, which is how the framework wrappers stamp CSP nonces on the tag.
+Without `flushChunk`, `wrapStream()` emits its own inline patch script for entries registered after the shell. The script is guarded, so it stays inert if the template never received the bootstrap. Pass `flushChunk` to control the wrapper yourself. That is how the framework wrappers stamp a CSP nonce on the tag.
 
 ### prepareTemplate
 

--- a/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
@@ -191,7 +191,7 @@ declare function wrapStream(
 ): ReadableStream<Uint8Array>
 ```
 
-Without `flushChunk`, `wrapStream()` emits its own inline patch script for entries registered after the shell. The script is guarded, so it stays inert if the template never received the bootstrap. Pass `flushChunk` to control the wrapper yourself. That is how the framework wrappers stamp a CSP nonce on the tag.
+Without `flushChunk`, `wrapStream()` emits its own inline patch script for entries registered after the shell. The script is guarded, so it stays inert if the template never received the bootstrap. Pass `flushChunk` to control the wrapper yourself. Use it to stamp a CSP nonce on the tag, or to emit the update in another form.
 
 ### prepareTemplate
 

--- a/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
@@ -191,7 +191,7 @@ declare function wrapStream(
 ): ReadableStream<Uint8Array>
 ```
 
-Without `flushChunk`, `wrapStream()` writes the initial shell, application stream, and closing HTML but does not serialize entries registered after the shell. Framework wrappers provide their own update mechanism; framework-agnostic integrations can use the callback above or take manual control of the stream.
+Without `flushChunk`, `wrapStream()` emits entries registered after the shell as an inline patch script of its own, guarded so it is inert if the template never received the bootstrap. Pass `flushChunk` to control that wrapper yourself, which is how the framework wrappers stamp CSP nonces on the tag.
 
 ### prepareTemplate
 

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -293,8 +293,23 @@ export function wrapStream(
   // emitting them as a patch script so the bare call does not lose tags.
   // Framework wrappers pass their own to control the wrapper (CSP nonces).
   const flushChunk = options?.flushChunk ?? (() => {
-    const chunk = renderSSRHeadSuspenseChunk(head)
-    return chunk ? `<script>${chunk};document.currentScript.remove()</script>` : ''
+    let chunk: string
+    try {
+      chunk = renderSSRHeadSuspenseChunk(head)
+    }
+    catch {
+      // Best effort, deliberately swallowed. This runs after bytes are on the
+      // wire, so rethrowing would error the stream and truncate a response the
+      // client is already reading, which is worse than losing the tags this
+      // default exists to save. `renderSSRHeadSuspenseChunk` drops the entry it
+      // could not serialize before throwing, so the next chunk recovers.
+      return ''
+    }
+    if (!chunk)
+      return ''
+    // A template with no `</head>` never received the bootstrap script, so the
+    // queue may not exist. Guard rather than throw on `undefined.push`.
+    return `<script>window.${getStreamKey(head)}&&(${chunk});document.currentScript.remove()</script>`
   })
   const enc = encoder ??= new TextEncoder()
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -288,7 +288,14 @@ export function wrapStream(
   preRenderedState?: SSRHeadPayload,
   options?: { flushChunk?: () => string },
 ): ReadableStream<Uint8Array> {
-  const flushChunk = options?.flushChunk
+  // Without a `flushChunk`, entries registered after the shell reach neither
+  // the served `<head>` nor the client: they are simply discarded. Default to
+  // emitting them as a patch script so the bare call does not lose tags.
+  // Framework wrappers pass their own to control the wrapper (CSP nonces).
+  const flushChunk = options?.flushChunk ?? (() => {
+    const chunk = renderSSRHeadSuspenseChunk(head)
+    return chunk ? `<script>${chunk};document.currentScript.remove()</script>` : ''
+  })
   const enc = encoder ??= new TextEncoder()
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
   let end = ''

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -290,27 +290,19 @@ export function wrapStream(
   preRenderedState?: SSRHeadPayload,
   options?: { flushChunk?: () => string },
 ): ReadableStream<Uint8Array> {
-  // Without a `flushChunk`, entries registered after the shell reach neither
-  // the served `<head>` nor the client: they are simply discarded. Default to
-  // emitting them as a patch script so the bare call does not lose tags.
-  // Framework wrappers pass their own to control the wrapper (CSP nonces).
+  // Without a default, entries registered after the shell are discarded.
   const flushChunk = options?.flushChunk ?? (() => {
     let chunk: string
     try {
       chunk = renderSSRHeadSuspenseChunk(head)
     }
     catch {
-      // Best effort, deliberately swallowed. This runs after bytes are on the
-      // wire, so rethrowing would error the stream and truncate a response the
-      // client is already reading, which is worse than losing the tags this
-      // default exists to save. `renderSSRHeadSuspenseChunk` drops the entry it
-      // could not serialize before throwing, so the next chunk recovers.
+      // Bytes are already on the wire; a throw here truncates the response.
       return ''
     }
     if (!chunk)
       return ''
-    // A template with no `</head>` never received the bootstrap script, so the
-    // queue may not exist. Guard rather than throw on `undefined.push`.
+    // A template with no `</head>` never received the bootstrap script.
     return `<script>window.${getStreamKey(head)}&&(${chunk});document.currentScript.remove()</script>`
   })
   const enc = encoder ??= new TextEncoder()

--- a/packages/unhead/test/streaming/wrapstream-late-entries.test.ts
+++ b/packages/unhead/test/streaming/wrapstream-late-entries.test.ts
@@ -48,6 +48,56 @@ describe('wrapStream late entries', () => {
     expect(html).not.toContain('__unhead__.push(')
   })
 
+  it('guards the queue when the template never got a bootstrap script', async () => {
+    const { head } = createStreamableHead()
+    const html = await new Response(wrapStream(
+      head,
+      lateStream(() => head.push({ title: 'Late' })),
+      '<html><body><div id="app"><!--app-html--></div></body></html>',
+    )).text()
+
+    expect(html).not.toContain('window.__unhead__={')
+    expect(html).toContain('window.__unhead__&&(')
+  })
+
+  it('completes the response when a chunk cannot be serialized', async () => {
+    const { head } = createStreamableHead()
+    const circular: any = {}
+    circular.self = circular
+
+    const html = await render(head, () => head.push({ script: [{ innerHTML: circular }] }))
+
+    // the tags are lost, but the document is whole
+    expect(html).toContain('</html>')
+    expect(html).not.toContain('__unhead__.push(')
+  })
+
+  it('recovers on the next chunk after an unserializable entry', async () => {
+    const { head } = createStreamableHead()
+    const circular: any = {}
+    circular.self = circular
+
+    // both pushes happen after the shell, in separate chunks
+    let pulls = 0
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls++
+        if (pulls === 1) {
+          head.push({ script: [{ innerHTML: circular }] })
+          controller.enqueue(new TextEncoder().encode('<p>one</p>'))
+          return
+        }
+        head.push({ title: 'Recovered' })
+        controller.enqueue(new TextEncoder().encode('<p>two</p>'))
+        controller.close()
+      },
+    })
+    const html = await new Response(wrapStream(head, stream, TEMPLATE)).text()
+
+    expect(html).toContain('</html>')
+    expect(html).toContain('Recovered')
+  })
+
   it('lets a caller override the wrapper', async () => {
     const { head } = createStreamableHead()
     const html = await render(

--- a/packages/unhead/test/streaming/wrapstream-late-entries.test.ts
+++ b/packages/unhead/test/streaming/wrapstream-late-entries.test.ts
@@ -1,0 +1,62 @@
+import { createStreamableHead, wrapStream } from 'unhead/stream/server'
+import { describe, expect, it } from 'vitest'
+
+const TEMPLATE = '<!DOCTYPE html><html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+
+/** A stream that registers head entries only once it is pulled, after the shell. */
+function lateStream(register: () => void) {
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      register()
+      controller.enqueue(new TextEncoder().encode('<p>app</p>'))
+      controller.close()
+    },
+  })
+}
+
+async function render(head: any, register: () => void, options?: { flushChunk?: () => string }) {
+  return new Response(wrapStream(head, lateStream(register), TEMPLATE, undefined, options)).text()
+}
+
+describe('wrapStream late entries', () => {
+  it('delivers entries registered after the shell', async () => {
+    const { head } = createStreamableHead()
+    const html = await render(head, () => head.push({
+      title: 'Late',
+      link: [{ rel: 'canonical', href: 'https://example.com/' }],
+    }))
+
+    expect(html).toContain('__unhead__.push(')
+    expect(html).toContain('Late')
+    expect(html).toContain('canonical')
+    expect(head.entries.size).toBe(0)
+  })
+
+  it('places the patch before the closing body tags', async () => {
+    const { head } = createStreamableHead()
+    const html = await render(head, () => head.push({ title: 'Late' }))
+
+    expect(html.indexOf('__unhead__.push(')).toBeLessThan(html.indexOf('</body>'))
+  })
+
+  it('emits nothing when no entries were registered after the shell', async () => {
+    const { head } = createStreamableHead()
+    head.push({ title: 'Early' })
+    const html = await render(head, () => {})
+
+    expect(html.slice(0, html.indexOf('</head>'))).toContain('<title>Early</title>')
+    expect(html).not.toContain('__unhead__.push(')
+  })
+
+  it('lets a caller override the wrapper', async () => {
+    const { head } = createStreamableHead()
+    const html = await render(
+      head,
+      () => head.push({ title: 'Late' }),
+      { flushChunk: () => '<!--custom-->' },
+    )
+
+    expect(html).toContain('<!--custom-->')
+    expect(html).not.toContain('__unhead__.push(')
+  })
+})

--- a/packages/unhead/test/streaming/wrapstream-patch-executes.test.ts
+++ b/packages/unhead/test/streaming/wrapstream-patch-executes.test.ts
@@ -1,0 +1,79 @@
+import { JSDOM } from 'jsdom'
+import { createStreamableHead, wrapStream } from 'unhead/stream/server'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { init as initIife } from '../../src/stream/iife'
+
+const TEMPLATE = '<!DOCTYPE html><html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+
+let originalWindow: any
+let originalDocument: any
+
+beforeEach(() => {
+  originalWindow = globalThis.window
+  originalDocument = globalThis.document
+})
+
+afterEach(() => {
+  globalThis.window = originalWindow
+  globalThis.document = originalDocument
+})
+
+/**
+ * Renders through a bare `wrapStream`, then executes the served HTML the way a
+ * browser would: the shell's bootstrap script and the streamed patch both run.
+ */
+async function serveAndRun(late: Record<string, unknown>) {
+  const { head } = createStreamableHead()
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      head.push(late as any)
+      controller.enqueue(new TextEncoder().encode('<p>app</p>'))
+      controller.close()
+    },
+  })
+  const html = await new Response(wrapStream(head, stream, TEMPLATE)).text()
+
+  const dom = new JSDOM(html, { runScripts: 'dangerously' })
+  globalThis.window = dom.window as any
+  globalThis.document = dom.window.document
+  // the bundler injects the iife in a real app; it drains the queue
+  initIife({})
+  return { html, document: dom.window.document }
+}
+
+describe('the patch a bare wrapStream emits', () => {
+  it('applies to the document once the browser runs it', async () => {
+    const { html, document } = await serveAndRun({
+      title: 'Streamed late',
+      link: [{ rel: 'canonical', href: 'https://example.com/' }],
+      script: [{ type: 'application/ld+json', innerHTML: '{"@type":"Organization"}' }],
+    })
+
+    // the tag was not in the served head
+    expect(html.slice(0, html.indexOf('</head>'))).not.toContain('Streamed late')
+
+    // ...but the browser ends up with it
+    expect(document.title).toBe('Streamed late')
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe('https://example.com/')
+    expect(document.querySelector('script[type="application/ld+json"]')).toBeTruthy()
+  })
+
+  it('removes its own script element', async () => {
+    const { document } = await serveAndRun({ title: 'Streamed late' })
+
+    const remaining = [...document.querySelectorAll('script')]
+      .filter(s => s.textContent?.includes('__unhead__.push('))
+    expect(remaining).toEqual([])
+  })
+
+  it('escapes content that would otherwise close the script element', async () => {
+    const { html, document } = await serveAndRun({
+      meta: [{ name: 'description', content: '</script><img onerror=alert(1)>' }],
+    })
+
+    expect(html).not.toContain('</script><img')
+    expect(document.querySelectorAll('img')).toHaveLength(0)
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content'))
+      .toBe('</script><img onerror=alert(1)>')
+  })
+})

--- a/packages/vue/src/stream/server.ts
+++ b/packages/vue/src/stream/server.ts
@@ -60,9 +60,7 @@ export function createStreamableHead(
 
   return {
     head: vueHead,
-    // No `flushChunk`: the core default emits the same self-deleting patch
-    // script, and additionally guards the queue and survives an entry it
-    // cannot serialize. A second copy here only drifts from it.
+    // No `flushChunk`: a second copy of the core default only drifts from it.
     wrapStream: (stream, template) => wrapStream(vueHead, stream, template),
   }
 }

--- a/packages/vue/src/stream/server.ts
+++ b/packages/vue/src/stream/server.ts
@@ -3,7 +3,6 @@ import type { CreateStreamableServerHeadOptions, ResolvableHead, SSRHeadPayload 
 import type { VueHeadClient } from '../types'
 import {
   createStreamableHead as _createStreamableHead,
-  renderSSRHeadSuspenseChunk,
   wrapStream,
 } from 'unhead/stream/server'
 import { vueInstall } from '../install'
@@ -23,16 +22,14 @@ export interface VueStreamableHeadContext extends Omit<WebStreamableHeadContext<
 /**
  * Creates a head instance configured for Vue streaming SSR.
  *
- * `wrapStream` is Vue-specific: Vue's `renderToWebStream` flushes chunks in
- * document order per resolved Suspense boundary, so any head entries added
- * during a chunk's render can be emitted as a self-deleting inline
- * `<script>` right after the chunk. The script executes at HTML parse
- * (updating the client head state progressively) and calls
- * `document.currentScript.remove()` so the DOM is clean before Vue
- * hydrates. This pattern is not safe for frameworks with out-of-order
- * Suspense reveals (React, Solid) or framework-specific chunk formats
- * (Svelte) — those continue to use an in-tree `<HeadStream />` component
- * whose output is serialized inside the framework's own stream.
+ * `wrapStream` suits Vue because `renderToWebStream` flushes chunks in
+ * document order per resolved Suspense boundary, so head entries added during
+ * a chunk's render can be emitted as a self-deleting inline `<script>` right
+ * after the chunk. The script executes at HTML parse (updating the client head
+ * state progressively) and calls `document.currentScript.remove()` so the DOM
+ * is clean before Vue hydrates. Frameworks with out-of-order Suspense reveals
+ * (React, Solid) place that script in the tree with `<HeadStream />` instead,
+ * so it lands inside the framework's own chunk format.
  *
  * @example
  * ```ts
@@ -61,15 +58,12 @@ export function createStreamableHead(
   const vueHead = head as VueHeadClient<any, SSRHeadPayload>
   vueHead.install = vueInstall(vueHead)
 
-  const flushPatch = () => {
-    const patch = renderSSRHeadSuspenseChunk(vueHead)
-    return patch ? `<script>${patch};document.currentScript.remove()</script>` : ''
-  }
-
   return {
     head: vueHead,
-    wrapStream: (stream, template) =>
-      wrapStream(vueHead, stream, template, undefined, { flushChunk: flushPatch }),
+    // No `flushChunk`: the core default emits the same self-deleting patch
+    // script, and additionally guards the queue and survives an entry it
+    // cannot serialize. A second copy here only drifts from it.
+    wrapStream: (stream, template) => wrapStream(vueHead, stream, template),
   }
 }
 

--- a/packages/vue/test/streaming-patch.test.ts
+++ b/packages/vue/test/streaming-patch.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { createStreamableHead } from '../src/stream/server'
+
+const TEMPLATE = '<!DOCTYPE html><html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+const NO_HEAD_TEMPLATE = '<html><body><div id="app"><!--app-html--></div></body></html>'
+
+function lateStream(register: () => void) {
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      register()
+      controller.enqueue(new TextEncoder().encode('<p>app</p>'))
+      controller.close()
+    },
+  })
+}
+
+describe('vue streamed patch script', () => {
+  it('delivers entries registered after the shell', async () => {
+    const { head, wrapStream } = createStreamableHead()
+    const html = await new Response(wrapStream(lateStream(() => head.push({ title: 'Late' })), TEMPLATE)).text()
+
+    expect(html).toContain('__unhead__.push(')
+    expect(html).toContain('Late')
+  })
+
+  it('completes the response when a late entry cannot be serialized', async () => {
+    const { head, wrapStream } = createStreamableHead()
+    const circular: any = {}
+    circular.self = circular
+
+    const html = await new Response(wrapStream(
+      lateStream(() => head.push({ script: [{ innerHTML: circular }] })),
+      TEMPLATE,
+    )).text()
+
+    expect(html).toContain('</html>')
+  })
+
+  it('guards the queue when the template never got a bootstrap script', async () => {
+    const { head, wrapStream } = createStreamableHead()
+    const html = await new Response(wrapStream(
+      lateStream(() => head.push({ title: 'Late' })),
+      NO_HEAD_TEMPLATE,
+    )).text()
+
+    expect(html).not.toContain('window.__unhead__={')
+    expect(html).toContain('window.__unhead__&&(')
+  })
+})

--- a/packages/vue/test/streaming.test.ts
+++ b/packages/vue/test/streaming.test.ts
@@ -174,7 +174,7 @@ describe('vue streaming SSR', () => {
       const text = await new Response(wrapStream(appStream, TEMPLATE)).text()
 
       expect(text).toContain('<title>Initial</title>')
-      expect(text).toMatch(/<div>first<\/div><script>window\.__unhead__\.push\(.*Updated mid-stream.*\);document\.currentScript\.remove\(\)<\/script><div>second<\/div>/)
+      expect(text).toMatch(/<div>first<\/div><script>window\.__unhead__&&\(window\.__unhead__\.push\(.*Updated mid-stream.*\)\);document\.currentScript\.remove\(\)<\/script><div>second<\/div>/)
     })
 
     it('escapes script-breakout sequences in streamed head updates', async () => {


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`wrapStream(head, stream, template)` lost every entry registered after the shell. Not in the served `<head>`, not in a `window.__unhead__.push(...)` script, nowhere in the response at all. `flushChunk` was the only thing that wrote them, and it's the fifth argument of an options object.

It now defaults to emitting the patch script. Pass your own and it still wins, which is the hook for a CSP nonce or a different update mechanism.

The default has to survive two things. A serialization failure is swallowed rather than rethrown, because it runs after bytes are on the wire and a throw would error the stream and truncate a response the client is already reading; `renderSSRHeadSuspenseChunk` drops the offending entry first, so the next chunk recovers. And the queue is guarded (`window.__unhead__&&(...)`), since a template with no `</head>` never gets the bootstrap script yet still streams happily.

Vue was carrying its own copy of that emitter without either protection, so it now uses the core default too.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming resilience when late head-entry serialization fails.
  * Prevented patch scripts from throwing when the client bootstrap queue is unavailable.
  * Ensured streamed updates continue after an individual serialization failure.
  * Preserved existing bootstrap queues during streamed updates.
  * Ensured streamed head updates execute correctly and safely escape content.

* **Documentation**
  * Clarified that `wrapStream()` emits guarded inline patch scripts by default and supports custom flushing, including CSP nonce handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
