### PR TITLE
docs: fix outdated types in use-head TypeScript section

### DIFF
--- a/docs/head/7.api/composables/0.use-head.md
+++ b/docs/head/7.api/composables/0.use-head.md
@@ -333,14 +333,13 @@ for (const locale of availableLocales) {
     rel: 'alternate',
     href: `https://example.com/${locale.code}`,
     hreflang: locale.code,
-    key: `alternate-${locale.code}`,
   })
 }
 
 useHead({ link })
 ```
 
-These types also carry the Unhead options for that tag, such as `key`, `tagPriority` and `tagPosition`. For a non-standard `rel`, wrap that entry in `defineLink()`{lang="ts"}, see [Type Narrowing](#type-narrowing).
+These types also carry the Unhead options for that tag, such as `key`, `tagPriority` and `tagPosition`. Alternate links deduplicate on `hreflang` already, so they need no `key`. For a non-standard `rel`, wrap that entry in `defineLink()`{lang="ts"}, see [Type Narrowing](#type-narrowing).
 
 To build the head object itself, type it as `ReactiveHead` in Vue, or `ResolvableHead` elsewhere. Keep the array in its own variable. Each tag array can also be a function, so you cannot push onto `head.link` directly.
 

--- a/docs/head/7.api/composables/0.use-head.md
+++ b/docs/head/7.api/composables/0.use-head.md
@@ -296,10 +296,10 @@ Sanitization must match the destination context: HTML, attributes, URLs, JavaScr
 Import types directly from your framework's package:
 
 ```ts
-import type { ActiveHeadEntry, Head, HeadEntryOptions, UseHeadInput } from '@unhead/vue'
+import type { ActiveHeadEntry, HeadEntryOptions, UseHeadInput } from '@unhead/vue'
 
 // Type your head input
-const headConfig: Head = {
+const headConfig: UseHeadInput = {
   title: 'My Page',
   meta: [{ name: 'description', content: 'Page description' }]
 }
@@ -312,7 +312,53 @@ const options: HeadEntryOptions = {
 const entry: ActiveHeadEntry<UseHeadInput> = useHead(headConfig, options)
 ```
 
+The `Head` type is deprecated. Use `UseHeadInput` for anything you pass to `useHead()`{lang="ts"}. Use `SerializableHead` when the object must stay plain, for example JSON you send over the wire.
+
 The tag types accept `data-*` attributes. Use `defineLink()` and `defineScript()` for non-standard `rel` and `type` values, as shown below.
+
+### Typing Tag Arrays
+
+To build a tag array before you call `useHead()`{lang="ts"}, use the per-tag types. Do not write your own `{ rel: string, href: string }` shape; `rel` must stay a literal so the union can narrow.
+
+```ts
+import type { Link } from '@unhead/vue'
+import { useHead } from '@unhead/vue'
+
+const link: Link[] = []
+
+link.push({ rel: 'canonical', href: 'https://example.com' })
+
+for (const locale of availableLocales) {
+  link.push({
+    rel: 'alternate',
+    href: `https://example.com/${locale.code}`,
+    hreflang: locale.code,
+    key: `alternate-${locale.code}`,
+  })
+}
+
+useHead({ link })
+```
+
+These types also carry the Unhead options for that tag, such as `key`, `tagPriority` and `tagPosition`. For a non-standard `rel`, wrap that entry in `defineLink()`{lang="ts"}, see [Type Narrowing](#type-narrowing).
+
+To build the head object itself, type it as `ReactiveHead` in Vue, or `ResolvableHead` elsewhere. Keep the array in its own variable. Each tag array can also be a function, so you cannot push onto `head.link` directly.
+
+```ts
+import type { ReactiveHead, ResolvableLink } from '@unhead/vue'
+import { useHead } from '@unhead/vue'
+
+const head: ReactiveHead = {}
+const link: ResolvableLink[] = []
+
+link.push({ rel: 'canonical', href: 'https://example.com' })
+
+head.link = link
+
+useHead(head)
+```
+
+`ResolvableLink` allows a ref, a computed, or a getter for each property. If every value is static, use `Link` instead.
 
 ### Type Narrowing
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

A user hit this on 3.3.1 and could not find a type that worked. The TypeScript section still showed the deprecated `Head` type, and nothing covered building a link array before the `useHead()` call, which is where the strict `Link` union bites. Their own `{ rel: string, href: string }` type stopped compiling at v3.0.0 and the page gave them nowhere to go.

Two new snippets: pushing into a `Link[]`, and filling a `ReactiveHead` object with a separate `ResolvableLink[]`. Both compile against the repo.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated TypeScript examples to use the current `UseHeadInput` type.
  - Added guidance for typing plain serializable head objects with `SerializableHead`.
  - Documented tag array typing, including `Link[]`, `ReactiveHead`, and `ResolvableLink[]`.
  - Clarified literal narrowing, tag options, and reactive tag values.
  - Updated alternate link examples to reflect automatic deduplication using `hreflang`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->