### PR TITLE
fix(ssr): escape ampersands and angle brackets in attribute values

### DIFF
--- a/packages/unhead/src/server/util/propsToString.ts
+++ b/packages/unhead/src/server/util/propsToString.ts
@@ -1,11 +1,15 @@
 import { INVALID_ATTR_NAME_RE } from '../../utils/attrs'
 
-const DOUBLE_QUOTE_RE = /"/g
+const HAS_ATTR_ESCAPE_RE = /[&<>"]/
+// & is only escaped when it does not already start a character reference, so
+// pre-escaped values (e.g. `&amp;`) pass through unchanged
+const ESCAPE_ATTR_RE = /&(?!#\d+;|#x[\da-fA-F]+;|[a-zA-Z][a-zA-Z0-9]*;)|[<>"]/g
+const ESCAPE_ATTR_MAP: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }
 
 /* @__PURE__ */
 function encodeAttribute(value: string) {
   const s = typeof value === 'string' ? value : String(value)
-  return s.includes('"') ? s.replace(DOUBLE_QUOTE_RE, '&quot;') : s
+  return HAS_ATTR_ESCAPE_RE.test(s) ? s.replace(ESCAPE_ATTR_RE, c => ESCAPE_ATTR_MAP[c]) : s
 }
 
 /* @__PURE__ */

--- a/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
+++ b/packages/unhead/test/unit/server/useHeadSafe-edge-cases.test.ts
@@ -380,13 +380,12 @@ describe('useHeadSafe edge cases', () => {
       expect(ctx.headTags).not.toContain('Content-Security-Policy')
     })
 
-    it('escapes quotes in attribute values', async () => {
+    it('escapes quotes, ampersands and angle brackets in attribute values', async () => {
       const ctx = await safeRender({
         meta: [{ name: 'description', content: 'He said "hello" & <goodbye>' }],
       })
       expect(ctx.headTags).toContain('&quot;')
-      // < and > are not escaped in attribute values (safe inside double quotes)
-      expect(ctx.headTags).toContain('content="He said &quot;hello&quot; & <goodbye>"')
+      expect(ctx.headTags).toContain('content="He said &quot;hello&quot; &amp; &lt;goodbye&gt;"')
     })
   })
 

--- a/packages/unhead/test/unit/server/useHeadSafe.test.ts
+++ b/packages/unhead/test/unit/server/useHeadSafe.test.ts
@@ -247,7 +247,7 @@ describe('dom useHeadSafe', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<meta charset="utf-8&quot;><script>alert(&quot;pwned?&quot;)</script>">",
+        "headTags": "<meta charset="utf-8&quot;&gt;&lt;script&gt;alert(&quot;pwned?&quot;)&lt;/script&gt;">",
         "htmlAttrs": "",
       }
     `)

--- a/packages/unhead/test/unit/server/util.test.ts
+++ b/packages/unhead/test/unit/server/util.test.ts
@@ -19,6 +19,51 @@ describe('propsToString', () => {
     props.src = '/app.js'
     expect(propsToString(props)).toStrictEqual(' src="/app.js"')
   })
+  it('escapes < and > in attribute values', () => {
+    expect(propsToString({
+      content: 'a<b>c',
+    })).toStrictEqual(' content="a&lt;b&gt;c"')
+  })
+  it('still escapes quotes', () => {
+    expect(propsToString({
+      content: 'say "hi"',
+    })).toStrictEqual(' content="say &quot;hi&quot;"')
+  })
+  it('preserves pre-escaped entities', () => {
+    expect(propsToString({
+      href: '/a?x=1&amp;y=2',
+    })).toStrictEqual(' href="/a?x=1&amp;y=2"')
+    expect(propsToString({
+      content: 'a&#39;b&#x27;c&copy;',
+    })).toStrictEqual(' content="a&#39;b&#x27;c&copy;"')
+  })
+  it('escapes ampersands that are not entity references', () => {
+    expect(propsToString({
+      href: '/search?q=a&b=2',
+    })).toStrictEqual(' href="/search?q=a&amp;b=2"')
+    expect(propsToString({
+      href: '/_ipx/f_webp&s_4162x6018/header.jpg',
+    })).toStrictEqual(' href="/_ipx/f_webp&amp;s_4162x6018/header.jpg"')
+  })
+  it('link hrefs round-trip to the same value a browser decodes', () => {
+    // legacy no-semicolon sequences: browsers do not decode these, so they must not be preserved as entities
+    expect(propsToString({
+      href: '/search?a=1&lt=b&copy=1',
+    })).toStrictEqual(' href="/search?a=1&amp;lt=b&amp;copy=1"')
+    // unknown named reference with a semicolon: preserved raw, matches pre-change output
+    expect(propsToString({
+      href: '/search?a=1&foo;bar=2',
+    })).toStrictEqual(' href="/search?a=1&foo;bar=2"')
+    // numeric and named references pass through
+    expect(propsToString({
+      href: '/redirect?to=%2Fa&#38;from=%2Fb',
+    })).toStrictEqual(' href="/redirect?to=%2Fa&#38;from=%2Fb"')
+  })
+  it('leaves clean values untouched', () => {
+    expect(propsToString({
+      href: '/images/header.webp',
+    })).toStrictEqual(' href="/images/header.webp"')
+  })
   it('skips invalid own attribute names', () => {
     expect(propsToString({
       'name': 'description',

--- a/packages/unhead/test/unit/server/xss.test.ts
+++ b/packages/unhead/test/unit/server/xss.test.ts
@@ -283,7 +283,7 @@ describe('xss', () => {
     })
 
     const ctx = renderSSRHead(head)
-    expect(ctx.headTags).toMatchInlineSnapshot(`"<meta name="description" content="<svg><script>alert(1)</script></svg>">"`)
+    expect(ctx.headTags).toMatchInlineSnapshot(`"<meta name="description" content="&lt;svg&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;/svg&gt;">"`)
   })
 
   it('meta with character encoding tricks', async () => {
@@ -312,7 +312,7 @@ describe('xss', () => {
     })
 
     const ctx = renderSSRHead(head)
-    expect(ctx.headTags).toMatchInlineSnapshot(`"<meta name="keywords" content="📝➡️<script>alert(1)</script>">"`)
+    expect(ctx.headTags).toMatchInlineSnapshot(`"<meta name="keywords" content="📝➡️&lt;script&gt;alert(1)&lt;/script&gt;">"`)
   })
 
   it('meta with tag name bypass using character casing', async () => {
@@ -325,7 +325,7 @@ describe('xss', () => {
     })
 
     const ctx = renderSSRHead(head)
-    expect(ctx.headTags).toMatchInlineSnapshot(`"<meta name="description" content="<ScRiPt>alert(1)</ScRiPt>">"`)
+    expect(ctx.headTags).toMatchInlineSnapshot(`"<meta name="description" content="&lt;ScRiPt&gt;alert(1)&lt;/ScRiPt&gt;">"`)
   })
 
   it('script with comment-based tag closure bypass', async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Fix inferred from open-discussion triage: #350. Docs and CSP coverage split into #966; schema-org fixes in #965.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`propsToString` only escaped double quotes, so raw `&`, `<`, `>` in attribute values produced invalid HTML (e.g. `href="/_ipx/f_webp&s_4162x6018/header.jpg"` flagged by W3C validators). Now escapes all four, entity-preserving: `&` is only escaped when it does not already start a character reference, so pre-escaped values such as `&amp;` or `&#58;` pass through byte-identical.

Regression safety:
- Pre-escaped attribute values (the main double-escape risk, e.g. Nuxt users with `&amp;` URLs) output unchanged.
- `<title>` content is unaffected: it goes through `escapeHtml` on textContent in `tagToString` (unchanged; `&` has been escaped there since 2cba3acf).
- Client rendering is unaffected: attributes are set via `setAttribute`, which does not serialize entities, so there is no hydration mismatch.
- Raw `<`/`>` in attribute values can never be legitimate pre-escaped input (that would be `&lt;`), so those escapes are collision-free.
- SSR serializer only; clean values keep the allocation-free fast path.

**Verification**
- `vitest run`: 2140 tests passed
- `eslint .`: clean
- `vue-tsc --noEmit`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered HTML attribute escaping for ampersands, angle brackets, and quotation marks.
  * Preserves already-escaped character references while preventing unsafe markup from being rendered in attribute values.
* **Tests**
  * Added and updated coverage for safe attribute encoding, including XSS edge cases and pre-escaped entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->