### PR TITLE
fix(schema-org): input no-op, primaryImageOfPage opt-out, types

### DIFF
--- a/packages/schema-org/src/nodes/WebPage/index.test.ts
+++ b/packages/schema-org/src/nodes/WebPage/index.test.ts
@@ -476,6 +476,40 @@ describe('defineWebPage', () => {
     })
   })
 
+  it('primaryImageOfPage: false opts out of logo inheritance', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        defineWebPage({
+          primaryImageOfPage: false,
+        }),
+        defineOrganization({
+          name: 'Harlan Wilton',
+          logo: '/logo.png',
+        }),
+      ])
+
+      const webPage = await findNode<WebPage>(head, PrimaryWebPageId)
+      expect(webPage).not.toHaveProperty('primaryImageOfPage')
+    })
+  })
+
+  it('primaryImageOfPage: false opts out of logo inheritance when the organization resolves first', async () => {
+    await useSetup(async (head) => {
+      useSchemaOrg(head, [
+        defineOrganization({
+          name: 'Harlan Wilton',
+          logo: '/logo.png',
+        }),
+        defineWebPage({
+          primaryImageOfPage: false,
+        }),
+      ])
+
+      const webPage = await findNode<WebPage>(head, PrimaryWebPageId)
+      expect(webPage).not.toHaveProperty('primaryImageOfPage')
+    })
+  })
+
   it('duplicate entries resolve as single', async () => {
     await useSetup(async (head) => {
       useSchemaOrg(head, [

--- a/packages/schema-org/src/nodes/WebPage/index.ts
+++ b/packages/schema-org/src/nodes/WebPage/index.ts
@@ -104,8 +104,10 @@ export interface WebPageSimple extends Thing {
   dateModified?: ResolvableDate
   /**
    * A reference-by-ID to a node representing the page's featured image.
+   *
+   * Pass `false` to opt out of the automatic `primaryImageOfPage` logo inheritance.
    */
-  primaryImageOfPage?: NodeRelation<ImageObject | string>
+  primaryImageOfPage?: NodeRelation<ImageObject | string> | false | null
   /**
    * A reference-by-ID to a node representing the page's breadrumb structure.
    */
@@ -219,6 +221,9 @@ export const webPageResolver = defineSchemaOrgResolver<WebPage>({
         ? node.hasPart.map(resolvePart)
         : resolvePart(node.hasPart)
     }
+    // false is an explicit opt-out, normalise it to the null sentinel so resolvers skip inheritance
+    if (node.primaryImageOfPage === false)
+      node.primaryImageOfPage = null
     node.primaryImageOfPage = resolveRelation(node.primaryImageOfPage, ctx, imageResolver)
     node.speakable = resolveRelation(node.speakable, ctx, speakableSpecificationResolver)
     node.video = resolveRelation(node.video, ctx, videoResolver)

--- a/packages/schema-org/src/plugin.ts
+++ b/packages/schema-org/src/plugin.ts
@@ -45,21 +45,23 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
   return defineHeadPlugin((head: Unhead): HeadPlugin => {
     head.use(TemplateParamsPlugin)
     function collectTag(tag: HeadTag) {
-      if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && tag.props.nodes) {
+      if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && (tag.props.nodes || tag.key === 'schema-org-graph')) {
         // this is a bit expensive, load in seperate chunk
         const nodes = tag.props.nodes
-        for (const node of Array.isArray(nodes) ? nodes : [nodes]) {
-          // malformed input - skip null/undefined but allow empty objects
-          if (typeof node !== 'object' || node === null) {
-            continue
-          }
+        if (nodes) {
+          for (const node of Array.isArray(nodes) ? nodes : [nodes]) {
+            // malformed input - skip null/undefined but allow empty objects
+            if (typeof node !== 'object' || node === null) {
+              continue
+            }
 
-          const newNode = {
-            ...node,
-            _dedupeStrategy: tag.tagDuplicateStrategy,
+            const newNode = {
+              ...node,
+              _dedupeStrategy: tag.tagDuplicateStrategy,
+            }
+            // Push node (it already has _resolver if it came from a defineXXX function)
+            graph.push(newNode)
           }
-          // Push node (it already has _resolver if it came from a defineXXX function)
-          graph.push(newNode)
         }
         tag.tagPosition = tag.tagPosition || (config.tagPosition === 'head' ? 'head' : 'bodyClose')
       }
@@ -123,7 +125,8 @@ export function UnheadSchemaOrg(config: MetaInput = {} as MetaInput, meta: () =>
           // find the schema.org node, should be a single instance
           for (const k in ctx.tags) {
             const tag = ctx.tags[k]
-            if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && tag.props.nodes) {
+            // nodes can resolve to nullish at runtime (reactive no-op input), match by key too
+            if (tag.tag === 'script' && tag.props.type === 'application/ld+json' && (tag.props.nodes || tag.key === 'schema-org-graph')) {
               delete tag.props.nodes
               const resolvedGraph = graph.resolveGraph({ ...(meta?.() || {}), ...config, ...resolvedMeta })
               if (!resolvedGraph.length) {

--- a/packages/schema-org/src/runtime.ts
+++ b/packages/schema-org/src/runtime.ts
@@ -278,7 +278,7 @@ export function defineBookEdition<Input extends object | undefined = undefined>(
 }
 /* end-simple-only */
 
-export type UseSchemaOrgInput = Arrayable<Thing | Record<string, unknown>>
+export type UseSchemaOrgInput = Arrayable<Thing | Record<string, unknown> | null | undefined | false>
 
 export interface SchemaOrgHeadInput<T = UseSchemaOrgInput> {
   script: [{
@@ -325,7 +325,8 @@ export function normalizeSchemaOrgInput(input: unknown): SchemaOrgHeadInput<unkn
       {
         type: 'application/ld+json',
         key: 'schema-org-graph',
-        nodes: input,
+        // nullish or falsy input is a no-op, keep nodes truthy so the tag is still collected
+        nodes: input || [],
       },
     ],
   }

--- a/packages/schema-org/src/vue/runtime/composables.ts
+++ b/packages/schema-org/src/vue/runtime/composables.ts
@@ -292,7 +292,7 @@ export function defineService<Input extends object | undefined = undefined>(inpu
   return provideResolver(input, serviceResolver)
 }
 
-export type UseSchemaOrgInput = Arrayable<MaybeRef<DeepResolvableProperties<Thing | Record<string, unknown>>>>
+export type UseSchemaOrgInput = Arrayable<MaybeRef<DeepResolvableProperties<Thing | Record<string, unknown>> | null | undefined | false>>
 
 export function useSchemaOrg(input: UseSchemaOrgInput = [], options: UseHeadOptions = {}): ActiveHeadEntry<UseSchemaOrgInput> {
   // lazy initialise the plugin

--- a/packages/schema-org/test/e2e/basic.test.ts
+++ b/packages/schema-org/test/e2e/basic.test.ts
@@ -323,6 +323,61 @@ describe('schema.org e2e', () => {
     const data = renderSSRHead(ssrHead)
     expect(data.bodyTags).toMatchInlineSnapshot(`""`)
   })
+
+  it('nullish input is a no-op', async () => {
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+      plugins: [
+        UnheadSchemaOrg(),
+      ],
+    })
+    useSchemaOrg(ssrHead, null)
+    useSchemaOrg(ssrHead, undefined)
+
+    const data = renderSSRHead(ssrHead)
+    expect(data.bodyTags).toBe('')
+  })
+
+  it('nullish input is a no-op as the only entry', async () => {
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+      plugins: [
+        UnheadSchemaOrg(),
+      ],
+    })
+    useSchemaOrg(ssrHead, null)
+
+    const data = renderSSRHead(ssrHead)
+    expect(data.bodyTags).toBe('')
+  })
+  it('nullish input does not suppress other entries', async () => {
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+      plugins: [
+        UnheadSchemaOrg(),
+      ],
+    })
+    useSchemaOrg(ssrHead, [defineWebPage({ name: 'a' })])
+    useSchemaOrg(ssrHead, null)
+    const data = renderSSRHead(ssrHead)
+    expect(data.bodyTags).toContain('"@type": "WebPage"')
+    expect(data.bodyTags).toContain('"name": "a"')
+  })
+
+  it('nullish input first does not suppress other entries', async () => {
+    const ssrHead = createServerHead({
+      disableDefaults: true,
+      plugins: [
+        UnheadSchemaOrg(),
+      ],
+    })
+    useSchemaOrg(ssrHead, null)
+    useSchemaOrg(ssrHead, [defineWebPage({ name: 'a' })])
+    const data = renderSSRHead(ssrHead)
+    expect(data.bodyTags).toContain('"@type": "WebPage"')
+    expect(data.bodyTags).toContain('"name": "a"')
+  })
+
   it('#441', async () => {
     const ssrHead = createServerHead({
       disableDefaults: true,

--- a/packages/schema-org/test/ssr/params.test.ts
+++ b/packages/schema-org/test/ssr/params.test.ts
@@ -1,0 +1,27 @@
+import { defineWebPage, useSchemaOrg } from '@unhead/schema-org'
+import { createHead, renderSSRHead } from '@unhead/ssr'
+import { useHead } from 'unhead'
+import { describe, expect, it } from 'vitest'
+
+describe('schema.org params', () => {
+  it('trailingSlash as a boolean through plain useHead (#819)', () => {
+    const ssrHead = createHead()
+
+    useHead(ssrHead, {
+      templateParams: {
+        schemaOrg: {
+          host: 'https://example.com',
+          path: '/blog',
+          trailingSlash: true,
+        },
+      },
+    })
+
+    useSchemaOrg(ssrHead, [
+      defineWebPage(),
+    ])
+
+    const data = renderSSRHead(ssrHead)
+    expect(data.bodyTags).toContain('"url": "https://example.com/blog/"')
+  })
+})

--- a/packages/schema-org/test/vue/vue.test.ts
+++ b/packages/schema-org/test/vue/vue.test.ts
@@ -177,6 +177,23 @@ describe('schema.org e2e', () => {
     `)
   })
 
+  it('nullish computed input renders nothing until truthy', () => {
+    const head = createServerHead({
+      disableDefaults: true,
+    })
+    const show = ref(false)
+    useSchemaOrg([defineWebSite({ name: 'Site' })], { head })
+    useSchemaOrg(computed(() => show.value ? defineWebPage({ name: 'test' }) : null), { head })
+
+    const initial = renderSSRHead(head).bodyTags
+    expect(initial).toContain('"@type": "WebSite"')
+    expect(initial).not.toContain('"@type": "WebPage"')
+    show.value = true
+    const updated = renderSSRHead(head).bodyTags
+    expect(updated).toContain('"@type": "WebSite"')
+    expect(updated).toContain('"@type": "WebPage"')
+  })
+
   it('keeps resolvers on recomputed and frozen ref values', () => {
     const head = createServerHead({
       disableDefaults: true,

--- a/packages/unhead/src/types/schema/head.ts
+++ b/packages/unhead/src/types/schema/head.ts
@@ -164,7 +164,7 @@ export type ResolvableScript = DistributeResolvableWithEvents<Script, SchemaAugm
 export type ResolvableNoscript = ResolvableProperties<Noscript & DataKeys & SchemaAugmentations['noscript']> | string
 export type ResolvableHtmlAttributes = ResolvableProperties<UnheadHtmlAttributes & DataKeys & SchemaAugmentations['htmlAttrs']>
 export type ResolvableBodyAttributes = ResolvableProperties<UnheadBodyAttributesWithoutEvents & DataKeys & SchemaAugmentations['bodyAttrs']> & MaybeEventFnHandlers<BodyEvents>
-export type ResolvableTemplateParams = { separator?: '|' | '-' | '·' | string } & Record<string, null | string | Record<string, string>> & TemplateParamsAugmentations
+export type ResolvableTemplateParams = { separator?: '|' | '-' | '·' | string } & Record<string, null | string | boolean | number | Record<string, string | boolean | number>> & TemplateParamsAugmentations
 
 export interface ResolvableHead {
   /**

--- a/packages/unhead/src/types/tags.ts
+++ b/packages/unhead/src/types/tags.ts
@@ -85,7 +85,7 @@ export type TagKey = keyof ResolvableHead | InternalTagKey
  */
 export type InternalTagKey = '_flatMeta'
 
-export type TemplateParams = { separator?: '|' | '-' | '·' | string } & Record<string, null | string | Record<string, string>>
+export type TemplateParams = { separator?: '|' | '-' | '·' | string } & Record<string, null | string | boolean | number | Record<string, string | boolean | number>>
 
 export interface ProcessesTemplateParams { processTemplateParams?: boolean }
 

--- a/packages/unhead/test/schema-org-utils.ts
+++ b/packages/unhead/test/schema-org-utils.ts
@@ -21,7 +21,6 @@ export async function useSetup(fn: (unhead: Unhead<any>) => void, meta: Partial<
     init: [
       {
         templateParams: {
-          // @ts-expect-error untyped
           schemaOrg: {
             currency: 'AUD',
             host: 'https://example.com/',

--- a/packages/unhead/test/unit/types.test.ts
+++ b/packages/unhead/test/unit/types.test.ts
@@ -1,4 +1,4 @@
-import type { HeadEntry, HeadEntryOptions, Link, PreloadLink, Script, SerializableHead, UnheadMeta } from '../../src/types'
+import type { HeadEntry, HeadEntryOptions, Link, PreloadLink, ResolvableTemplateParams, Script, SerializableHead, UnheadMeta } from '../../src/types'
 import type { MetaKeyType, ResolveTagsOptions } from '../../src/utils'
 import { expectTypeOf } from 'vitest'
 import { useHead, useHeadSafe, useSeoMeta } from '../../src/composables'
@@ -54,6 +54,18 @@ describe('types', () => {
     })
     expectTypeOf(customScript['data-purpose']).toEqualTypeOf<'debug'>()
     customScript satisfies Script
+  })
+  it('accepts nested non-string template param values', () => {
+    const head = createHead()
+    useHead(head, {
+      templateParams: {
+        schemaOrg: {
+          trailingSlash: true,
+        },
+      },
+    })
+    const params: ResolvableTemplateParams = { schemaOrg: { trailingSlash: true } }
+    void params
   })
   it('types useHead', () => {
     const unhead = createHead()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Fixes inferred from open-discussion triage: #922, #646, #819

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Schema.org fixes from open-discussion triage, split out of #964.

**Conditional schema.org input (#922)**
`useSchemaOrg(computed(() => show ? defineWebPage() : null))` was not possible: nullish input leaked an empty `ld+json` script tag (and an empty-object input still emitted a stub node with only an `@id`). Nullish input now normalizes to an empty graph and renders nothing; input types accept `null | undefined | false` (core + Vue reactive). A null entry also no longer suppresses other entries' nodes.

**`primaryImageOfPage` opt-out (#646)**
When an Organization has a logo, WebPage always inherited it as `primaryImageOfPage` with no way to unset it (`undefined`, `null`, `false`, `0`, `''` were all stripped or ignored). `primaryImageOfPage: false` on the WebPage node is now an explicit opt-out from logo inheritance.

**Nested template param types (#819)**
`templateParams.schemaOrg.trailingSlash: true` failed to type-check because nested values were typed `Record<string, string>`, while the runtime (schema-org meta) accepts booleans. Nested values widened to `string | boolean | number`: objects and arrays are still rejected, so typo catching is preserved.

**Verification**
- `vitest run packages/schema-org packages/unhead`: 1393 tests passed
- `eslint .`: clean
- `vue-tsc --noEmit`: clean

Each fix is backed by failing-first tests where the bug was observable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web pages can now explicitly disable inherited primary images.
  * Schema.org inputs safely support `null`, `undefined`, and `false` values.
  * Template parameters now support boolean and numeric values, including nested values.
  * Schema.org metadata is recognized and rendered when node data is absent or deferred.
  * Trailing-slash URL settings are honored during server-side rendering.

* **Bug Fixes**
  * Prevented unintended organization logo inheritance on web pages.
  * Improved handling of deferred and empty schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->