### PR TITLE
docs: class dedupe recipe and CSP notes

### DIFF
--- a/docs/head/1.guides/1.core-concepts/3.class-attr.md
+++ b/docs/head/1.guides/1.core-concepts/3.class-attr.md
@@ -107,6 +107,38 @@ useHead({
 })
 ```
 
+## Merging classes across entries
+
+When several entries set classes on the same element, Unhead merges them into a single tag and combines all class names. Conflicting utility classes, such as two Tailwind background colors from `app.vue` and a page, are kept side by side because Unhead does not know they conflict.
+
+```ts
+// app.vue
+useHead({ bodyAttrs: { class: 'bg-red-500' } })
+
+// pages/index.vue
+useHead({ bodyAttrs: { class: 'bg-green-500' } })
+// <body class="bg-red-500 bg-green-500">
+```
+
+Use the `tags:afterResolve` hook with a class merge tool such as [tailwind-merge](https://github.com/dcastil/tailwind-merge) to resolve conflicts yourself.
+
+```ts
+import { twMerge } from 'tailwind-merge'
+import { injectHead } from 'unhead/vue'
+
+const head = injectHead()
+
+head.hooks.hook('tags:afterResolve', ({ tags }) => {
+  for (const tag of tags) {
+    if (tag.tag !== 'bodyAttrs' || !tag.props.class)
+      continue
+    // resolved classes are an iterable of class names
+    tag.props.class = twMerge([...tag.props.class].join(' ')).split(' ')
+  }
+})
+// <body class="bg-green-500">
+```
+
 ## See Also
 
 - [useHead() API](/docs/head/api/composables/use-head): Full API reference

--- a/docs/head/1.guides/1.core-concepts/3.class-attr.md
+++ b/docs/head/1.guides/1.core-concepts/3.class-attr.md
@@ -133,7 +133,8 @@ head.hooks.hook('tags:afterResolve', ({ tags }) => {
     if (tag.tag !== 'bodyAttrs' || !tag.props.class)
       continue
     // resolved classes are an iterable of class names
-    tag.props.class = twMerge([...tag.props.class].join(' ')).split(' ')
+    const merged = twMerge([...tag.props.class].join(' ')).trim()
+    tag.props.class = merged ? merged.split(/\s+/) : []
   }
 })
 // <body class="bg-green-500">

--- a/docs/head/1.guides/1.core-concepts/8.dom-event-handling.md
+++ b/docs/head/1.guides/1.core-concepts/8.dom-event-handling.md
@@ -18,6 +18,12 @@ During SSR, a function handler is rendered as a small marker handler such as:
 
 If the event fires before hydration, the marker lets the client renderer replay the handler with a synthetic event after adopting the element. You should therefore register the same handler during SSR and hydration. Wrapping `useHead()` in `if (import.meta.client)` removes this replay path and can also produce different server and client head entries.
 
+## Content Security Policy
+
+On the client, Unhead never writes inline event handlers: listeners go through `addEventListener()`, so strict CSP policies that block inline handlers stay clean.
+
+During SSR, a function handler is rendered as the marker attribute shown above, for example `onload="this.dataset.onloadfired = true"`. A strict policy such as `script-src-attr 'none'` blocks this attribute in the browser console. The marker only powers handler replay for events that fire before hydration; the resource itself still loads, and handlers registered on the client keep working after hydration.
+
 ## Resource events
 
 ```ts

--- a/docs/head/1.guides/1.core-concepts/8.dom-event-handling.md
+++ b/docs/head/1.guides/1.core-concepts/8.dom-event-handling.md
@@ -22,7 +22,7 @@ If the event fires before hydration, the marker lets the client renderer replay 
 
 On the client, Unhead never writes inline event handlers: listeners go through `addEventListener()`, so strict CSP policies that block inline handlers stay clean.
 
-During SSR, a function handler is rendered as the marker attribute shown above, for example `onload="this.dataset.onloadfired = true"`. A strict policy such as `script-src-attr 'none'` blocks this attribute in the browser console. The marker only powers handler replay for events that fire before hydration; the resource itself still loads, and handlers registered on the client keep working after hydration.
+During SSR, a function handler is rendered as the marker attribute shown above, for example `onload="this.dataset.onloadfired = true"`. A strict policy such as `script-src-attr 'none'` blocks execution of this inline handler and reports a CSP violation in the browser console. The marker only powers handler replay for events that fire before hydration; the resource itself still loads, and handlers registered on the client keep working after hydration.
 
 ## Resource events
 

--- a/packages/unhead/test/unit/client/eventHandlers.test.ts
+++ b/packages/unhead/test/unit/client/eventHandlers.test.ts
@@ -33,6 +33,27 @@ describe('dom event handlers', () => {
     `)
   })
 
+  it('binds script event handlers without inline attributes (CSP-safe)', () => {
+    const head = useDOMHead()
+    const dom = getActiveDom()!
+    const onLoad = vi.fn()
+    const onError = vi.fn()
+
+    head.push({
+      script: [{ key: 'csp', src: '/csp.js', onload: onLoad, onerror: onError }],
+    })
+
+    const script = dom.window.document.querySelector('script')!
+    expect(script.hasAttribute('onload')).toBe(false)
+    expect(script.hasAttribute('onerror')).toBe(false)
+    expect(script.getAttribute('data-onload')).toBe('')
+    expect(script.getAttribute('data-onerror')).toBe('')
+
+    script.dispatchEvent(new dom.window.Event('load'))
+    expect(onLoad).toHaveBeenCalledOnce()
+    expect(onError).not.toHaveBeenCalled()
+  })
+
   it('replaces element listeners without retaining stale handlers', () => {
     const head = useDOMHead()
     const dom = getActiveDom()!


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Docs and test coverage inferred from open-discussion triage: #431, #323

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Zero runtime changes, split out of #964.

**Class & Style Attributes guide (#431)**
Adds a "Merging classes across entries" section: explains how Unhead combines `bodyAttrs` classes from multiple entries, why conflicting utility classes (two Tailwind backgrounds) are kept side by side, and a `tags:afterResolve` + tailwind-merge recipe to resolve conflicts.

**DOM Event Handling guide (#323)**
Adds a "Content Security Policy" section: documents that the client renderer attaches `onload`/`onerror` via `addEventListener` (strict-CSP safe) and explains what the SSR replay marker means under a strict policy.

**CSP regression test (#323)**
Locks the client behavior in: no inline handler attributes on rendered script tags, `data-*` replay markers present, dispatching `load` calls the user handler.

**Verification**
- `vitest run packages/unhead/test/unit/client`: 72 tests passed
- `eslint`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for merging classes across multiple `bodyAttrs` entries, including conflict resolution with `tailwind-merge`.
  * Documented Content Security Policy considerations for DOM event handling and pre-hydration event replay.

* **Bug Fixes**
  * Improved event handling under strict CSP by avoiding inline event handlers while preserving event tracking and dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->