### PR TITLE
docs: security guide

### DIFF
--- a/docs/head/1.guides/0.get-started/0.overview.md
+++ b/docs/head/1.guides/0.get-started/0.overview.md
@@ -45,6 +45,8 @@ These guides cover the behavior you will use most often.
 
 :UPageCard{title="Script Loading" description="Control script triggers, lifecycle, APIs, and resource hints" to="/docs/head/guides/core-concepts/loading-scripts" icon="i-heroicons-code-bracket-square" spotlight spotlight-color="info"}
 
+:UPageCard{title="Security" description="Untrusted input, CSP compatibility, nonces, and script hardening" to="/docs/head/guides/core-concepts/security" icon="i-heroicons-shield-check" spotlight spotlight-color="info"}
+
 ::
 
 ## Extend Unhead

--- a/docs/head/1.guides/1.core-concepts/10.security.md
+++ b/docs/head/1.guides/1.core-concepts/10.security.md
@@ -8,15 +8,22 @@ Unhead renders the tags you give it. It escapes what it can, but it does not dec
 
 ## Untrusted input
 
-Head data often comes from somewhere else: a CMS, a user profile, an API response. Anything you do not fully control should go through [`useHeadSafe()`](/docs/head/api/composables/use-head-safe). It keeps an allowlist of tags and attributes, drops executable scripts, and blocks URL schemes such as `javascript:`.
+Head data often comes from somewhere else: a CMS, a user profile, an API response. The dangerous case is passing such data as a whole head object, because an attacker who controls the JSON controls the tags:
+
+```ts
+// profile.head comes from an API the user can edit
+useHead(profile.head)
+// { script: [{ src: 'https://evil.example.com/x.js' }] }
+// → arbitrary script, exactly as the attacker wrote it
+```
+
+Unhead renders the tags you give it. Filtering has to happen first. Pass untrusted input through [`useHeadSafe()`](/docs/head/api/composables/use-head-safe): it keeps an allowlist of tags and attributes, drops executable scripts, and blocks URL schemes such as `javascript:`.
 
 ```ts
 import { useHeadSafe } from '@unhead/dynamic-import'
 
-useHeadSafe({
-  title: userInput.title,
-  meta: [{ name: 'description', content: userInput.description }],
-})
+useHeadSafe(profile.head)
+// script dropped, data-* dropped, javascript: URLs rejected
 ```
 
 For metadata your application owns, `useHead()` and `useSeoMeta()` are the right tools. Nothing extra is needed.
@@ -66,22 +73,25 @@ A `<meta http-equiv="content-security-policy">` tag is supported. Unhead sorts i
 [`useScript()`](/docs/head/api/composables/use-script) ships conservative defaults for external scripts:
 
 - `crossorigin="anonymous"` and `referrerpolicy="no-referrer"` for absolute or protocol-relative URLs
-- `defer` and `fetchpriority="low"`, so third-party code never competes with your critical resources
+- `defer` and `fetchpriority="low"`, so third-party code is less likely to hold up your critical resources. Actual scheduling still depends on the browser.
 
-Add `integrity` to pin a script or stylesheet with Subresource Integrity (SRI):
+Add `integrity` to pin a script or stylesheet with Subresource Integrity (SRI). Generate the digest from the exact file you deploy, for example `openssl dgst -sha384 -binary sdk.js | openssl base64 -A`:
 
 ```ts
 useScript('https://cdn.example.com/sdk.js', {
-  integrity: 'sha384-0123456789abcdef',
+  integrity: 'sha384-YOUR_BASE64_DIGEST',
 })
 ```
 
-To load a script only after consent, hold it back with a trigger:
+To load a script only after consent, hold it back with a trigger and call `load()` when consent is granted:
 
 ```ts
-useScript('https://example.com/analytics.js', {
+const analytics = useScript('https://example.com/analytics.js', {
   trigger: 'manual',
-}).load() // call after the user accepts cookies
+})
+
+// later, in your consent callback:
+analytics.load()
 ```
 
 Interaction triggers work well here too: load on first click or keypress rather than on page load.

--- a/docs/head/1.guides/1.core-concepts/10.security.md
+++ b/docs/head/1.guides/1.core-concepts/10.security.md
@@ -17,7 +17,7 @@ useHead(profile.head)
 // → arbitrary script, exactly as the attacker wrote it
 ```
 
-Unhead renders the tags you give it. Filtering has to happen first. Pass untrusted input through [`useHeadSafe()`](/docs/head/api/composables/use-head-safe): it keeps an allowlist of tags and attributes, drops executable scripts, and blocks URL schemes such as `javascript:`.
+Unhead renders whatever that object contains. Filtering has to happen first. Pass untrusted input through [`useHeadSafe()`](/docs/head/api/composables/use-head-safe): it keeps an allowlist of tags and attributes, drops executable scripts, and blocks URL schemes such as `javascript:`.
 
 ```ts
 import { useHeadSafe } from '@unhead/dynamic-import'
@@ -62,7 +62,7 @@ useHead({
 
 ### Streaming
 
-SSR streaming injects a small inline bootstrap script plus per-chunk update scripts. The streaming build plugin accepts a `nonce` option, including a function so the nonce can rotate per request, but it covers only the bootstrap it injects. The framework wrappers and the streamed chunk updates go nonce-less. If your policy is nonce-only, use the manual template-free flow described in the [Streaming guide](/docs/typescript/head/guides/core-concepts/streaming).
+SSR streaming injects a small inline bootstrap script plus per-chunk update scripts. The framework streaming options expose only `mode`. The low-level unplugin accepts a `nonce`, string or per-request function, but it covers just the Vite-injected client bootstrap. Streamed chunk updates carry no nonce. A nonce-only policy needs the manual template-free flow in the [Streaming guide](/docs/typescript/head/guides/core-concepts/streaming): `createBootstrapScript()` takes your nonce there, and you stamp the update scripts yourself.
 
 ### Policy meta tag
 

--- a/docs/head/1.guides/1.core-concepts/10.security.md
+++ b/docs/head/1.guides/1.core-concepts/10.security.md
@@ -1,0 +1,102 @@
+---
+title: Security
+description: Escape behavior, untrusted input, CSP compatibility, nonces, SRI, and privacy defaults for scripts loaded through Unhead.
+navigation.title: Security
+---
+
+Unhead renders the tags you give it. It escapes what it can, but it does not decide for you what is safe to render. This guide covers where Unhead helps, where it steps back, and what to expect under a Content Security Policy.
+
+## Untrusted input
+
+Head data often comes from somewhere else: a CMS, a user profile, an API response. Anything you do not fully control should go through [`useHeadSafe()`](/docs/head/api/composables/use-head-safe). It keeps an allowlist of tags and attributes, drops executable scripts, and blocks URL schemes such as `javascript:`.
+
+```ts
+import { useHeadSafe } from '@unhead/dynamic-import'
+
+useHeadSafe({
+  title: userInput.title,
+  meta: [{ name: 'description', content: userInput.description }],
+})
+```
+
+For metadata your application owns, `useHead()` and `useSeoMeta()` are the right tools. Nothing extra is needed.
+
+## Escaping
+
+During SSR, Unhead encodes attribute values and escapes `title` text for you. Inline content in `script`, `style`, and `noscript` tags is a different story: it is serialized raw.
+
+Unhead does escape the closing tag sequence, so content cannot break out of its element. But the code itself runs exactly as written. If you put untrusted JavaScript or CSS there, it executes. Treat `textContent` and `innerHTML` on scripts and styles as code you authored yourself. The [Inline Style & Scripts](/docs/head/guides/core-concepts/inner-content) guide explains the parsing contexts.
+
+## Content Security Policy
+
+### Event handlers
+
+On the client, Unhead never writes inline event handlers. Every `onload`, `onerror`, and `bodyAttrs` listener is attached with `addEventListener()`. A policy with `script-src-attr 'none'` produces no violations from client-side rendering.
+
+SSR is the one exception. A function handler is serialized as a marker attribute:
+
+```html
+<script onload="this.dataset.onloadfired = true"></script>
+```
+
+The marker exists so Unhead can replay a handler that fired before hydration. A strict policy blocks it and logs a violation to the console. That is the full extent of the damage: the resource still loads, and client-side handlers keep working after hydration. See [DOM Event Handling](/docs/head/guides/core-concepts/dom-event-handling).
+
+### Inline scripts you author
+
+`nonce` passes through on `script` and `style` tags. Generate a fresh nonce per response, add it to the tags, and send the same value in the `Content-Security-Policy` header. If you use Nuxt, the [Nuxt Security](https://nuxt-security.vercel.app/) module can generate per-request nonces for you.
+
+```ts
+useHead({
+  script: [
+    { textContent: 'window.dataLayer = window.dataLayer || []', nonce: requestNonce },
+  ],
+})
+```
+
+### Streaming
+
+SSR streaming injects a small inline bootstrap script plus per-chunk update scripts. The streaming build plugin accepts a `nonce` option, including a function so the nonce can rotate per request, but it covers only the bootstrap it injects. The framework wrappers and the streamed chunk updates go nonce-less. If your policy is nonce-only, use the manual template-free flow described in the [Streaming guide](/docs/typescript/head/guides/core-concepts/streaming).
+
+### Policy meta tag
+
+A `<meta http-equiv="content-security-policy">` tag is supported. Unhead sorts it at weight -30, ahead of most other tags. Prefer a header-based policy where you can. The meta form cannot express `frame-ancestors` or report-only mode.
+
+## Third-party scripts
+
+[`useScript()`](/docs/head/api/composables/use-script) ships conservative defaults for external scripts:
+
+- `crossorigin="anonymous"` and `referrerpolicy="no-referrer"` for absolute or protocol-relative URLs
+- `defer` and `fetchpriority="low"`, so third-party code never competes with your critical resources
+
+Add `integrity` to pin a script or stylesheet with Subresource Integrity (SRI):
+
+```ts
+useScript('https://cdn.example.com/sdk.js', {
+  integrity: 'sha384-0123456789abcdef',
+})
+```
+
+To load a script only after consent, hold it back with a trigger:
+
+```ts
+useScript('https://example.com/analytics.js', {
+  trigger: 'manual',
+}).load() // call after the user accepts cookies
+```
+
+Interaction triggers work well here too: load on first click or keypress rather than on page load.
+
+## Checklist
+
+- Filter untrusted head data with `useHeadSafe()`
+- Treat inline `textContent` and `innerHTML` as authored code
+- Serve inline scripts with per-response nonces
+- Add `integrity` hashes where the CDN supports SRI
+- Expect a console violation per SSR handler under `script-src-attr 'none'`. Replay is the only thing lost.
+
+## See Also
+
+- [useHeadSafe() API](/docs/head/api/composables/use-head-safe): Allowlist reference
+- [Inline Style & Scripts](/docs/head/guides/core-concepts/inner-content): Inline content behavior
+- [DOM Event Handling](/docs/head/guides/core-concepts/dom-event-handling): Handler rendering and CSP notes
+- [Loading Scripts](/docs/head/guides/core-concepts/loading-scripts): Triggers and warmup

--- a/docs/head/1.guides/1.core-concepts/4.inner-content.md
+++ b/docs/head/1.guides/1.core-concepts/4.inner-content.md
@@ -87,6 +87,7 @@ For loading triggers, API readiness, and callbacks, use [`useScript()`](/docs/he
 
 ## See Also
 
+- [Security](/docs/head/guides/core-concepts/security): CSP and untrusted input overview
 - [Loading Scripts](/docs/head/guides/core-concepts/loading-scripts): Script management
 - [useHeadSafe() API](/docs/head/api/composables/use-head-safe): Restricted input handling
 - [useScript() API](/docs/head/api/composables/use-script): Managed script loading

--- a/docs/head/1.guides/1.core-concepts/8.dom-event-handling.md
+++ b/docs/head/1.guides/1.core-concepts/8.dom-event-handling.md
@@ -85,6 +85,7 @@ If a handler creates its own observer, timer, or subscription, clean that resour
 
 ## See Also
 
+- [Security](/docs/head/guides/core-concepts/security): CSP overview
 - [Loading Scripts](/docs/head/guides/core-concepts/loading-scripts): Managed script loading
 - [useScript() API](/docs/head/api/composables/use-script): Script callbacks and triggers
 - [useHead() API](/docs/head/api/composables/use-head): Head entry reference

--- a/docs/head/7.api/composables/1.use-head-safe.md
+++ b/docs/head/7.api/composables/1.use-head-safe.md
@@ -105,4 +105,4 @@ The allowlist reduces the attack surface, but it should be one layer in your sec
 - Treat `style` values on `htmlAttrs` and `bodyAttrs` as untrusted CSS and validate them separately if your application permits them.
 - Use `useHead()` only after sanitizing any fields that the safe API intentionally rejects.
 
-For ordinary, typed SEO metadata, [`useSeoMeta()`](/docs/head/api/composables/use-seo-meta) is usually more convenient.
+For ordinary, typed SEO metadata, [`useSeoMeta()`](/docs/head/api/composables/use-seo-meta) is usually more convenient. See the [Security guide](/docs/head/guides/core-concepts/security) for the wider security model.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Related to #323

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Security answers were spread across five pages: the useHeadSafe allowlist, inner-content escaping, the CSP notes in DOM event handling, streaming nonces, and useScript's defaults. Someone deploying a strict CSP, like the nuxt-security folks in #323, had to find all five to know where Unhead stands.

This adds a Security guide under core concepts covering untrusted input, escaping, CSP behaviour (client listeners vs the SSR marker attribute, per-response nonces, the streaming bootstrap), third-party script hardening, and a closing checklist. Cross-linked from the overview, DOM event handling, inner content, and useHeadSafe.

One thing I could not verify locally: whether the docs nav picks up the new `10.security.md` automatically. The numbering follows the existing siblings, so I expect it does.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive Security guide covering untrusted input, escaping, CSP compatibility, nonces, script hardening, SRI, consent-based loading, and security best practices.
  - Added links to the Security guide from relevant getting-started, core concept, event-handling, and API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->