### PR TITLE
fix(unhead): throw a clean error for circular head input

### DIFF
--- a/packages/unhead/src/utils/walkResolver.ts
+++ b/packages/unhead/src/utils/walkResolver.ts
@@ -1,7 +1,23 @@
 import type { PropResolver } from '../types'
 import { isUnsafeKey } from './unsafeKey'
 
-export function walkResolver(val: any, resolve?: PropResolver, key?: string): any {
+/**
+ * A repeated ancestor is a cycle in the user's input. The walk recurses
+ * forever without this check, so the caller sees `Maximum call stack size
+ * exceeded` ten frames deep in unhead internals instead of the input's
+ * fault. Siblings may share a reference, so each object leaves the set when
+ * its subtree completes.
+ */
+function assertNotCycle(v: object, seen: Set<object> | undefined, key?: string): Set<object> {
+  if (seen?.has(v)) {
+    throw new Error(`[unhead] Circular reference detected in head input${key ? ` at key "${key}"` : ''}. Remove the cycle, head tags must be a serialisable tree.`)
+  }
+  const next = seen ?? new Set()
+  next.add(v)
+  return next
+}
+
+export function walkResolver(val: any, resolve?: PropResolver, key?: string, seen?: Set<object>): any {
   if (key === '_resolver')
     return val
   if (typeof val === 'function' && (!key || (key !== 'titleTemplate' && !key.startsWith('on'))))
@@ -13,9 +29,10 @@ export function walkResolver(val: any, resolve?: PropResolver, key?: string): an
   // reference, so the whole tree is shared instead of deep-cloned. Downstream
   // (normalizeProps) copies into fresh objects, so sharing here is safe.
   if (Array.isArray(v)) {
+    const walking = assertNotCycle(v, seen)
     let out: any[] | undefined
     for (let i = 0; i < v.length; i++) {
-      const r = walkResolver(v[i], resolve)
+      const r = walkResolver(v[i], resolve, undefined, walking)
       if (out) {
         out[i] = r
       }
@@ -25,13 +42,15 @@ export function walkResolver(val: any, resolve?: PropResolver, key?: string): an
         out[i] = r
       }
     }
+    walking.delete(v)
     return out || v
   }
   if (v?.constructor === Object) {
+    const walking = assertNotCycle(v, seen, key)
     let next: Record<string, any> | undefined
     for (const k in v) {
       const unsafe = isUnsafeKey(k)
-      const r = unsafe ? undefined : walkResolver(v[k], resolve, k)
+      const r = unsafe ? undefined : walkResolver(v[k], resolve, k, walking)
       // Diverge from `v` on the first unsafe key (which must be dropped) or changed
       // child: clone the safe keys already visited. This keeps the walked result free
       // of __proto__/constructor/prototype (matching the old deep-clone) while still
@@ -48,6 +67,7 @@ export function walkResolver(val: any, resolve?: PropResolver, key?: string): an
       if (next && !unsafe)
         next[k] = r
     }
+    walking.delete(v)
     return next || v
   }
   return v

--- a/packages/unhead/test/unit/walkResolver.test.ts
+++ b/packages/unhead/test/unit/walkResolver.test.ts
@@ -1,0 +1,63 @@
+import { renderSSRHead } from '../../src/server'
+import { createHead } from '../../src/server/createHead'
+import { resolveHeadInput } from '../../src/utils/normalize'
+import { walkResolver } from '../../src/utils/walkResolver'
+
+describe('walkResolver cycle detection', () => {
+  it('throws for an object referencing itself', () => {
+    const input: any = { title: 'x' }
+    input.self = input
+    expect(() => walkResolver(input)).toThrowError(/\[unhead\] Circular reference detected in head input at key "self"/)
+  })
+
+  it('throws for a cycle through nested keys', () => {
+    const input: any = { meta: [{ name: 'a' }] }
+    input.meta[0].root = input
+    expect(() => walkResolver(input)).toThrowError(/\[unhead\] Circular reference detected/)
+  })
+
+  it('throws for an array containing itself', () => {
+    const input: any = { script: [] }
+    input.script.push(input.script)
+    expect(() => walkResolver(input)).toThrowError(/\[unhead\] Circular reference detected/)
+  })
+
+  it('allows the same object as siblings, not ancestors', () => {
+    const shared = { rel: 'icon', href: '/favicon.ico' }
+    const input = { link: [shared, shared], meta: [shared] }
+    expect(walkResolver(input)).toBe(input)
+  })
+
+  it('keeps structural sharing for unchanged input', () => {
+    const tag = { name: 'description', content: 'x' }
+    const input = { meta: [tag] }
+    expect(walkResolver(input)).toBe(input)
+  })
+
+  it('reports the key the cycle was entered through', () => {
+    const input: any = {}
+    input.innerHTML = input
+    try {
+      walkResolver(input)
+      expect.unreachable()
+    }
+    catch (error) {
+      expect((error as Error).message).toContain('at key "innerHTML"')
+    }
+  })
+
+  it('throws through resolveHeadInput with a resolver present', () => {
+    const input: any = { title: () => 'x' }
+    input.cycle = input
+    const resolver = (key: string | undefined, value: any) => value
+    expect(() => resolveHeadInput(input, [resolver])).toThrowError(/\[unhead\] Circular reference detected/)
+  })
+
+  it('surfaces as a clean error from an SSR render, not a stack overflow', () => {
+    const circular: any = { name: 'loop' }
+    circular.self = circular
+    const head = createHead()
+    head.push({ script: [{ type: 'application/ld+json', innerHTML: circular }] })
+    expect(() => renderSSRHead(head)).toThrowError(/\[unhead\] Circular reference detected in head input at key "self"/)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

found while integrating unhead 3.4 streaming into Nuxt (nuxt/nuxt#36120, nuxt/nuxt#36139)

### 📚 Description

A circular reference in head input sent `walkResolver` into infinite recursion. The caller received `Maximum call stack size exceeded` ten frames deep in unhead internals, with nothing pointing at the user's input as the fault.

The walk now tracks ancestors in a `Set` and throws:

```
[unhead] Circular reference detected in head input at key "self". Remove the cycle, head tags must be a serialisable tree.
```

Sibling reuse stays legal: each object leaves the set when its subtree completes, so the same tag object may appear under two keys without a false positive. Structural sharing is untouched: unchanged input still returns the same reference.

Callers that already catch resolve failures keep working: `renderSSRHeadSuspenseChunk` drops the poisoned entry and rethrows, `wrapStream`'s default `flushChunk` skips the patch, and the SSR render surfaces the clean message instead of a `RangeError`.

### 📝 Notes

- one `Set` per top-level walk, allocated on first object entry; the static fast path still shares the whole tree
- the `children` prop case from the same integration (renders as a literal attribute without the deprecations plugin) is already covered by the `deprecated-prop-children` rule, so no change there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Circular references in head configuration are now detected and reported with clear errors instead of causing indefinite recursion.
  - Nested and array-based cycles are handled safely while valid shared references continue to work.
  - Error messages identify the relevant head entry, including when resolution occurs during server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->