### PR TITLE
fix(unhead): handle relative useScript warmup URLs

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -99,11 +99,13 @@ jobs:
         run: |
           output=$(bun bench/bundle/report.ts)
           echo "$output"
+          printf '%s\n' "$output" >> "$GITHUB_STEP_SUMMARY"
           echo "result<<EOF" >> $GITHUB_OUTPUT
           echo "$output" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Post comment on PR
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: Bundle Size Analysis

--- a/packages/unhead/src/scripts/types.ts
+++ b/packages/unhead/src/scripts/types.ts
@@ -25,6 +25,8 @@ type BaseScriptApi = Record<symbol | string, any>
 export interface UseScriptLoaderInput<T extends BaseScriptApi = BaseScriptApi> {
   key: string
   loader: UseScriptLoader<T>
+  crossorigin?: never
+  referrerpolicy?: never
   src?: never
   innerHTML?: never
   onerror?: never

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -32,7 +32,41 @@ import { createScriptWaitFor } from './waitFor'
 type ScriptApi = Record<symbol | string, any>
 type ResolveScriptOptions<R> = Omit<UseScriptOptions<any>, 'resolve' | 'use'> & { resolve: (ctx: UseScriptContextOptions) => R, use?: never }
 type ResolvedScriptApi<R> = Extract<NonNullable<Awaited<R>>, ScriptApi>
+type ParsedHttpSource
+  = | { _tag: 'absolute', url: URL }
+    | { _tag: 'protocol-relative', httpUrl: URL, httpsUrl: URL }
 function noop() {}
+
+function tryParseUrl(src: string, base?: string): URL | undefined {
+  let url: URL | undefined
+  try {
+    url = new URL(src, base)
+  }
+  catch {
+    // Invalid script URLs cannot produce origin-only warmups.
+  }
+  return url
+}
+
+function parseHttpSource(src: string): ParsedHttpSource | undefined {
+  const absoluteUrl = tryParseUrl(src)
+  if (absoluteUrl) {
+    return absoluteUrl.protocol === 'http:' || absoluteUrl.protocol === 'https:'
+      ? { _tag: 'absolute', url: absoluteUrl }
+      : undefined
+  }
+
+  const httpBase = 'http://http-base.invalid'
+  const httpsBase = 'https://https-base.invalid'
+  const httpUrl = tryParseUrl(src, httpBase)
+  const httpsUrl = tryParseUrl(src, httpsBase)
+  if (!httpUrl || !httpsUrl)
+    return
+
+  return httpUrl.hostname === httpsUrl.hostname
+    ? { _tag: 'protocol-relative', httpUrl, httpsUrl }
+    : undefined
+}
 
 export function useScript<T extends Record<symbol | string, any>>(head: Unhead<any>, _input: UseScriptLoaderInput<T>, _options: UseScriptLoaderOptions<T> & { scope: true }): ScriptScope<T>
 export function useScript<T extends Record<symbol | string, any>>(head: Unhead<any>, _input: UseScriptLoaderInput<T>, _options?: UseScriptLoaderOptions<T> & { scope?: false }): ScriptInstance<T>
@@ -290,22 +324,21 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       const { src } = input
       if (!src)
         return
-      const isProtocolRelative = src.startsWith('//')
-      const isCrossOrigin = isProtocolRelative || /^https?:\/\//i.test(src)
+      const parsedSource = parseHttpSource(src)
+      const isCrossOrigin = !!parsedSource
       const isPreconnect = rel === 'preconnect' || rel === 'dns-prefetch'
       let href = src
       if (!rel || (isPreconnect && !isCrossOrigin)) {
         return
       }
-      if (isPreconnect) {
-        const $url = new URL(isProtocolRelative ? `http:${src}` : src)
-        if (isProtocolRelative) {
+      if (isPreconnect && parsedSource) {
+        if (parsedSource._tag === 'protocol-relative') {
           // Parse both web schemes because URL.host removes a scheme's default port.
-          const host = $url.port ? $url.host : new URL(`https:${src}`).host
+          const host = parsedSource.httpUrl.port ? parsedSource.httpUrl.host : parsedSource.httpsUrl.host
           href = `//${host}`
         }
         else {
-          href = `${$url.protocol}//${$url.host}`
+          href = `${parsedSource.url.protocol}//${parsedSource.url.host}`
         }
       }
       // Type assertion is safe: runtime logic ensures `as: 'script'` is set when rel === 'preload',

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -38,30 +38,30 @@ type ParsedHttpSource
 function noop() {}
 
 function tryParseUrl(src: string, base?: string): URL | undefined {
-  let url: URL | undefined
   try {
-    url = new URL(src, base)
+    return new URL(src, base)
   }
   catch {
-    // Invalid script URLs cannot produce origin-only warmups.
+    // URL rejection is an expected non-HTTP source at this boundary.
+    return undefined
   }
-  return url
 }
 
 function parseHttpSource(src: string): ParsedHttpSource | undefined {
-  const absoluteUrl = tryParseUrl(src)
-  if (absoluteUrl) {
-    return absoluteUrl.protocol === 'http:' || absoluteUrl.protocol === 'https:'
-      ? { _tag: 'absolute', url: absoluteUrl }
-      : undefined
-  }
-
   const httpBase = 'http://http-base.invalid'
   const httpsBase = 'https://https-base.invalid'
   const httpUrl = tryParseUrl(src, httpBase)
   const httpsUrl = tryParseUrl(src, httpsBase)
   if (!httpUrl || !httpsUrl)
     return
+
+  const absoluteUrl = tryParseUrl(src)
+  if (absoluteUrl) {
+    const isHttp = absoluteUrl.protocol === 'http:' || absoluteUrl.protocol === 'https:'
+    return isHttp && httpUrl.origin === httpsUrl.origin
+      ? { _tag: 'absolute', url: absoluteUrl }
+      : undefined
+  }
 
   return httpUrl.hostname === httpsUrl.hostname
     ? { _tag: 'protocol-relative', httpUrl, httpsUrl }
@@ -92,6 +92,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
     : loaderInput
       ? { key: loaderInput.key }
       : { ..._input }
+  const parsedSource = input.src ? parseHttpSource(input.src) : undefined
   const {
     beforeInit,
     eventContext: _eventContext,
@@ -324,7 +325,6 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       const { src } = input
       if (!src)
         return
-      const parsedSource = parseHttpSource(src)
       const isCrossOrigin = !!parsedSource
       const isPreconnect = rel === 'preconnect' || rel === 'dns-prefetch'
       let href = src
@@ -373,7 +373,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
           defer: true,
           fetchpriority: 'low',
         }
-        if (input.src && parseHttpSource(input.src)) {
+        if (parsedSource) {
           defaults.crossorigin = 'anonymous'
           defaults.referrerpolicy = 'no-referrer'
         }

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -334,7 +334,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
         return
       }
       if (isPreconnect)
-        href = parsedOrigin
+        href = parsedOrigin!
       // Type assertion is safe: runtime logic ensures `as: 'script'` is set when rel === 'preload',
       // and `as` is omitted for preconnect/dns-prefetch which don't require it.
       const link = {

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -373,8 +373,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
           defer: true,
           fetchpriority: 'low',
         }
-        // is absolute, add privacy headers
-        if (input.src && (input.src.startsWith('http') || input.src.startsWith('//'))) {
+        if (input.src && parseHttpSource(input.src)) {
           defaults.crossorigin = 'anonymous'
           defaults.referrerpolicy = 'no-referrer'
         }

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -44,17 +44,16 @@ function tryParseUrl(src: string, base?: string): URL | undefined {
   }
 }
 
-function parseHttpOrigin(src: string): string | undefined {
+function parseHttpOrigin(src: string, baseURI?: string): string | undefined {
   const absoluteUrl = tryParseUrl(src)
   if (absoluteUrl) {
     if (absoluteUrl.protocol !== 'http:' && absoluteUrl.protocol !== 'https:')
       return
     // Use another host so same-scheme relative URLs cannot match the absolute parse.
-    const baseHost = absoluteUrl.hostname === 'a' ? 'b' : 'a'
-    const resolvedUrl = tryParseUrl(src, `${absoluteUrl.protocol}//${baseHost}`)
-    return resolvedUrl?.origin === absoluteUrl.origin
-      ? absoluteUrl.origin
-      : undefined
+    const resolvedUrl = tryParseUrl(src, `${absoluteUrl.protocol}//${absoluteUrl.hostname === 'a' ? 'b' : 'a'}`)
+    if (resolvedUrl?.origin === absoluteUrl.origin)
+      return absoluteUrl.origin
+    return baseURI && !baseURI.startsWith(absoluteUrl.protocol) ? absoluteUrl.origin : undefined
   }
 
   const httpUrl = tryParseUrl(src, 'http://a')
@@ -92,7 +91,6 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
     : loaderInput
       ? { key: loaderInput.key }
       : { ..._input }
-  const parsedOrigin = input.src ? parseHttpOrigin(input.src) : undefined
   const {
     beforeInit,
     eventContext: _eventContext,
@@ -117,6 +115,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       prevScript._setupTriggerHandler(trigger, false)
     return result
   }
+  const parsedOrigin = input.src ? parseHttpOrigin(input.src, head.resolvedOptions.document?.baseURI) : undefined
   const lifecycleController = new AbortController()
   const useContext = {
     signal: lifecycleController.signal,
@@ -325,21 +324,20 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       const { src } = input
       if (!src)
         return
-      const isCrossOrigin = !!parsedOrigin
       const isPreconnect = rel === 'preconnect' || rel === 'dns-prefetch'
       let href = src
-      if (!rel || (isPreconnect && !isCrossOrigin)) {
+      if (!rel || (isPreconnect && !parsedOrigin)) {
         return
       }
-      if (isPreconnect && parsedOrigin)
+      if (isPreconnect)
         href = parsedOrigin
       // Type assertion is safe: runtime logic ensures `as: 'script'` is set when rel === 'preload',
       // and `as` is omitted for preconnect/dns-prefetch which don't require it.
       const link = {
         href,
         rel,
-        crossorigin: typeof input.crossorigin !== 'undefined' ? input.crossorigin : (isCrossOrigin ? 'anonymous' : undefined),
-        referrerpolicy: typeof input.referrerpolicy !== 'undefined' ? input.referrerpolicy : (isCrossOrigin ? 'no-referrer' : undefined),
+        crossorigin: typeof input.crossorigin !== 'undefined' ? input.crossorigin : (parsedOrigin ? 'anonymous' : undefined),
+        referrerpolicy: typeof input.referrerpolicy !== 'undefined' ? input.referrerpolicy : (parsedOrigin ? 'no-referrer' : undefined),
         fetchpriority: typeof input.fetchpriority !== 'undefined' ? input.fetchpriority : 'low',
         integrity: input.integrity,
         as: rel === 'preload' ? 'script' : undefined,

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -116,6 +116,10 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
     return result
   }
   const parsedOrigin = input.src ? parseHttpOrigin(input.src, head.resolvedOptions.document?.baseURI) : undefined
+  if (parsedOrigin && input.crossorigin === undefined)
+    input.crossorigin = 'anonymous'
+  if (parsedOrigin && input.referrerpolicy === undefined)
+    input.referrerpolicy = 'no-referrer'
   const lifecycleController = new AbortController()
   const useContext = {
     signal: lifecycleController.signal,
@@ -336,8 +340,8 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       const link = {
         href,
         rel,
-        crossorigin: typeof input.crossorigin !== 'undefined' ? input.crossorigin : (parsedOrigin ? 'anonymous' : undefined),
-        referrerpolicy: typeof input.referrerpolicy !== 'undefined' ? input.referrerpolicy : (parsedOrigin ? 'no-referrer' : undefined),
+        crossorigin: input.crossorigin,
+        referrerpolicy: input.referrerpolicy,
         fetchpriority: typeof input.fetchpriority !== 'undefined' ? input.fetchpriority : 'low',
         integrity: input.integrity,
         as: rel === 'preload' ? 'script' : undefined,
@@ -362,10 +366,6 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
         const defaults: Partial<RawInput<'script'>> = {
           defer: true,
           fetchpriority: 'low',
-        }
-        if (parsedOrigin) {
-          defaults.crossorigin = 'anonymous'
-          defaults.referrerpolicy = 'no-referrer'
         }
         // status should get updated from script events
         script.entry = head.push({

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -298,7 +298,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
         return
       }
       if (isPreconnect) {
-        const $url = new URL(isProtocolRelative ? `https:${src}` : src)
+        const $url = new URL(isProtocolRelative ? `unhead:${src}` : src)
         href = isProtocolRelative ? `//${$url.host}` : `${$url.protocol}//${$url.host}`
       }
       // Type assertion is safe: runtime logic ensures `as: 'script'` is set when rel === 'preload',

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -290,15 +290,16 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       const { src } = input
       if (!src)
         return
-      const isCrossOrigin = !src.startsWith('/') || src.startsWith('//')
+      const isProtocolRelative = src.startsWith('//')
+      const isCrossOrigin = isProtocolRelative || /^https?:\/\//i.test(src)
       const isPreconnect = rel === 'preconnect' || rel === 'dns-prefetch'
       let href = src
       if (!rel || (isPreconnect && !isCrossOrigin)) {
         return
       }
       if (isPreconnect) {
-        const $url = new URL(src)
-        href = `${$url.protocol}//${$url.host}`
+        const $url = new URL(isProtocolRelative ? `https:${src}` : src)
+        href = isProtocolRelative ? `//${$url.host}` : `${$url.protocol}//${$url.host}`
       }
       // Type assertion is safe: runtime logic ensures `as: 'script'` is set when rel === 'preload',
       // and `as` is omitted for preconnect/dns-prefetch which don't require it.

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -32,9 +32,6 @@ import { createScriptWaitFor } from './waitFor'
 type ScriptApi = Record<symbol | string, any>
 type ResolveScriptOptions<R> = Omit<UseScriptOptions<any>, 'resolve' | 'use'> & { resolve: (ctx: UseScriptContextOptions) => R, use?: never }
 type ResolvedScriptApi<R> = Extract<NonNullable<Awaited<R>>, ScriptApi>
-type ParsedHttpSource
-  = | { _tag: 'absolute', url: URL }
-    | { _tag: 'protocol-relative', httpUrl: URL, httpsUrl: URL }
 function noop() {}
 
 function tryParseUrl(src: string, base?: string): URL | undefined {
@@ -47,24 +44,27 @@ function tryParseUrl(src: string, base?: string): URL | undefined {
   }
 }
 
-function parseHttpSource(src: string): ParsedHttpSource | undefined {
-  const httpBase = 'http://http-base.invalid'
-  const httpsBase = 'https://https-base.invalid'
-  const httpUrl = tryParseUrl(src, httpBase)
-  const httpsUrl = tryParseUrl(src, httpsBase)
-  if (!httpUrl || !httpsUrl)
-    return
-
+function parseHttpOrigin(src: string): string | undefined {
   const absoluteUrl = tryParseUrl(src)
   if (absoluteUrl) {
-    const isHttp = absoluteUrl.protocol === 'http:' || absoluteUrl.protocol === 'https:'
-    return isHttp && httpUrl.origin === httpsUrl.origin
-      ? { _tag: 'absolute', url: absoluteUrl }
+    if (absoluteUrl.protocol !== 'http:' && absoluteUrl.protocol !== 'https:')
+      return
+    // Use another host so same-scheme relative URLs cannot match the absolute parse.
+    const baseHost = absoluteUrl.hostname === 'a' ? 'b' : 'a'
+    const resolvedUrl = tryParseUrl(src, `${absoluteUrl.protocol}//${baseHost}`)
+    return resolvedUrl?.origin === absoluteUrl.origin
+      ? absoluteUrl.origin
       : undefined
   }
 
+  const httpUrl = tryParseUrl(src, 'http://a')
+  const httpsUrl = tryParseUrl(src, 'https://b')
+  if (!httpUrl || !httpsUrl)
+    return
+
+  // Prefer the parse that preserves an explicit default port.
   return httpUrl.hostname === httpsUrl.hostname
-    ? { _tag: 'protocol-relative', httpUrl, httpsUrl }
+    ? `//${httpUrl.port ? httpUrl.host : httpsUrl.host}`
     : undefined
 }
 
@@ -92,7 +92,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
     : loaderInput
       ? { key: loaderInput.key }
       : { ..._input }
-  const parsedSource = input.src ? parseHttpSource(input.src) : undefined
+  const parsedOrigin = input.src ? parseHttpOrigin(input.src) : undefined
   const {
     beforeInit,
     eventContext: _eventContext,
@@ -325,22 +325,14 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
       const { src } = input
       if (!src)
         return
-      const isCrossOrigin = !!parsedSource
+      const isCrossOrigin = !!parsedOrigin
       const isPreconnect = rel === 'preconnect' || rel === 'dns-prefetch'
       let href = src
       if (!rel || (isPreconnect && !isCrossOrigin)) {
         return
       }
-      if (isPreconnect && parsedSource) {
-        if (parsedSource._tag === 'protocol-relative') {
-          // Parse both web schemes because URL.host removes a scheme's default port.
-          const host = parsedSource.httpUrl.port ? parsedSource.httpUrl.host : parsedSource.httpsUrl.host
-          href = `//${host}`
-        }
-        else {
-          href = `${parsedSource.url.protocol}//${parsedSource.url.host}`
-        }
-      }
+      if (isPreconnect && parsedOrigin)
+        href = parsedOrigin
       // Type assertion is safe: runtime logic ensures `as: 'script'` is set when rel === 'preload',
       // and `as` is omitted for preconnect/dns-prefetch which don't require it.
       const link = {
@@ -373,7 +365,7 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
           defer: true,
           fetchpriority: 'low',
         }
-        if (parsedSource) {
+        if (parsedOrigin) {
           defaults.crossorigin = 'anonymous'
           defaults.referrerpolicy = 'no-referrer'
         }

--- a/packages/unhead/src/scripts/useScript.ts
+++ b/packages/unhead/src/scripts/useScript.ts
@@ -298,8 +298,15 @@ function _useScript<T extends Record<symbol | string, any> = Record<symbol | str
         return
       }
       if (isPreconnect) {
-        const $url = new URL(isProtocolRelative ? `unhead:${src}` : src)
-        href = isProtocolRelative ? `//${$url.host}` : `${$url.protocol}//${$url.host}`
+        const $url = new URL(isProtocolRelative ? `http:${src}` : src)
+        if (isProtocolRelative) {
+          // Parse both web schemes because URL.host removes a scheme's default port.
+          const host = $url.port ? $url.host : new URL(`https:${src}`).host
+          href = `//${host}`
+        }
+        else {
+          href = `${$url.protocol}//${$url.host}`
+        }
       }
       // Type assertion is safe: runtime logic ensures `as: 'script'` is set when rel === 'preload',
       // and `as` is omitted for preconnect/dns-prefetch which don't require it.

--- a/packages/unhead/test/unit/scripts/dom.test.ts
+++ b/packages/unhead/test/unit/scripts/dom.test.ts
@@ -43,9 +43,13 @@ describe('dom useScript', () => {
   it.each([
     ['http-script.js', [null, null]],
     ['http:cdn.example/x.js', [null, null]],
+    ['http:http-base.invalid/..', [null, null]],
+    ['http:a/..', [null, null]],
     ['http:/cdn.example/x.js', [null, null]],
     ['http:\\cdn.example/x.js', [null, null]],
     ['https:cdn.example/x.js', [null, null]],
+    ['https:https-base.invalid/..', [null, null]],
+    ['https:b/..', [null, null]],
     ['https:/cdn.example/x.js', [null, null]],
     ['https:\\cdn.example/x.js', [null, null]],
     ['/\\cdn.example.com/x.js', ['anonymous', 'no-referrer']],

--- a/packages/unhead/test/unit/scripts/dom.test.ts
+++ b/packages/unhead/test/unit/scripts/dom.test.ts
@@ -42,16 +42,16 @@ describe('dom useScript', () => {
   })
   it.each([
     ['http-script.js', [null, null]],
-    ['http:cdn.example/x.js', [null, null]],
-    ['http:http-base.invalid/..', [null, null]],
-    ['http:a/..', [null, null]],
-    ['http:/cdn.example/x.js', [null, null]],
-    ['http:\\cdn.example/x.js', [null, null]],
-    ['https:cdn.example/x.js', [null, null]],
-    ['https:https-base.invalid/..', [null, null]],
-    ['https:b/..', [null, null]],
-    ['https:/cdn.example/x.js', [null, null]],
-    ['https:\\cdn.example/x.js', [null, null]],
+    ['http:cdn.example/x.js', ['anonymous', 'no-referrer']],
+    ['http:http-base.invalid/..', ['anonymous', 'no-referrer']],
+    ['http:a/..', ['anonymous', 'no-referrer']],
+    ['http:/cdn.example/x.js', ['anonymous', 'no-referrer']],
+    ['http:\\cdn.example/x.js', ['anonymous', 'no-referrer']],
+    ['https:cdn.example/x.js', ['anonymous', 'no-referrer']],
+    ['https:https-base.invalid/..', ['anonymous', 'no-referrer']],
+    ['https:b/..', ['anonymous', 'no-referrer']],
+    ['https:/cdn.example/x.js', ['anonymous', 'no-referrer']],
+    ['https:\\cdn.example/x.js', ['anonymous', 'no-referrer']],
     ['/\\cdn.example.com/x.js', ['anonymous', 'no-referrer']],
     [' https://cdn.example.com/script.js ', ['anonymous', 'no-referrer']],
   ])('keeps preload privacy attributes aligned for %s', async (src, expected) => {
@@ -73,6 +73,47 @@ describe('dom useScript', () => {
       preload!.getAttribute('crossorigin'),
       preload!.getAttribute('referrerpolicy'),
     ]).toEqual(expected)
+  })
+  it.each([
+    ['https://app.example/', 'http:cdn.example/x.js', ['anonymous', 'no-referrer']],
+    ['http://app.example/', 'http:cdn.example/x.js', [null, null]],
+    ['http://app.example/', 'https:cdn.example/x.js', ['anonymous', 'no-referrer']],
+    ['https://app.example/', 'https:cdn.example/x.js', [null, null]],
+  ])('uses document %s for privacy defaults from %s', async (baseURI, src, expected) => {
+    const head = useDOMHead()
+    const document = getActiveDom()!.window.document
+    const base = document.createElement('base')
+    base.href = baseURI
+    document.head.append(base)
+
+    useScript(head, src)
+    await useDelayedSerializedDom()
+
+    const script = document.querySelector('script')
+    const preload = document.querySelector('link[rel="preload"]')
+    expect([
+      script!.getAttribute('crossorigin'),
+      script!.getAttribute('referrerpolicy'),
+    ]).toEqual(expected)
+    expect([
+      preload!.getAttribute('crossorigin'),
+      preload!.getAttribute('referrerpolicy'),
+    ]).toEqual(expected)
+  })
+  it('preconnects when the document proves a scheme-dependent origin', async () => {
+    const head = useDOMHead()
+    const document = getActiveDom()!.window.document
+    const base = document.createElement('base')
+    base.href = 'https://app.example/'
+    document.head.append(base)
+
+    useScript(head, 'http:cdn.example/x.js', {
+      trigger: 'manual',
+      warmupStrategy: 'preconnect',
+    })
+    await useDelayedSerializedDom()
+
+    expect(document.querySelector('link[rel="preconnect"]')?.getAttribute('href')).toBe('http://cdn.example')
   })
   it('keeps removed handles terminal and re-adds through a new instance', async () => {
     const head = useDOMHead()

--- a/packages/unhead/test/unit/scripts/dom.test.ts
+++ b/packages/unhead/test/unit/scripts/dom.test.ts
@@ -42,6 +42,12 @@ describe('dom useScript', () => {
   })
   it.each([
     ['http-script.js', [null, null]],
+    ['http:cdn.example/x.js', [null, null]],
+    ['http:/cdn.example/x.js', [null, null]],
+    ['http:\\cdn.example/x.js', [null, null]],
+    ['https:cdn.example/x.js', [null, null]],
+    ['https:/cdn.example/x.js', [null, null]],
+    ['https:\\cdn.example/x.js', [null, null]],
     ['/\\cdn.example.com/x.js', ['anonymous', 'no-referrer']],
     [' https://cdn.example.com/script.js ', ['anonymous', 'no-referrer']],
   ])('keeps preload privacy attributes aligned for %s', async (src, expected) => {

--- a/packages/unhead/test/unit/scripts/dom.test.ts
+++ b/packages/unhead/test/unit/scripts/dom.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { useScript } from '../../../src/composables'
-import { useDelayedSerializedDom, useDOMHead } from '../../../test/util'
+import { getActiveDom, useDelayedSerializedDom, useDOMHead } from '../../../test/util'
 
 describe('dom useScript', () => {
   it('basic', async () => {
@@ -39,6 +39,30 @@ describe('dom useScript', () => {
     })
 
     expect(instance.proxy.test('hello-world')).toEqual('hello-world')
+  })
+  it.each([
+    ['http-script.js', [null, null]],
+    ['/\\cdn.example.com/x.js', ['anonymous', 'no-referrer']],
+    [' https://cdn.example.com/script.js ', ['anonymous', 'no-referrer']],
+  ])('keeps preload privacy attributes aligned for %s', async (src, expected) => {
+    const head = useDOMHead()
+
+    useScript(head, src)
+    await useDelayedSerializedDom()
+
+    const document = getActiveDom()!.window.document
+    const script = document.querySelector('script')
+    const preload = document.querySelector('link[rel="preload"]')
+    expect(script).not.toBeNull()
+    expect(preload).not.toBeNull()
+    expect([
+      script!.getAttribute('crossorigin'),
+      script!.getAttribute('referrerpolicy'),
+    ]).toEqual(expected)
+    expect([
+      preload!.getAttribute('crossorigin'),
+      preload!.getAttribute('referrerpolicy'),
+    ]).toEqual(expected)
   })
   it('keeps removed handles terminal and re-adds through a new instance', async () => {
     const head = useDOMHead()

--- a/packages/unhead/test/unit/scripts/dom.test.ts
+++ b/packages/unhead/test/unit/scripts/dom.test.ts
@@ -100,6 +100,28 @@ describe('dom useScript', () => {
       preload!.getAttribute('referrerpolicy'),
     ]).toEqual(expected)
   })
+  it('defaults undefined privacy fields on object input', async () => {
+    const head = useDOMHead()
+
+    useScript(head, {
+      src: 'https://cdn.example.com/script.js',
+      crossorigin: undefined,
+      referrerpolicy: undefined,
+    })
+    await useDelayedSerializedDom()
+
+    const document = getActiveDom()!.window.document
+    const script = document.querySelector('script')
+    const preload = document.querySelector('link[rel="preload"]')
+    expect([
+      script!.getAttribute('crossorigin'),
+      script!.getAttribute('referrerpolicy'),
+    ]).toEqual(['anonymous', 'no-referrer'])
+    expect([
+      preload!.getAttribute('crossorigin'),
+      preload!.getAttribute('referrerpolicy'),
+    ]).toEqual(['anonymous', 'no-referrer'])
+  })
   it('preconnects when the document proves a scheme-dependent origin', async () => {
     const head = useDOMHead()
     const document = getActiveDom()!.window.document
@@ -126,7 +148,7 @@ describe('dom useScript', () => {
     let dom = await useDelayedSerializedDom()
     expect(dom.split('\n').filter(l => l.trim().startsWith('<script'))).toMatchInlineSnapshot(`
       [
-        "<script defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" data-onload="" data-onerror=""></script><link href="https://cdn.example.com/script.js" rel="preload" crossorigin="anonymous" referrerpolicy="no-referrer" fetchpriority="low" as="script"></head>",
+        "<script defer="" fetchpriority="low" src="https://cdn.example.com/script.js" crossorigin="anonymous" referrerpolicy="no-referrer" data-onload="" data-onerror=""></script><link href="https://cdn.example.com/script.js" rel="preload" crossorigin="anonymous" referrerpolicy="no-referrer" fetchpriority="low" as="script"></head>",
       ]
     `)
     instance.remove()
@@ -150,7 +172,7 @@ describe('dom useScript', () => {
     dom = await useDelayedSerializedDom()
     expect(dom.split('\n').filter(l => l.trim().startsWith('<script'))).toMatchInlineSnapshot(`
       [
-        "<script defer="" fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" data-onload="" data-onerror=""></script><link href="https://cdn.example.com/script.js" rel="preload" crossorigin="anonymous" referrerpolicy="no-referrer" fetchpriority="low" as="script"></head>",
+        "<script defer="" fetchpriority="low" src="https://cdn.example.com/script.js" crossorigin="anonymous" referrerpolicy="no-referrer" data-onload="" data-onerror=""></script><link href="https://cdn.example.com/script.js" rel="preload" crossorigin="anonymous" referrerpolicy="no-referrer" fetchpriority="low" as="script"></head>",
       ]
     `)
   })

--- a/packages/unhead/test/unit/scripts/ssr.test.ts
+++ b/packages/unhead/test/unit/scripts/ssr.test.ts
@@ -40,7 +40,7 @@ describe('ssr useScript', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true"></script>",
+        "headTags": "<script defer fetchpriority="low" src="https://cdn.example.com/script.js" crossorigin="anonymous" referrerpolicy="no-referrer" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true"></script>",
         "htmlAttrs": "",
       }
     `)
@@ -63,7 +63,7 @@ describe('ssr useScript', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://cdn.example.com/script.js" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true"></script>",
+        "headTags": "<script defer fetchpriority="low" src="https://cdn.example.com/script.js" crossorigin="anonymous" referrerpolicy="no-referrer" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true"></script>",
         "htmlAttrs": "",
       }
     `)
@@ -101,7 +101,7 @@ describe('ssr useScript', () => {
         "bodyAttrs": "",
         "bodyTags": "",
         "bodyTagsOpen": "",
-        "headTags": "<script defer fetchpriority="low" crossorigin="anonymous" referrerpolicy="no-referrer" src="https://www.googletagmanager.com/gtm.js?id=GTM-MNJD4B" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true"></script>",
+        "headTags": "<script defer fetchpriority="low" src="https://www.googletagmanager.com/gtm.js?id=GTM-MNJD4B" crossorigin="anonymous" referrerpolicy="no-referrer" onload="this.dataset.onloadfired = true" onerror="this.dataset.onerrorfired = true"></script>",
         "htmlAttrs": "",
       }
     `)

--- a/packages/unhead/test/unit/scripts/warmup.test.ts
+++ b/packages/unhead/test/unit/scripts/warmup.test.ts
@@ -85,4 +85,19 @@ describe('warmup', () => {
     expect(link.href).toEqual('//cdn.example.com')
     expect(link.rel).toEqual('preconnect')
   })
+
+  it('preserves explicit ports in protocol-relative origin warmups', () => {
+    const head = createServerHead({
+      disableDefaults: true,
+    })
+
+    useScript(head, '//cdn.example.com:443/script.js', {
+      trigger: 'manual',
+      warmupStrategy: 'preconnect',
+    })
+
+    // @ts-expect-error untyped
+    const link = [...head.entries.values()][0]!.input!.link![0] as GenericLink
+    expect(link.href).toEqual('//cdn.example.com:443')
+  })
 })

--- a/packages/unhead/test/unit/scripts/warmup.test.ts
+++ b/packages/unhead/test/unit/scripts/warmup.test.ts
@@ -70,6 +70,28 @@ describe('warmup', () => {
     expect([...head.entries.values()]).toHaveLength(0)
   })
 
+  it.each([
+    'http:cdn.example/x.js',
+    'http:/cdn.example/x.js',
+    'http:\\cdn.example/x.js',
+    'https:cdn.example/x.js',
+    'https:/cdn.example/x.js',
+    'https:\\cdn.example/x.js',
+  ])('skips origin-only warmups when source %s depends on the document scheme', (src) => {
+    for (const warmupStrategy of ['preconnect', 'dns-prefetch'] as const) {
+      const head = createServerHead({
+        disableDefaults: true,
+      })
+
+      useScript(head, src, {
+        trigger: 'manual',
+        warmupStrategy,
+      })
+
+      expect([...head.entries.values()]).toHaveLength(0)
+    }
+  })
+
   it('supports protocol-relative sources for origin-only warmups', () => {
     const head = createServerHead({
       disableDefaults: true,
@@ -126,8 +148,10 @@ describe('warmup', () => {
   })
 
   it.each([
+    ['http://cdn.example.com/script.js', 'http://cdn.example.com'],
     [' https://cdn.example.com/script.js ', 'https://cdn.example.com'],
     [' //cdn.example.com/script.js ', '//cdn.example.com'],
+    ['http:\\\\cdn.example.com/script.js', 'http://cdn.example.com'],
     ['https:\\\\cdn.example.com/script.js', 'https://cdn.example.com'],
   ])('uses the parsed HTTP origin for source %s', (src, expectedHref) => {
     const head = createServerHead({

--- a/packages/unhead/test/unit/scripts/warmup.test.ts
+++ b/packages/unhead/test/unit/scripts/warmup.test.ts
@@ -57,4 +57,32 @@ describe('warmup', () => {
     expect(link.href).toEqual('https://cdn.example.com')
     expect(link.rel).toEqual('dns-prefetch')
   })
+
+  it('skips origin-only warmups for document-relative sources', () => {
+    const head = createServerHead({
+      disableDefaults: true,
+    })
+
+    expect(() => useScript(head, 'script.js', {
+      trigger: 'manual',
+      warmupStrategy: 'preconnect',
+    })).not.toThrow()
+    expect([...head.entries.values()]).toHaveLength(0)
+  })
+
+  it('supports protocol-relative sources for origin-only warmups', () => {
+    const head = createServerHead({
+      disableDefaults: true,
+    })
+
+    expect(() => useScript(head, '//cdn.example.com/script.js', {
+      trigger: 'manual',
+      warmupStrategy: 'preconnect',
+    })).not.toThrow()
+
+    // @ts-expect-error untyped
+    const link = [...head.entries.values()][0]!.input!.link![0] as GenericLink
+    expect(link.href).toEqual('//cdn.example.com')
+    expect(link.rel).toEqual('preconnect')
+  })
 })

--- a/packages/unhead/test/unit/scripts/warmup.test.ts
+++ b/packages/unhead/test/unit/scripts/warmup.test.ts
@@ -86,6 +86,25 @@ describe('warmup', () => {
     expect(link.rel).toEqual('preconnect')
   })
 
+  it.each([
+    ['//cdn.example.com\\script.js', '//cdn.example.com'],
+    ['//cdn.example.com\\@evil.example/script.js', '//cdn.example.com'],
+    ['///script.js', '//script.js'],
+  ])('uses browser URL parsing for protocol-relative source %s', (src, expectedHref) => {
+    const head = createServerHead({
+      disableDefaults: true,
+    })
+
+    expect(() => useScript(head, src, {
+      trigger: 'manual',
+      warmupStrategy: 'preconnect',
+    })).not.toThrow()
+
+    // @ts-expect-error untyped
+    const link = [...head.entries.values()][0]!.input!.link![0] as GenericLink
+    expect(link.href).toEqual(expectedHref)
+  })
+
   it('preserves explicit ports in protocol-relative origin warmups', () => {
     const head = createServerHead({
       disableDefaults: true,

--- a/packages/unhead/test/unit/scripts/warmup.test.ts
+++ b/packages/unhead/test/unit/scripts/warmup.test.ts
@@ -105,18 +105,62 @@ describe('warmup', () => {
     expect(link.href).toEqual(expectedHref)
   })
 
-  it('preserves explicit ports in protocol-relative origin warmups', () => {
+  it.each([
+    ['//cdn.example.com/script.js', '//cdn.example.com'],
+    ['//cdn.example.com:80/script.js', '//cdn.example.com:80'],
+    ['//cdn.example.com:443/script.js', '//cdn.example.com:443'],
+    ['//cdn.example.com:8080/script.js', '//cdn.example.com:8080'],
+  ])('preserves the port in protocol-relative origin warmup %s', (src, expectedHref) => {
     const head = createServerHead({
       disableDefaults: true,
     })
 
-    useScript(head, '//cdn.example.com:443/script.js', {
+    useScript(head, src, {
       trigger: 'manual',
       warmupStrategy: 'preconnect',
     })
 
     // @ts-expect-error untyped
     const link = [...head.entries.values()][0]!.input!.link![0] as GenericLink
-    expect(link.href).toEqual('//cdn.example.com:443')
+    expect(link.href).toEqual(expectedHref)
+  })
+
+  it.each([
+    [' https://cdn.example.com/script.js ', 'https://cdn.example.com'],
+    [' //cdn.example.com/script.js ', '//cdn.example.com'],
+    ['https:\\\\cdn.example.com/script.js', 'https://cdn.example.com'],
+  ])('uses the parsed HTTP origin for source %s', (src, expectedHref) => {
+    const head = createServerHead({
+      disableDefaults: true,
+    })
+
+    useScript(head, src, {
+      trigger: 'manual',
+      warmupStrategy: 'preconnect',
+    })
+
+    // @ts-expect-error untyped
+    const link = [...head.entries.values()][0]!.input!.link![0] as GenericLink
+    expect(link.href).toEqual(expectedHref)
+  })
+
+  it.each([
+    ' https://cdn.example.com/script.js ',
+    ' //cdn.example.com/script.js ',
+    'https:\\\\cdn.example.com/script.js',
+  ])('adds cross-origin privacy defaults for preload source %s', (src) => {
+    const head = createServerHead({
+      disableDefaults: true,
+    })
+
+    useScript(head, src, {
+      head,
+      trigger: 'client',
+    })
+
+    // @ts-expect-error untyped
+    const link = [...head.entries.values()][0]!.input!.link![0] as GenericLink
+    expect(link.crossorigin).toEqual('anonymous')
+    expect(link.referrerpolicy).toEqual('no-referrer')
   })
 })

--- a/packages/unhead/test/unit/scripts/warmup.test.ts
+++ b/packages/unhead/test/unit/scripts/warmup.test.ts
@@ -72,9 +72,13 @@ describe('warmup', () => {
 
   it.each([
     'http:cdn.example/x.js',
+    'http:http-base.invalid/..',
+    'http:a/..',
     'http:/cdn.example/x.js',
     'http:\\cdn.example/x.js',
     'https:cdn.example/x.js',
+    'https:https-base.invalid/..',
+    'https:b/..',
     'https:/cdn.example/x.js',
     'https:\\cdn.example/x.js',
   ])('skips origin-only warmups when source %s depends on the document scheme', (src) => {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Document-relative and protocol-relative script sources made `useScript()` throw `TypeError: Invalid URL` with documented `preconnect` or `dns-prefetch` warmups. Origin-only hints now skip document-relative sources and keep the `//host` origin for protocol-relative sources. Absolute HTTPS and relative preload output stay unchanged.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource warmup behavior for external scripts.
  * Protocol-relative script URLs now generate origin-only preconnect hints, including explicit ports.
  * Relative and unsupported script URL formats are excluded from preconnect and DNS-prefetch hints.
  * External scripts and preloaded resources now apply consistent anonymous cross-origin and no-referrer privacy defaults.
  * Warmup behavior now handles additional URL formats more reliably, helping eligible resources begin loading sooner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->