### PR TITLE
fix(bundler): inject resolved path for devtools runtime plugin

### DIFF
--- a/packages/bundler/src/devtools/vite.ts
+++ b/packages/bundler/src/devtools/vite.ts
@@ -14,6 +14,7 @@ import { getConfigRpc, runLintRpc } from './rpc'
 
 const LEADING_SLASH_RE = /^\//
 const UNHEAD_VERSION_RE = /__UNHEAD_VERSION__ = ['"]'?["']/
+const BACKSLASH_RE = /\\/g
 
 function isViteDevtoolsPlugin(plugin: { name?: string }): boolean {
   return !!plugin.name?.startsWith('vite:devtools')
@@ -39,6 +40,20 @@ function findPkgRoot(fromUrl: string): string {
     dir = dirname(dir)
   }
   return dir
+}
+
+/**
+ * Absolute path to this package's runtime entry (which exports `devtoolsPlugin`).
+ *
+ * This is needed for projects that do not have `@unhead/bundler` as an explicit dep.
+ */
+function resolveRuntimeEntry(pkgDir: string): string {
+  const candidates = [
+    resolve(pkgDir, 'dist/index.mjs'),
+    // running from source (repo tests, unbuilt workspace)
+    resolve(pkgDir, 'src/index.ts'),
+  ]
+  return (candidates.find(existsSync) ?? candidates[0]).replace(BACKSLASH_RE, '/')
 }
 
 function resolveDevToolsKitClient(root: string, pkgDir: string): string | undefined {
@@ -142,7 +157,7 @@ export function unheadDevtools(options?: UnheadDevtoolsInternalOptions): Plugin 
       // Register runtime plugins via the shared context
       if (options?._ctx) {
         options._ctx.addRuntimePlugin({
-          import: { name: 'devtoolsPlugin', source: '@unhead/bundler', as: '__unhead_devtoolsPlugin' },
+          import: { name: 'devtoolsPlugin', source: resolveRuntimeEntry(pkgDir), as: '__unhead_devtoolsPlugin' },
           client: 'window.__unhead_devtools__=_h',
           server: '_h.use(__unhead_devtoolsPlugin())',
         })

--- a/packages/bundler/src/unplugin/CreateHeadTransform.ts
+++ b/packages/bundler/src/unplugin/CreateHeadTransform.ts
@@ -60,7 +60,7 @@ export function CreateHeadTransform(ctx: HeadTransformContext): Plugin {
           .map(r => (isServer ? r.server! : r.client!).replace(/__ROOT__/g, rootLiteral))
           .join(',')
         const imports = envRegistrations
-          .map(reg => `import { ${reg.import.name} as ${reg.import.as} } from '${reg.import.source}';\n`)
+          .map(reg => `import { ${reg.import.name} as ${reg.import.as} } from ${JSON.stringify(reg.import.source)};\n`)
           .join('')
         const s = new MagicString(code)
         let transformed = false

--- a/packages/bundler/test/createHeadTransform.test.ts
+++ b/packages/bundler/test/createHeadTransform.test.ts
@@ -69,7 +69,7 @@ describe('createHeadTransform', () => {
       client: '_h.use(__validate({ root: __ROOT__ }))',
     }], 'client')
     const result = await transform(`import { createHead } from '@unhead/vue/client'\nconst head = createHead()`)
-    expect(result.code).toContain('import { ValidatePlugin as __validate } from \'@unhead/vue/plugins\'')
+    expect(result.code).toContain('import { ValidatePlugin as __validate } from "@unhead/vue/plugins"')
     expect(result.code).toContain('_h.use(__validate({ root: "/project" }))')
     expect(result.code).not.toContain('typeof window')
   })
@@ -80,8 +80,22 @@ describe('createHeadTransform', () => {
       server: '_h.use(__devtools())',
     }], 'server')
     const result = await transform(`import { createHead } from '@unhead/vue/server'\nconst head = createHead()`)
-    expect(result.code).toContain('import { devtoolsPlugin as __devtools } from \'@unhead/bundler\'')
+    expect(result.code).toContain('import { devtoolsPlugin as __devtools } from "@unhead/bundler"')
     expect(result.code).toContain('_h.use(__devtools())')
+  })
+
+  it.each([
+    '/Users/o\'brien/app/node_modules/@unhead/bundler/dist/index.mjs',
+    '/tmp/line\nbreak/node_modules/@unhead/bundler/dist/index.mjs',
+  ])('emits a valid string literal for the import source %j', async (source) => {
+    const { transform } = createPlugin([{
+      import: { name: 'devtoolsPlugin', source, as: '__devtools' },
+      server: '_h.use(__devtools())',
+    }], 'server')
+    const result = await transform(`import { createHead } from '@unhead/vue/server'\nconst head = createHead()`)
+    const literal = result.code.match(/^import \{ devtoolsPlugin as __devtools \} from (.+);$/m)?.[1]
+    expect(literal).toBeTruthy()
+    expect(JSON.parse(literal!)).toBe(source)
   })
 
   it('injects validation into development server heads', async () => {

--- a/packages/bundler/test/devtoolsRuntimeImport.test.ts
+++ b/packages/bundler/test/devtoolsRuntimeImport.test.ts
@@ -1,0 +1,62 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { unheadDevtools } from '../src/devtools/vite'
+import { CreateHeadTransform, createHeadTransformContext } from '../src/unplugin/CreateHeadTransform'
+
+const IMPORT_RE = /import \{ devtoolsPlugin as __unhead_devtoolsPlugin \} from '([^']+)'/
+
+const RENDERER = `import { createHead } from '@unhead/vue'\nexport const head = createHead()\n`
+
+/**
+ * An app whose `createHead()` call site lives in a package that only depends on
+ * a framework package, so `@unhead/bundler` is not resolvable from there.
+ */
+function createIsolatedApp(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'unhead-isolated-'))
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'renderer', dependencies: { '@unhead/vue': '*' } }))
+  const vueDir = join(dir, 'node_modules/@unhead/vue')
+  mkdirSync(vueDir, { recursive: true })
+  writeFileSync(join(vueDir, 'package.json'), JSON.stringify({ name: '@unhead/vue', main: 'index.js' }))
+  writeFileSync(join(vueDir, 'index.js'), 'module.exports = { createHead: () => ({}) }')
+  writeFileSync(join(dir, 'renderer.ts'), RENDERER)
+  return dir
+}
+
+/**
+ * Resolves in a child process, because vitest patches `createRequire` to use
+ * Vite's resolver and injects a `NODE_PATH` that makes every hoisted pnpm
+ * package resolvable from anywhere.
+ */
+function resolveFrom(importer: string, specifier: string): string | undefined {
+  const script = `const { createRequire } = require('node:module');`
+    + `try { process.stdout.write(createRequire(${JSON.stringify(importer)}).resolve(${JSON.stringify(specifier)})) } catch {}`
+  const { NODE_PATH: _, ...env } = process.env
+  return execFileSync(process.execPath, ['-e', script], { encoding: 'utf-8', env }) || undefined
+}
+
+describe('devtools runtime plugin injection', () => {
+  it('injects a specifier resolvable from the transformed module', async () => {
+    const appDir = createIsolatedApp()
+    const importer = join(appDir, 'renderer.ts')
+    expect(resolveFrom(importer, '@unhead/bundler')).toBeUndefined()
+
+    const ctx = createHeadTransformContext()
+    const devtools = unheadDevtools({ _ctx: ctx }) as any
+    await devtools.configResolved({ root: appDir, devtools: { enabled: true }, plugins: [] })
+
+    const transform = CreateHeadTransform(ctx) as any
+    transform.configResolved({ root: appDir })
+    const result = transform.transform.handler.call(
+      { environment: { config: { consumer: 'server' } } },
+      RENDERER,
+      importer,
+    )
+
+    const source = result.code.match(IMPORT_RE)?.[1]
+    expect(source).toBeTruthy()
+    expect(resolveFrom(importer, source!)).toBeTruthy()
+  })
+})

--- a/packages/bundler/test/devtoolsRuntimeImport.test.ts
+++ b/packages/bundler/test/devtoolsRuntimeImport.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest'
 import { unheadDevtools } from '../src/devtools/vite'
 import { CreateHeadTransform, createHeadTransformContext } from '../src/unplugin/CreateHeadTransform'
 
-const IMPORT_RE = /import \{ devtoolsPlugin as __unhead_devtoolsPlugin \} from ("[^"]+")/
+const IMPORT_RE = /import \{ devtoolsPlugin as __unhead_devtoolsPlugin \} from ("(?:[^"\\]|\\.)+")/
 
 const RENDERER = `import { createHead } from '@unhead/vue'\nexport const head = createHead()\n`
 

--- a/packages/bundler/test/devtoolsRuntimeImport.test.ts
+++ b/packages/bundler/test/devtoolsRuntimeImport.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest'
 import { unheadDevtools } from '../src/devtools/vite'
 import { CreateHeadTransform, createHeadTransformContext } from '../src/unplugin/CreateHeadTransform'
 
-const IMPORT_RE = /import \{ devtoolsPlugin as __unhead_devtoolsPlugin \} from '([^']+)'/
+const IMPORT_RE = /import \{ devtoolsPlugin as __unhead_devtoolsPlugin \} from ("[^"]+")/
 
 const RENDERER = `import { createHead } from '@unhead/vue'\nexport const head = createHead()\n`
 
@@ -55,8 +55,9 @@ describe('devtools runtime plugin injection', () => {
       importer,
     )
 
-    const source = result.code.match(IMPORT_RE)?.[1]
-    expect(source).toBeTruthy()
+    const literal = result.code.match(IMPORT_RE)?.[1]
+    expect(literal).toBeTruthy()
+    const source = JSON.parse(literal!) as string
     expect(resolveFrom(importer, source!)).toBeTruthy()
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

noticed in the nuxt playground I was getting 500 errors as the bare `@unhead/bundler` specifier wasn't resolvable in a pnpm setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vite devtools integration for projects that do not directly depend on the bundler package.
  - Ensured injected devtools imports resolve correctly across different project setups and operating systems.
  - Prevented special characters, including apostrophes and line breaks, from breaking generated imports.

- **Tests**
  - Added coverage for runtime imports when the bundler package is not directly available.
  - Added regression coverage for safely handling special characters in injected import paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->