### PR TITLE
docs: document the ssr:streamChunk hook

### DIFF
--- a/docs/head/7.api/0.get-started/overview.md
+++ b/docs/head/7.api/0.get-started/overview.md
@@ -44,6 +44,7 @@ See the [Plugins API](/docs/head/api/plugins) for creating custom plugins with `
 - [ssr:beforeRender](/docs/head/api/hooks/ssr-before-render): Called before server-side rendering
 - [ssr:render](/docs/head/api/hooks/ssr-render): Called after tags resolve but before serialization
 - [ssr:rendered](/docs/head/api/hooks/ssr-rendered): Called with the final SSR payload
+- [ssr:streamChunk](/docs/head/api/hooks/ssr-stream-chunk): Called with tags that resolve after the streamed shell (synchronous)
 
 ### Script loading
 

--- a/docs/head/7.api/hooks/11.ssr-stream-chunk.md
+++ b/docs/head/7.api/hooks/11.ssr-stream-chunk.md
@@ -1,0 +1,60 @@
+---
+title: "ssr:streamChunk Hook"
+description: "Hook for inspecting normalized tags from entries that resolve after the SSR shell has streamed."
+navigation:
+  title: "ssr:streamChunk"
+---
+
+The `ssr:streamChunk` hook is fired by `renderSSRHeadSuspenseChunk()` with normalized tags from entries that were still pending after the shell was sent. When no pending entries remain, the chunk renderer returns early and the hook does not fire.
+
+## Hook Signature
+
+```ts
+export interface Hook {
+  'ssr:streamChunk': (ctx: { tags: HeadTag[] }) => SyncHookResult
+}
+
+type SyncHookResult = void
+```
+
+Unlike the other SSR hooks, this hook cannot be asynchronous: `SyncHookResult` resolves to `void`.
+
+### Parameters
+
+| Name | Type | Description |
+| ------ | ------ | ------------- |
+| `ctx.tags` | `HeadTag[]` | Normalized copies of the tags resolved from entries pending after the shell |
+
+### When It Fires
+
+Inside `renderSSRHeadSuspenseChunk()`, the hook runs:
+
+1. After the pending entries are resolved into normalized tags
+2. Before streamed body tags are split out of the patch
+3. Before the remaining patch is serialized and the pending entries clear
+
+The chunk renderer normally serializes entry input without normalizing its tags. This hook supplies normalized copies for inspection. The rendered patch does not use these tags. Plugin-owned shapes (`_flatMeta`, the legacy `body` prop) are left for the listener to resolve.
+
+Normalization only runs when a listener is registered, so the hook adds no cost when nothing listens to it.
+
+The hook is synchronous: the renderer does not wait for promises before it serializes the patch and clears entries.
+
+## Usage Example
+
+```ts
+import { defineHeadPlugin } from '@unhead/dynamic-import/plugins'
+
+export const pendingTagsPlugin = defineHeadPlugin({
+  key: 'pending-tags',
+  hooks: {
+    'ssr:streamChunk': ({ tags }) => {
+      for (const tag of tags)
+        console.log(`Tag arrived after the shell: ${tag.tagName}`)
+    }
+  }
+})
+```
+
+Tags reported by this hook were not part of the initial shell. They ship to the client as a patch, so bots that do not run JavaScript will not see them. Register such tags before the shell renders when crawlers need to see them.
+
+The shell counterpart is the `ssr:rendered` hook, which receives the serialized payload of the initial render instead of per-boundary patches.

--- a/docs/head/7.api/hooks/11.ssr-stream-chunk.md
+++ b/docs/head/7.api/hooks/11.ssr-stream-chunk.md
@@ -25,7 +25,7 @@ type SyncHookResult = void
 
 ## When It Fires
 
-Inside `renderSSRHeadSuspenseChunk()` the hook runs after the pending entries are normalized. It runs before the renderer splits out Streamed Body Tags, serializes the client patch, and clears the entries.
+Inside `renderSSRHeadSuspenseChunk()` the hook runs after the pending entries are normalized. It runs before the renderer splits out streamed body tags, serializes the client patch, and clears the entries.
 
 The client patch is built from the raw entry input, not from `ctx.tags`. The tags are copies for inspection. Changing them does not change what the client receives.
 
@@ -53,7 +53,7 @@ export const pendingTagsPlugin = defineHeadPlugin({
 
 ## Crawler Visibility
 
-Every tag this hook reports was missing from the initial shell. If a tag ends up in the client patch, the browser applies it with JavaScript, so crawlers that skip JavaScript never see it. Tags that qualify as Streamed Body Tags are written into the HTML body instead and stay visible. See [Streaming](/docs/typescript/head/guides/core-concepts/streaming) for which tags qualify.
+Every tag this hook reports was missing from the initial shell. If a tag ends up in the client patch, the browser applies it with JavaScript, so crawlers that skip JavaScript never see it. Tags that qualify as streamed body tags are written into the HTML body instead and stay visible. See [Streaming](/docs/typescript/head/guides/core-concepts/streaming) for which tags qualify.
 
 [`ValidatePlugin`](/docs/typescript/head/guides/tooling/validate-plugin) uses this hook to report `streamed-tag-hidden-from-bots` during development.
 

--- a/docs/head/7.api/hooks/11.ssr-stream-chunk.md
+++ b/docs/head/7.api/hooks/11.ssr-stream-chunk.md
@@ -1,11 +1,11 @@
 ---
 title: "ssr:streamChunk Hook"
-description: "Hook for inspecting normalized tags from entries that resolve after the SSR shell has streamed."
+description: "Hook for inspecting the tags that resolve after the SSR shell has streamed."
 navigation:
   title: "ssr:streamChunk"
 ---
 
-The `ssr:streamChunk` hook is fired by `renderSSRHeadSuspenseChunk()` with normalized tags from entries that were still pending after the shell was sent. When no pending entries remain, the chunk renderer returns early and the hook does not fire.
+The `ssr:streamChunk` hook runs inside `renderSSRHeadSuspenseChunk()`, once per chunk. It receives normalized copies of the tags from entries that were still pending after the shell went out. If no entries are pending, the chunk renderer returns early and the hook does not fire.
 
 ## Hook Signature
 
@@ -17,32 +17,28 @@ export interface Hook {
 type SyncHookResult = void
 ```
 
-Unlike the other SSR hooks, this hook cannot be asynchronous: `SyncHookResult` resolves to `void`.
-
 ### Parameters
 
 | Name | Type | Description |
 | ------ | ------ | ------------- |
-| `ctx.tags` | `HeadTag[]` | Normalized copies of the tags resolved from entries pending after the shell |
+| `ctx.tags` | `HeadTag[]` | Normalized copies of the tags from entries pending after the shell |
 
-### When It Fires
+## When It Fires
 
-Inside `renderSSRHeadSuspenseChunk()`, the hook runs:
+Inside `renderSSRHeadSuspenseChunk()` the hook runs after the pending entries are normalized. It runs before the renderer splits out Streamed Body Tags, serializes the client patch, and clears the entries.
 
-1. After the pending entries are resolved into normalized tags
-2. Before streamed body tags are split out of the patch
-3. Before the remaining patch is serialized and the pending entries clear
+The client patch is built from the raw entry input, not from `ctx.tags`. The tags are copies for inspection. Changing them does not change what the client receives.
 
-The chunk renderer normally serializes entry input without normalizing its tags. This hook supplies normalized copies for inspection. The rendered patch does not use these tags. Plugin-owned shapes (`_flatMeta`, the legacy `body` prop) are left for the listener to resolve.
+Only core normalization runs on these copies. Shapes that plugins own, such as `_flatMeta` or the legacy `body` prop, pass through as they are. If your listener needs them resolved, resolve them yourself.
 
-Normalization only runs when a listener is registered, so the hook adds no cost when nothing listens to it.
+Unlike the other SSR hooks, this one is typed `void`. The renderer does not wait for a returned promise before it serializes the patch and clears entries. Keep the listener synchronous.
 
-The hook is synchronous: the renderer does not wait for promises before it serializes the patch and clears entries.
+Normalization only runs when a listener is registered. With no listener, the hook costs nothing.
 
 ## Usage Example
 
 ```ts
-import { defineHeadPlugin } from 'unhead/plugins'
+import { defineHeadPlugin } from '@unhead/dynamic-import/plugins'
 
 export const pendingTagsPlugin = defineHeadPlugin({
   key: 'pending-tags',
@@ -55,6 +51,10 @@ export const pendingTagsPlugin = defineHeadPlugin({
 })
 ```
 
-Tags reported by this hook were not part of the initial shell. Tags that remain in the client patch require JavaScript, so bots that do not run JavaScript will not see them. Streamed body tags are emitted in the streamed HTML body instead.
+## Crawler Visibility
 
-The shell counterpart is the `ssr:rendered` hook, which receives the serialized payload of the initial render instead of per-boundary patches.
+Every tag this hook reports was missing from the initial shell. If a tag ends up in the client patch, the browser applies it with JavaScript, so crawlers that skip JavaScript never see it. Tags that qualify as Streamed Body Tags are written into the HTML body instead and stay visible. See [Streaming](/docs/typescript/head/guides/core-concepts/streaming) for which tags qualify.
+
+[`ValidatePlugin`](/docs/typescript/head/guides/tooling/validate-plugin) uses this hook to report `streamed-tag-hidden-from-bots` during development.
+
+For the initial render, use the [`ssr:rendered`](/docs/head/api/hooks/ssr-rendered) hook instead. It receives the serialized payload of the shell, not per-boundary patches.

--- a/docs/head/7.api/hooks/11.ssr-stream-chunk.md
+++ b/docs/head/7.api/hooks/11.ssr-stream-chunk.md
@@ -42,19 +42,19 @@ The hook is synchronous: the renderer does not wait for promises before it seria
 ## Usage Example
 
 ```ts
-import { defineHeadPlugin } from '@unhead/dynamic-import/plugins'
+import { defineHeadPlugin } from 'unhead/plugins'
 
 export const pendingTagsPlugin = defineHeadPlugin({
   key: 'pending-tags',
   hooks: {
     'ssr:streamChunk': ({ tags }) => {
       for (const tag of tags)
-        console.log(`Tag arrived after the shell: ${tag.tagName}`)
+        console.log(`Tag arrived after the shell: ${tag.tag}`)
     }
   }
 })
 ```
 
-Tags reported by this hook were not part of the initial shell. They ship to the client as a patch, so bots that do not run JavaScript will not see them. Register such tags before the shell renders when crawlers need to see them.
+Tags reported by this hook were not part of the initial shell. Tags that remain in the client patch require JavaScript, so bots that do not run JavaScript will not see them. Streamed body tags are emitted in the streamed HTML body instead.
 
 The shell counterpart is the `ssr:rendered` hook, which receives the serialized payload of the initial render instead of per-boundary patches.


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The hooks API reference covers most hooks but had no page for `ssr:streamChunk`. This adds `docs/head/7.api/hooks/11.ssr-stream-chunk.md`, following the format of the other hook pages. The signature and behavior notes are taken from the public docstring in `packages/unhead/src/types/hooks.ts` and the call site in `renderSSRHeadSuspenseChunk()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added documentation for the `ssr:streamChunk` hook in the server-rendering guide.
  - Described its signature, synchronous execution, firing order, normalized tag handling, and crawler visibility.
  - Included an updated usage example for plugin setup and streamed tag logging.
  - Explained how the hook differs from `ssr:rendered`.
  - Added links to the Streaming guide and `ValidatePlugin`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->