### PR TITLE
chore: stop capitalizing streamed body tags

### DIFF
--- a/docs/0.react/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.react/head/guides/1.core-concepts/5.streaming.md
@@ -30,7 +30,7 @@ Entries registered before this callback reach the initial head.
 Entries from later `<Suspense>` content follow two paths:
 
 - Head-only tags become inline patch scripts.
-- JSON-LD, `noscript`, and body-positioned tags become Streamed Body Tags before `</body>`.
+- JSON-LD, `noscript`, and body-positioned tags become streamed body tags before `</body>`.
 
 The build plugin adds `HeadStream` inside each transformed component that calls `useHead()`.
 Keep the plugin enabled or late entries will not reach the response.

--- a/docs/0.solid-js/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.solid-js/head/guides/1.core-concepts/5.streaming.md
@@ -26,7 +26,7 @@ Entries registered before this callback reach the initial head.
 Entries from later resource content follow two paths:
 
 - Head-only tags become inline patch scripts.
-- JSON-LD, `noscript`, and body-positioned tags become Streamed Body Tags before `</body>`.
+- JSON-LD, `noscript`, and body-positioned tags become streamed body tags before `</body>`.
 
 The build plugin adds `HeadStream` to transformed components that use head composables.
 Keep the plugin enabled or late entries will not reach the response.

--- a/docs/0.svelte/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.svelte/head/guides/1.core-concepts/5.streaming.md
@@ -24,7 +24,7 @@ The streaming option does not make `{#await}` blocks resolve in later server chu
 If server code adds a head entry after the shell, Unhead handles it as a late entry:
 
 - Head-only tags become inline patch scripts.
-- JSON-LD, `noscript`, and body-positioned tags become Streamed Body Tags before `</body>`.
+- JSON-LD, `noscript`, and body-positioned tags become streamed body tags before `</body>`.
 
 ::warning
 Many bots and link previews do not run patch scripts.

--- a/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
@@ -32,12 +32,12 @@ Tags follow three paths:
 | --- | --- |
 | before `wrapStream()` starts | initial document shell |
 | after the shell | inline patch script |
-| after the shell, when valid in the body | Streamed Body Tag before `</body>` |
+| after the shell, when valid in the body | streamed body tag before `</body>` |
 
-Late JSON-LD, `noscript`, and explicit body positions become Streamed Body Tags.
+Late JSON-LD, `noscript`, and explicit body positions become streamed body tags.
 Late `bodyOpen` tags move to the body close because the opening body has already left the server.
 
-`flushChunk` only changes patch output. `renderStreamEnd()` writes Streamed Body Tags.
+`flushChunk` only changes patch output. `renderStreamEnd()` writes streamed body tags.
 
 ::warning
 Many bots and link previews do not run patch scripts.
@@ -295,7 +295,7 @@ If you set `streamKey`, use the same key in this guard.
 
 ### renderStreamEnd
 
-Builds closing HTML and inserts Streamed Body Tags:
+Builds closing HTML and inserts streamed body tags:
 
 ```ts
 import { renderStreamEnd } from 'unhead/stream/server'
@@ -307,7 +307,7 @@ Use it instead of writing `parts.end`.
 
 ### renderStreamBodyTags
 
-Renders and clears Streamed Body Tags without a prepared template:
+Renders and clears streamed body tags without a prepared template:
 
 ```ts
 import { renderStreamBodyTags } from 'unhead/stream/server'
@@ -394,13 +394,13 @@ A tag is reported when it is not body-positioned and matches one of these:
 | `meta` | `http-equiv` is `refresh` or `content-language` |
 | `meta` | `property` (falling back to `name`) starts with `og:`, `twitter:`, `article:`, `book:`, `profile:`, `fb:`, `al:`, `music:`, `video:`, `place:`, or `product:` |
 | `link` | any `rel` token is `canonical`, `alternate`, `amphtml`, `prev`, `next`, `author`, or `license` |
-| `script` | `type` is `application/ld+json`, at any position, unless the driver writes Streamed Body Tags |
+| `script` | `type` is `application/ld+json`, at any position, unless the driver writes streamed body tags |
 
 `useHeadSafe()` strips some tags, such as a `rel="canonical"` link. The rule skips them. Nothing renders them, so a bot warning would mislead.
 
-JSON-LD can leave the stream as Streamed Body Tags. `wrapStream()` always writes them. Manual drivers opt in with `writesBodyTags: true`.
+JSON-LD can leave the stream as streamed body tags. `wrapStream()` always writes them. Manual drivers opt in with `writesBodyTags: true`.
 
-The rule stays quiet when the driver writes Streamed Body Tags. Otherwise, patch-only JSON-LD stays hidden from bots and the rule reports it.
+The rule stays quiet when the driver writes streamed body tags. Otherwise, patch-only JSON-LD stays hidden from bots and the rule reports it.
 
 Search engines read served JSON-LD anywhere in the document. Every other reported tag only works from the head.
 

--- a/docs/0.vue/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.vue/head/guides/1.core-concepts/5.streaming.md
@@ -29,7 +29,7 @@ A `useHead()` call reaches the initial head when both conditions are true:
 An async ancestor defers its whole subtree. A `<Suspense>` boundary does not change this cutoff.
 
 Later head-only tags become inline patch scripts.
-Late JSON-LD, `noscript`, and body-positioned tags become Streamed Body Tags before `</body>`.
+Late JSON-LD, `noscript`, and body-positioned tags become streamed body tags before `</body>`.
 
 ::warning
 Many bots and link previews do not run patch scripts.

--- a/docs/head/1.guides/1.core-concepts/2.positions.md
+++ b/docs/head/1.guides/1.core-concepts/2.positions.md
@@ -14,7 +14,7 @@ The `<link>`{lang="html"}, `<script>`{lang="html"}, `<noscript>`{lang="html"}, a
 - `bodyClose`{lang="bash"}: Render at the end of the `<body>`{lang="html"}
 
 ::note
-During [streaming SSR](/docs/typescript/head/guides/core-concepts/streaming), a late `bodyOpen` tag becomes a Streamed Body Tag before `</body>`.
+During [streaming SSR](/docs/typescript/head/guides/core-concepts/streaming), a late `bodyOpen` tag becomes a streamed body tag before `</body>`.
 ::
 
 ::note

--- a/packages/react/src/stream/server.ts
+++ b/packages/react/src/stream/server.ts
@@ -96,7 +96,7 @@ export function createStreamableHead<T = ResolvableHead>(
     head,
     onShellReady,
     wrap: (pipe: ReactPipeFunction, template: string | PreparedTemplate) => {
-      // `renderStreamEnd()` writes Streamed Body Tags.
+      // `renderStreamEnd()` writes streamed body tags.
       // Manual drivers retain the client patch by default.
       ;(head._stream ||= {}).writesBodyTags = true
       return (writable: Writable) => {

--- a/packages/solid-js/src/stream/server.ts
+++ b/packages/solid-js/src/stream/server.ts
@@ -82,7 +82,7 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
       resolveShellReady(shellState)
     },
     wrapStream: (stream: ReadableStream<Uint8Array>, template: string | PreparedTemplate) => {
-      // `renderStreamEnd()` writes Streamed Body Tags.
+      // `renderStreamEnd()` writes streamed body tags.
       // Manual drivers retain the client patch by default.
       ;(head._stream ||= {}).writesBodyTags = true
       const encoder = new TextEncoder()

--- a/packages/unhead/src/plugins/validate.ts
+++ b/packages/unhead/src/plugins/validate.ts
@@ -235,7 +235,7 @@ function* expandPendingTag(tag: HeadTag): Generator<HeadTag> {
 
 function isHiddenFromBots(tag: HeadTag, writesBodyTags: boolean): boolean {
   const props = tag.props
-  // Served JSON-LD remains visible as Streamed Body Tags.
+  // Served JSON-LD remains visible as streamed body tags.
   if (tag.tag === 'script')
     return !writesBodyTags && JSON_LD_TYPE_RE.test(String(props.type || ''))
   // Other reported tags only carry meaning from the head.

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -154,7 +154,7 @@ export function createBootstrapScript(streamKey: string = DEFAULT_STREAM_KEY, no
  * const { headTags, bodyTags, bodyTagsOpen, htmlAttrs, bodyAttrs } = renderShell(head)
  * const shell = `<!DOCTYPE html><html${htmlAttrs}><head>${headTags}</head><body${bodyAttrs}>${bodyTagsOpen}`
  *
- * // Stream the app, then close it with the Streamed Body Tags.
+ * // Stream the app, then close it with the streamed body tags.
  * res.end(`${renderStreamBodyTags(head)}${bodyTags}</body></html>`)
  * ```
  */
@@ -355,13 +355,13 @@ function splitStreamedBodyTags(input: any, seen: Set<string>, entryPosition?: st
       (bodyTags ||= {})[key] = carried
   }
 
-  // No client patch remains when every tag becomes a Streamed Body Tag.
+  // No client patch remains when every tag becomes a streamed body tag.
   const hasPatch = Object.keys(patch).some(k => patch[k] !== undefined)
   return { patch: hasPatch ? patch : undefined, bodyTags }
 }
 
 /**
- * Renders and clears Streamed Body Tags.
+ * Renders and clears streamed body tags.
  *
  * Manual drivers must write this before `</body>`.
  * `renderStreamEnd()` includes it for template streams.
@@ -391,7 +391,7 @@ export function renderStreamBodyTags(head: Unhead<any>): string {
 }
 
 /**
- * Adds Streamed Body Tags to the closing HTML.
+ * Adds streamed body tags to the closing HTML.
  *
  * Manual drivers must write this instead of `parts.end`.
  *
@@ -470,7 +470,7 @@ export function renderSSRHeadSuspenseChunk(head: Unhead<any>): string {
     throw error
   }
   head.entries.clear()
-  // No client patch remains when every tag becomes a Streamed Body Tag.
+  // No client patch remains when every tag becomes a streamed body tag.
   if (!patchCount)
     return ''
   return `window.${streamKey}.push(${serialized})`
@@ -521,7 +521,7 @@ export function wrapStream(
   preRenderedState?: SSRHeadPayload,
   options?: { flushChunk?: () => string },
 ): ReadableStream<Uint8Array> {
-  // `renderStreamEnd()` writes Streamed Body Tags.
+  // `renderStreamEnd()` writes streamed body tags.
   // Manual drivers opt in with `writesBodyTags`.
   streamState(head).writesBodyTags = true
   // Preserve late entries when no custom chunk renderer exists.
@@ -633,7 +633,7 @@ export interface StreamingTemplateParts {
    */
   end: string
   /**
-   * Offset for Streamed Body Tags within `end`.
+   * Offset for streamed body tags within `end`.
    */
   bodyTagsAt?: number
 }

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -167,7 +167,7 @@ export interface CreateStreamableServerHeadOptions extends Omit<CreateServerHead
    */
   streamKey?: string
   /**
-   * Set when the driver writes Streamed Body Tags before `</body>`.
+   * Set when the driver writes streamed body tags before `</body>`.
    *
    * Use `renderStreamBodyTags()` or `renderStreamEnd()` to write them.
    * `wrapStream()` enables this option automatically.
@@ -309,7 +309,7 @@ export interface Unhead<Input = ResolvableHead, RenderResult = unknown> {
    */
   _titleTemplate?: string
   /**
-   * Per-response state for Streamed Body Tags.
+   * Per-response state for streamed body tags.
    *
    * @internal
    */

--- a/packages/unhead/src/types/hooks.ts
+++ b/packages/unhead/src/types/hooks.ts
@@ -56,7 +56,7 @@ export interface DOMHeadHooks {
 export interface SSRHeadHooks {
   /**
    * Fired by `renderSSRHeadSuspenseChunk` with normalized tags from entries
-   * pending after the shell. It runs before Streamed Body Tags are split out.
+   * pending after the shell. It runs before streamed body tags are split out.
    * It also runs before the remaining patch is serialized and entries clear.
    *
    * The chunk renderer normally serializes entry input without normalizing

--- a/packages/unhead/test/streaming/broken-features.test.ts
+++ b/packages/unhead/test/streaming/broken-features.test.ts
@@ -284,7 +284,7 @@ describe('streaming SSR - potentially broken features', () => {
         }],
       })
 
-      // Streamed Body Tags keep JSON-LD visible without client scripts.
+      // Streamed body tags keep JSON-LD visible without client scripts.
       expect(renderSSRHeadSuspenseChunk(head)).toBe('')
 
       const end = renderStreamEnd(head, { shell: '', end: '</body></html>', bodyTagsAt: 0 })
@@ -344,7 +344,7 @@ describe('streaming SSR - potentially broken features', () => {
   })
 
   describe('noscript tags', () => {
-    it('writes noscript content as Streamed Body Tags', async () => {
+    it('writes noscript content as streamed body tags', async () => {
       const { head } = createStreamableHead({ writesBodyTags: true })
 
       await renderSSRHeadShell(head, '<html><head></head><body>')

--- a/packages/unhead/test/streaming/streamed-body-tag-adoption.test.ts
+++ b/packages/unhead/test/streaming/streamed-body-tag-adoption.test.ts
@@ -17,7 +17,7 @@ function appendJsonLd(doc: Document) {
   return el
 }
 
-describe('adopting late Streamed Body Tags', () => {
+describe('adopting late streamed body tags', () => {
   it('reuses a tag appended between renders', async () => {
     const doc = setup()
     const head = createHead({ document: doc })

--- a/packages/unhead/test/streaming/streamed-body-tags.test.ts
+++ b/packages/unhead/test/streaming/streamed-body-tags.test.ts
@@ -4,13 +4,13 @@ import { describe, expect, it } from 'vitest'
 import { renderShell, renderSSRHeadSuspenseChunk, renderStreamEnd, wrapStream } from '../../src/stream/server'
 import { createStreamableServerHead } from '../util'
 
-// Streamed Body Tags render at the body-close position in `end`.
+// Streamed body tags render at the body-close position in `end`.
 const PARTS = { shell: '', end: '</div></body></html>', bodyTagsAt: '</div>'.length }
 
 const GTM = '<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-1"></iframe>'
 
 describe('noscript registered after the shell', () => {
-  it('writes noscript as a Streamed Body Tag', () => {
+  it('writes noscript as a streamed body tag', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     head.push({ noscript: [{ innerHTML: GTM, tagPosition: 'bodyOpen' }] })
 
@@ -39,7 +39,7 @@ describe('noscript registered after the shell', () => {
 })
 
 describe('body-positioned tags registered after the shell', () => {
-  it('writes a body-close script as a Streamed Body Tag', () => {
+  it('writes a body-close script as a streamed body tag', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     head.push({ script: [{ src: '/late.js', tagPosition: 'bodyClose' }] })
 
@@ -47,7 +47,7 @@ describe('body-positioned tags registered after the shell', () => {
     expect(renderStreamEnd(head, PARTS)).toContain('<script src="/late.js"')
   })
 
-  it('writes a body-close style as a Streamed Body Tag', () => {
+  it('writes a body-close style as a streamed body tag', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     head.push({ style: [{ innerHTML: '.a{color:red}', tagPosition: 'bodyClose' }] })
     renderSSRHeadSuspenseChunk(head)
@@ -67,7 +67,7 @@ describe('body-positioned tags registered after the shell', () => {
   })
 })
 
-describe('an entry with patch tags and Streamed Body Tags', () => {
+describe('an entry with patch tags and streamed body tags', () => {
   it('splits each tag into the correct output', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     head.push({
@@ -90,8 +90,8 @@ describe('an entry with patch tags and Streamed Body Tags', () => {
 })
 
 describe('a stream that pauses mid-element', () => {
-  // Vue may pause inside `<select>`. Streamed Body Tags remain body children.
-  it('renders Streamed Body Tags outside the open select', async () => {
+  // Vue may pause inside `<select>`. Streamed body tags remain body children.
+  it('renders streamed body tags outside the open select', async () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     const template = '<!DOCTYPE html><html><head></head><body><div id="app"><!--app-html--></div></body></html>'
     const enc = new TextEncoder()
@@ -150,7 +150,7 @@ describe('a tag the shell already served', () => {
     expect(renderStreamEnd(head, PARTS)).toBe(PARTS.end)
   })
 
-  it('writes a different unkeyed Streamed Body Tag', () => {
+  it('writes a different unkeyed streamed body tag', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     head.push({ script: [{ type: 'application/ld+json', innerHTML: '{"a":1}' }] })
     renderShell(head)
@@ -165,7 +165,7 @@ describe('a tag the shell already served', () => {
 describe('a driver that builds the response by hand', () => {
   const LD = { type: 'application/ld+json', innerHTML: '{"@type":"Organization"}' } as const
 
-  it('keeps Streamed Body Tags in the patch until the driver opts in', () => {
+  it('keeps streamed body tags in the patch until the driver opts in', () => {
     const head = createStreamableServerHead()
     renderShell(head)
     head.push({ script: [LD], noscript: [{ innerHTML: '<img src="px.gif">' }] })
@@ -176,7 +176,7 @@ describe('a driver that builds the response by hand', () => {
     expect(chunk).toContain('px.gif')
   })
 
-  it('does not buffer Streamed Body Tags until the driver opts in', () => {
+  it('does not buffer streamed body tags until the driver opts in', () => {
     const head = createStreamableServerHead()
     renderShell(head)
     head.push({ script: [LD] })
@@ -201,7 +201,7 @@ describe('a driver that builds the response by hand', () => {
     expect(doc.querySelectorAll('script[type="application/ld+json"]')).toHaveLength(1)
   })
 
-  it('does not duplicate a Streamed Body Tag after a client patch', async () => {
+  it('does not duplicate a streamed body tag after a client patch', async () => {
     const head = createStreamableServerHead()
     renderShell(head)
     head.push({ script: [LD] })
@@ -219,7 +219,7 @@ describe('a driver that builds the response by hand', () => {
 })
 
 describe('tagPosition given as an entry option', () => {
-  it('writes an entry-positioned Streamed Body Tag', () => {
+  it('writes an entry-positioned streamed body tag', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     renderShell(head)
     head.push({ script: [{ src: '/x.js' }] }, { tagPosition: 'bodyClose' })

--- a/packages/unhead/test/streaming/streamed-bot-rule.test.ts
+++ b/packages/unhead/test/streaming/streamed-bot-rule.test.ts
@@ -75,7 +75,7 @@ describe('streamed-tag-hidden-from-bots', () => {
     expect(flagged({ script: [{ type: 'application/ld+json', innerHTML: '{}', tagPosition: 'bodyClose' }] })).toHaveLength(1)
   })
 
-  it('stays quiet when the driver writes JSON-LD as Streamed Body Tags', () => {
+  it('stays quiet when the driver writes JSON-LD as streamed body tags', () => {
     const reported: HeadValidationRule[] = []
     const { head } = createStreamableHead({
       disableDefaults: true,

--- a/packages/unhead/test/streaming/streamed-jsonld-body-tags.test.ts
+++ b/packages/unhead/test/streaming/streamed-jsonld-body-tags.test.ts
@@ -30,10 +30,10 @@ async function readAll(stream: ReadableStream<Uint8Array>) {
 
 const LD = { type: 'application/ld+json', innerHTML: '{"@type":"Organization"}' } as const
 
-// Streamed Body Tags render at the body-close position in `end`.
+// Streamed body tags render at the body-close position in `end`.
 const PARTS = { shell: '', end: '</div></body></html>', bodyTagsAt: '</div>'.length }
 
-describe('rendering JSON-LD as Streamed Body Tags', () => {
+describe('rendering JSON-LD as streamed body tags', () => {
   it('keeps JSON-LD out of the patch script', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     head.push({ script: [LD] })
@@ -51,7 +51,7 @@ describe('rendering JSON-LD as Streamed Body Tags', () => {
     expect(chunk).not.toContain('ld+json')
   })
 
-  it('renders JSON-LD as a Streamed Body Tag', () => {
+  it('renders JSON-LD as a streamed body tag', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     head.push({ title: 'Reviews', script: [LD] })
     renderSSRHeadSuspenseChunk(head)
@@ -169,7 +169,7 @@ describe('pre-rendered shell state', () => {
 })
 
 describe('template-free drivers', () => {
-  it('returns Streamed Body Tags once', () => {
+  it('returns streamed body tags once', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     renderShell(head)
     head.push({ script: [LD] })
@@ -180,7 +180,7 @@ describe('template-free drivers', () => {
   })
 })
 
-describe('render failures for Streamed Body Tags', () => {
+describe('render failures for streamed body tags', () => {
   it('keeps valid JSON-LD when another entry cannot serialize', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     head.push({ script: [LD] })
@@ -191,7 +191,7 @@ describe('render failures for Streamed Body Tags', () => {
     expect(renderStreamBodyTags(head)).toContain('Organization')
   })
 
-  it('keeps Streamed Body Tags for a retry', () => {
+  it('keeps streamed body tags for a retry', () => {
     const head = createStreamableServerHead({ writesBodyTags: true })
     head.push({ script: [LD] })
     renderSSRHeadSuspenseChunk(head)


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

"Streamed Body Tags" had crept into docs, JSDoc, comments, and test names as if it were a named concept. It is just a description of where the tags go, so it reads better lowercase. No code change.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01AwRpNaSNi7McMPFY2mApcG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Standardized capitalization and terminology for “streamed body tags” across streaming SSR guides and API documentation.
  - Clarified related descriptions of JSON-LD, `noscript`, and body-positioned tags.

- **Maintenance**
  - Updated internal comments, test descriptions, and examples to use consistent sentence-case terminology.
  - No functional behavior or test coverage changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->