### PR TITLE
fix(react): keep initial head tags in the streamed shell

### DIFF
--- a/packages/react/src/stream/server.ts
+++ b/packages/react/src/stream/server.ts
@@ -39,7 +39,8 @@ export function HeadStream(): ReactNode {
     throw new Error('HeadStream: head context not found')
   }
 
-  const update = renderSSRHeadSuspenseChunk(head)
+  // Initial entries belong to the shell, including tags from earlier components.
+  const update = head._stream?.shellRendered ? renderSSRHeadSuspenseChunk(head) : ''
   // Always render script element for hydration consistency with client
   return createElement('script', {
     suppressHydrationWarning: true,

--- a/packages/react/test/streaming-shell-entries.test.tsx
+++ b/packages/react/test/streaming-shell-entries.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment node
+import { PassThrough } from 'node:stream'
+import { JSDOM } from 'jsdom'
+import React, { Suspense, use } from 'react'
+import { renderToPipeableStream, renderToStaticMarkup } from 'react-dom/server'
+import { renderShell } from 'unhead/stream/server'
+import { describe, expect, it } from 'vitest'
+import { useHead } from '../src'
+import { createStreamableHead, HeadStream, prepareStreamingTemplate, renderSSRHeadShell, UnheadProvider } from '../src/stream/server'
+
+const TEMPLATE = '<!DOCTYPE html><html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+
+async function collectStream(stream: PassThrough): Promise<string> {
+  let html = ''
+  for await (const chunk of stream)
+    html += chunk
+  return html
+}
+
+describe('react shell entries', () => {
+  it('keeps initial and component tags in the shell when HeadStream renders', async () => {
+    const context = createStreamableHead({
+      init: [{ link: [{ id: 'plugin-preload', rel: 'preload', as: 'style', href: '/plugin.css' }] }],
+    })
+
+    function App() {
+      useHead({ title: 'Page', htmlAttrs: { lang: 'en' } })
+      return (
+        <>
+          <HeadStream />
+          <main>Page</main>
+          <HeadStream />
+        </>
+      )
+    }
+
+    const output = new PassThrough()
+    const done = collectStream(output)
+    const { pipe } = renderToPipeableStream(<UnheadProvider value={context.head}><App /></UnheadProvider>, {
+      onShellReady: context.onShellReady,
+      onShellError: error => output.destroy(error as Error),
+    })
+    context.wrap(pipe, TEMPLATE)(output)
+
+    const document = new JSDOM(await done).window.document
+    expect(document.head.querySelectorAll('#plugin-preload')).toHaveLength(1)
+    expect(document.title).toBe('Page')
+    expect(document.documentElement.lang).toBe('en')
+    expect([...document.querySelectorAll('#app script')].map(script => script.textContent)).toEqual(['', ''])
+  })
+
+  it('keeps the shell and emits each resolved Suspense update once', async () => {
+    const context = createStreamableHead({
+      init: [{ link: [{ id: 'plugin-preload', rel: 'preload', as: 'style', href: '/plugin.css' }] }],
+    })
+    let resolveTitle!: (title: string) => void
+    const title = new Promise<string>((resolve) => {
+      resolveTitle = resolve
+    })
+
+    function AsyncPage() {
+      const value = use(title)
+      useHead({ title: value, meta: [{ name: 'description', content: 'Loaded description' }] })
+      return (
+        <>
+          <HeadStream />
+          <main>{value}</main>
+          <HeadStream />
+        </>
+      )
+    }
+
+    function App() {
+      useHead({ title: 'Loading' })
+      return (
+        <>
+          <HeadStream />
+          <Suspense fallback={<p>Loading</p>}><AsyncPage /></Suspense>
+        </>
+      )
+    }
+
+    const output = new PassThrough()
+    const shell = new Promise<string>(resolve => output.once('data', chunk => resolve(chunk.toString())))
+    const done = collectStream(output)
+    const { pipe } = renderToPipeableStream(<UnheadProvider value={context.head}><App /></UnheadProvider>, {
+      onShellReady: context.onShellReady,
+      onShellError: error => output.destroy(error as Error),
+    })
+    context.wrap(pipe, TEMPLATE)(output)
+
+    const shellDocument = new JSDOM(await shell).window.document
+    resolveTitle('Loaded page')
+    const document = new JSDOM(await done).window.document
+    const patches = [...document.scripts].map(script => script.textContent).filter(content => content?.startsWith('window.__unhead__.push('))
+
+    expect(shellDocument.head.querySelectorAll('#plugin-preload')).toHaveLength(1)
+    expect(shellDocument.title).toBe('Loading')
+    expect(document.head.querySelectorAll('#plugin-preload')).toHaveLength(1)
+    expect(patches).toHaveLength(1)
+    expect(JSON.parse(patches[0]!.slice('window.__unhead__.push('.length, -1))).toEqual([
+      { title: 'Loaded page', meta: [{ name: 'description', content: 'Loaded description' }] },
+    ])
+  })
+
+  it.each([
+    ['renderShell', (head: ReturnType<typeof createStreamableHead>['head']) => renderShell(head).headTags],
+    ['renderSSRHeadShell', (head: ReturnType<typeof createStreamableHead>['head']) => renderSSRHeadShell(head, TEMPLATE)],
+    ['prepareStreamingTemplate', (head: ReturnType<typeof createStreamableHead>['head']) => prepareStreamingTemplate(head, TEMPLATE).shell],
+    ['prepareStreamingTemplate without body', (head: ReturnType<typeof createStreamableHead>['head']) => prepareStreamingTemplate(head, '<html><head></head>').shell],
+  ] as const)('starts HeadStream updates after %s captures the shell', (_, captureShell) => {
+    const { head } = createStreamableHead()
+    head.push({ title: 'Initial page' })
+    const stream = <UnheadProvider value={head}><HeadStream /></UnheadProvider>
+
+    expect(renderToStaticMarkup(stream)).toBe('<script></script>')
+    expect(captureShell(head)).toContain('<title>Initial page</title>')
+    head.push({ title: 'Late page' })
+    expect(renderToStaticMarkup(stream)).toContain('window.__unhead__.push([{"title":"Late page"}])')
+    expect(renderToStaticMarkup(stream)).toBe('<script></script>')
+  })
+
+  it.each([renderSSRHeadShell, prepareStreamingTemplate])('retains shell entries after a template failure', (render) => {
+    const { head } = createStreamableHead()
+    head.push({ title: 'Retained page' })
+    expect(() => render(head, null as any)).toThrow()
+
+    const stream = <UnheadProvider value={head}><HeadStream /></UnheadProvider>
+    expect(renderToStaticMarkup(stream)).toBe('<script></script>')
+    const { shell } = prepareStreamingTemplate(head, TEMPLATE)
+    expect(new JSDOM(shell).window.document.title).toBe('Retained page')
+  })
+
+  it('retains shell entries after a head render failure', () => {
+    const { head } = createStreamableHead()
+    let fail = true
+    head.push({
+      get title() {
+        if (fail)
+          throw new Error('Shell render failed')
+        return 'Retained page'
+      },
+    })
+
+    expect(() => renderShell(head)).toThrow('Shell render failed')
+    fail = false
+    const stream = <UnheadProvider value={head}><HeadStream /></UnheadProvider>
+    expect(renderToStaticMarkup(stream)).toBe('<script></script>')
+    expect(renderShell(head).headTags).toContain('<title>Retained page</title>')
+  })
+})

--- a/packages/react/test/streaming-shell-entries.test.tsx
+++ b/packages/react/test/streaming-shell-entries.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import type { ReactStreamableHeadContext } from '../src/stream/server'
 import { PassThrough } from 'node:stream'
 import { JSDOM } from 'jsdom'
 import React, { Suspense, use } from 'react'
@@ -104,10 +105,10 @@ describe('react shell entries', () => {
   })
 
   it.each([
-    ['renderShell', (head: ReturnType<typeof createStreamableHead>['head']) => renderShell(head).headTags],
-    ['renderSSRHeadShell', (head: ReturnType<typeof createStreamableHead>['head']) => renderSSRHeadShell(head, TEMPLATE)],
-    ['prepareStreamingTemplate', (head: ReturnType<typeof createStreamableHead>['head']) => prepareStreamingTemplate(head, TEMPLATE).shell],
-    ['prepareStreamingTemplate without body', (head: ReturnType<typeof createStreamableHead>['head']) => prepareStreamingTemplate(head, '<html><head></head>').shell],
+    ['renderShell', (head: ReactStreamableHeadContext['head']) => renderShell(head).headTags],
+    ['renderSSRHeadShell', (head: ReactStreamableHeadContext['head']) => renderSSRHeadShell(head, TEMPLATE)],
+    ['prepareStreamingTemplate', (head: ReactStreamableHeadContext['head']) => prepareStreamingTemplate(head, TEMPLATE).shell],
+    ['prepareStreamingTemplate without body', (head: ReactStreamableHeadContext['head']) => prepareStreamingTemplate(head, '<html><head></head>').shell],
   ] as const)('starts HeadStream updates after %s captures the shell', (_, captureShell) => {
     const { head } = createStreamableHead()
     head.push({ title: 'Initial page' })

--- a/packages/react/test/streaming-shell-hydration.test.tsx
+++ b/packages/react/test/streaming-shell-hydration.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { PassThrough } from 'node:stream'
+import { act, fireEvent, render } from '@testing-library/react'
+import React, { useState } from 'react'
+import { renderToPipeableStream } from 'react-dom/server'
+import { expect, it } from 'vitest'
+import { useHead } from '../src'
+import { createHead, renderDOMHead } from '../src/client'
+import { HeadStream as ClientHeadStream } from '../src/stream/client'
+import { createStreamableHead, HeadStream, UnheadProvider } from '../src/stream/server'
+
+it('hydrates the empty shell HeadStream and keeps client head updates working', async () => {
+  const context = createStreamableHead({
+    init: [{ link: [{ id: 'plugin-preload', rel: 'preload', as: 'style', href: '/plugin.css' }] }],
+  })
+  function App({ Stream = HeadStream }: { Stream?: typeof HeadStream }) {
+    const [title, setTitle] = useState('Initial page')
+    useHead({ title })
+    return (
+      <>
+        <Stream />
+        <button onClick={() => setTitle('Next page')}>{title}</button>
+      </>
+    )
+  }
+
+  const output = new PassThrough()
+  const done = (async () => {
+    let html = ''
+    for await (const chunk of output)
+      html += chunk
+    return html
+  })()
+  const { pipe } = renderToPipeableStream(<UnheadProvider value={context.head}><App /></UnheadProvider>, {
+    onShellReady: context.onShellReady,
+    onShellError: error => output.destroy(error as Error),
+  })
+  context.wrap(pipe, '<html><head></head><body><div id="app"><!--app-html--></div></body></html>')(output)
+  const parsed = new DOMParser().parseFromString(await done, 'text/html')
+  document.documentElement.innerHTML = parsed.documentElement.innerHTML
+  const container = document.getElementById('app')!
+  const serverScript = container.querySelector('script')
+  const serverButton = container.querySelector('button')
+  const errors: unknown[] = []
+  const head = createHead({ document })
+
+  const hydrated = render(<UnheadProvider value={head}><App Stream={ClientHeadStream} /></UnheadProvider>, {
+    container,
+    hydrate: true,
+    onRecoverableError: error => errors.push(error),
+  })
+  await act(async () => {
+    renderDOMHead(head)
+  })
+  expect(errors).toEqual([])
+  expect(container.querySelector('script')).toBe(serverScript)
+  expect(container.querySelector('button')).toBe(serverButton)
+  expect(document.head.querySelectorAll('#plugin-preload')).toHaveLength(1)
+  expect(document.title).toBe('Initial page')
+
+  fireEvent.click(hydrated.getByRole('button'))
+  await act(async () => {
+    renderDOMHead(head)
+  })
+  expect(document.title).toBe('Next page')
+  expect(document.querySelectorAll('title')).toHaveLength(1)
+})

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -147,6 +147,7 @@ export function renderShell(head: Unhead<any, SSRHeadPayload>): SSRHeadPayload {
   const result = head.render()
   rememberShellBodyTags(head)
   head.entries.clear()
+  streamState(head).shellRendered = true
   return result
 }
 
@@ -174,6 +175,7 @@ export function renderSSRHeadShell(head: Unhead<any>, template: string | Prepare
   rememberShellBodyTags(head)
   // Keep entries when template rendering fails, so the caller can retry.
   head.entries.clear()
+  streamState(head).shellRendered = true
   return result
 }
 
@@ -781,6 +783,7 @@ export function prepareStreamingTemplate(
     rememberShellBodyTags(head)
     head.entries.clear()
   }
+  streamState(head).shellRendered = true
   return parts
 }
 

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -309,11 +309,11 @@ export interface Unhead<Input = ResolvableHead, RenderResult = unknown> {
    */
   _titleTemplate?: string
   /**
-   * Per-response state for streamed body tags.
+   * Per-response state for shell rendering and streamed body tags.
    *
    * @internal
    */
-  _stream?: { bodyTags?: any[], seen?: Set<string>, writesBodyTags?: boolean }
+  _stream?: { shellRendered?: true, bodyTags?: any[], seen?: Set<string>, writesBodyTags?: boolean }
 }
 
 export interface DomState {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Related to https://github.com/unjs/unhead/pull/969

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

React’s first `HeadStream` moved preloads and page metadata into client patches, leaving them out of the initial head. Initial tags now stay available until the shell renders; later Suspense updates still stream.

![React keeps initial tags until shell capture, then streams late patches](https://github.com/user-attachments/assets/0e7e264e-3fc6-47a1-8f74-dab27890d471)

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamed document head updates now begin after the initial page shell is rendered.
  * Prevented duplicate or premature head updates during server-side streaming.
  * Improved hydration of streamed pages by preserving existing server-rendered elements without recoverable errors.
  * Ensured streamed title updates continue after client interaction while maintaining a single document title.
  * Preserved initial head content when rendering or template processing encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->