### PR TITLE
fix(stream): preserve body tags and request script nonces

### DIFF
--- a/docs/0.react/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.react/head/guides/1.core-concepts/5.streaming.md
@@ -64,11 +64,11 @@ export default defineConfig({
 
 For webpack projects, import `Unhead` from `@unhead/react/bundler` and call `Unhead({ streaming: true }).webpack()`.
 
-::warning
-The automatic wrapper does not add CSP nonces to its inline scripts.
-For a nonce-only policy, use the [manual core flow](/docs/typescript/head/guides/core-concepts/streaming#template-free-integration).
-Otherwise, use standard SSR.
-::
+Pass each response's CSP nonce to `createStreamableHead({ nonce })`.
+Unhead applies it to its bootstrap and patch scripts.
+Use the same nonce in the response CSP header and application scripts.
+Pass it to `renderToPipeableStream()` too, as shown below.
+See the [core CSP example](/docs/typescript/head/guides/core-concepts/streaming#server) for request setup.
 
 ### Server Entry
 
@@ -79,8 +79,8 @@ import { StaticRouter } from 'react-router-dom'
 import { createStreamableHead, type PreparedTemplate, UnheadProvider } from '@unhead/react/stream/server'
 import App from './App'
 
-export function render(url: string, template: string | PreparedTemplate) {
-  const { head, onShellReady, wrap } = createStreamableHead()
+export function render(url: string, template: string | PreparedTemplate, nonce?: string) {
+  const { head, onShellReady, wrap } = createStreamableHead({ nonce })
 
   const { pipe, abort } = renderToPipeableStream(
     <UnheadProvider value={head}>
@@ -88,7 +88,7 @@ export function render(url: string, template: string | PreparedTemplate) {
         <App />
       </StaticRouter>
     </UnheadProvider>,
-    { onShellReady },
+    { onShellReady, nonce },
   )
 
   return {

--- a/docs/0.solid-js/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.solid-js/head/guides/1.core-concepts/5.streaming.md
@@ -60,11 +60,11 @@ export default defineConfig({
 
 For webpack projects, import `Unhead` from `@unhead/solid-js/bundler` and call `Unhead({ streaming: true }).webpack()`.
 
-::warning
-The automatic wrapper does not add CSP nonces to its inline scripts.
-For a nonce-only policy, use the [manual core flow](/docs/typescript/head/guides/core-concepts/streaming#template-free-integration).
-Otherwise, use standard SSR.
-::
+Pass each response's CSP nonce to `createStreamableHead({ nonce })`.
+Unhead applies it to its bootstrap and patch scripts.
+Use the same nonce in the response CSP header and application scripts.
+Pass it to `renderToStream()` too, as shown below.
+See the [core CSP example](/docs/typescript/head/guides/core-concepts/streaming#server) for request setup.
 
 ### Server Entry
 
@@ -74,8 +74,8 @@ import { renderToStream } from 'solid-js/web'
 import { createStreamableHead, type PreparedTemplate, UnheadContext } from '@unhead/solid-js/stream/server'
 import App from './App'
 
-export function render(url: string, template: string | PreparedTemplate) {
-  const { head, onCompleteShell, wrapStream } = createStreamableHead()
+export function render(url: string, template: string | PreparedTemplate, nonce?: string) {
+  const { head, onCompleteShell, wrapStream } = createStreamableHead({ nonce })
 
   const { readable, writable } = new TransformStream()
 
@@ -83,7 +83,7 @@ export function render(url: string, template: string | PreparedTemplate) {
     <UnheadContext.Provider value={head}>
       <App url={url} />
     </UnheadContext.Provider>
-  ), { onCompleteShell }).pipeTo(writable)
+  ), { onCompleteShell, nonce }).pipeTo(writable)
 
   return wrapStream(readable, template)
 }

--- a/docs/0.svelte/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.svelte/head/guides/1.core-concepts/5.streaming.md
@@ -53,11 +53,10 @@ export default defineConfig({
 
 For webpack projects, import `Unhead` from `@unhead/svelte/bundler` and call `Unhead({ streaming: true }).webpack()`.
 
-::warning
-The automatic wrapper does not add a CSP nonce to its bootstrap script.
-For a nonce-only policy, use the [manual core flow](/docs/typescript/head/guides/core-concepts/streaming#template-free-integration).
-Otherwise, use standard SSR.
-::
+Pass each response's CSP nonce to `createStreamableHead({ nonce })`.
+Unhead applies it to its bootstrap and patch scripts.
+Use the same nonce in the response CSP header and application scripts.
+See the [core CSP example](/docs/typescript/head/guides/core-concepts/streaming#server) for request setup.
 
 ### Server Entry
 
@@ -67,8 +66,8 @@ import { render as _render } from 'svelte/server'
 import { createStreamableHead, type PreparedTemplate, UnheadContextKey } from '@unhead/svelte/stream/server'
 import App from './App.svelte'
 
-export async function render(url: string, template: string | PreparedTemplate) {
-  const { head, wrapStream } = createStreamableHead()
+export async function render(url: string, template: string | PreparedTemplate, nonce?: string) {
+  const { head, wrapStream } = createStreamableHead({ nonce })
   const context = new Map()
   context.set(UnheadContextKey, head)
 

--- a/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.typescript/head/guides/1.core-concepts/5.streaming.md
@@ -53,7 +53,7 @@ Google can read [JSON-LD from the head or body](https://developers.google.com/se
 Use `wrapStream()` to add head updates to the response:
 
 ```ts
-import { createStreamableHead, prepareTemplate, renderSSRHeadSuspenseChunk, wrapStream } from 'unhead/stream/server'
+import { createStreamableHead, prepareTemplate, wrapStream } from 'unhead/stream/server'
 
 const { head } = createStreamableHead()
 
@@ -65,14 +65,25 @@ head.push({
 const template = prepareTemplate('<!DOCTYPE html><html><head></head><body></body></html>')
 
 // Flush head entries registered while each app chunk renders.
-const fullStream = wrapStream(head, appStream, template, undefined, {
-  flushChunk: () => {
-    const update = renderSSRHeadSuspenseChunk(head)
-    return update ? `<script>window.__unhead__&&(${update});document.currentScript.remove()</script>` : ''
-  },
-})
+const fullStream = wrapStream(head, appStream, template)
 return new Response(fullStream)
 ```
+
+For CSP, pass each response's nonce when creating its head:
+
+```ts
+import { createStreamableHead, wrapStream } from 'unhead/stream/server'
+
+// Generate a new nonce for each response. Include it in that response's CSP header.
+declare const nonce: string
+const { head } = createStreamableHead({ nonce })
+return new Response(wrapStream(head, appStream, template))
+```
+
+Unhead stamps its bootstrap and patch scripts with this nonce.
+Apply the same nonce to application scripts through tag props or your request hooks.
+If you supply `flushChunk` or write scripts yourself, include the nonce in those script tags.
+Keep nonce values out of shared production templates and build configuration.
 
 ### Reuse a Production Template
 
@@ -84,18 +95,13 @@ return new Response(fullStream)
 
 ```ts
 import { readFile } from 'node:fs/promises'
-import { createStreamableHead, prepareTemplate, renderSSRHeadSuspenseChunk, wrapStream } from 'unhead/stream/server'
+import { createStreamableHead, prepareTemplate, wrapStream } from 'unhead/stream/server'
 
 const template = prepareTemplate(await readFile('dist/client/index.html', 'utf8'))
 
 export function handleRequest(appStream: ReadableStream<Uint8Array>) {
   const { head } = createStreamableHead()
-  return wrapStream(head, appStream, template, undefined, {
-    flushChunk: () => {
-      const update = renderSSRHeadSuspenseChunk(head)
-      return update ? `<script>window.__unhead__&&(${update});document.currentScript.remove()</script>` : ''
-    },
-  })
+  return wrapStream(head, appStream, template)
 }
 ```
 
@@ -149,8 +155,8 @@ res.write(renderStreamEnd(head, parts))
 
 Use this flow only when your renderer exposes chunk boundaries.
 
-`prepareStreamingTemplate()` cannot add a nonce to its bootstrap script.
-If your CSP requires one, use the template-free flow below.
+For CSP, create the head with `createStreamableHead({ nonce, writesBodyTags: true })`.
+Add the same nonce to each script tag you write.
 
 ## Template-Free Integration
 
@@ -209,8 +215,11 @@ Creates a streaming-aware head instance:
 ```ts
 import { createStreamableHead } from 'unhead/stream/server'
 
+declare const nonce: string
+
 const { head, onShellReady, shellReady } = createStreamableHead({
   streamKey: '__unhead__', // Optional custom stream identifier
+  nonce, // Optional nonce from the current response
 })
 ```
 
@@ -234,7 +243,8 @@ declare function wrapStream(
 ```
 
 By default, `wrapStream()` writes a guarded patch after each application chunk.
-Use `flushChunk` to change that output or add a CSP nonce.
+Set `nonce` in `createStreamableHead()` to stamp these scripts.
+Use `flushChunk` to replace the default output.
 
 ### prepareTemplate
 

--- a/docs/0.vue/head/guides/1.core-concepts/5.streaming.md
+++ b/docs/0.vue/head/guides/1.core-concepts/5.streaming.md
@@ -60,11 +60,10 @@ export default defineConfig({
 
 For webpack projects, import `Unhead` from `@unhead/vue/bundler` and call `Unhead({ streaming: true }).webpack()`.
 
-::warning
-The automatic wrapper does not add CSP nonces to its inline scripts.
-For a nonce-only policy, use the [manual core flow](/docs/typescript/head/guides/core-concepts/streaming#template-free-integration).
-Otherwise, use standard SSR.
-::
+Pass each response's CSP nonce to `createStreamableHead({ nonce })`.
+Unhead applies it to its bootstrap and patch scripts.
+Use the same nonce in the response CSP header and application scripts.
+See the [core CSP example](/docs/typescript/head/guides/core-concepts/streaming#server) for request setup.
 
 ### Server Entry
 
@@ -74,9 +73,9 @@ import { renderToWebStream } from 'vue/server-renderer'
 import { createStreamableHead, type PreparedTemplate } from '@unhead/vue/stream/server'
 import { createApp } from './main'
 
-export async function render(url: string, template: string | PreparedTemplate) {
+export async function render(url: string, template: string | PreparedTemplate, nonce?: string) {
   const { app, router } = createApp()
-  const { head, wrapStream } = createStreamableHead()
+  const { head, wrapStream } = createStreamableHead({ nonce })
 
   app.use(head)
 

--- a/packages/react/src/stream/server.ts
+++ b/packages/react/src/stream/server.ts
@@ -42,6 +42,7 @@ export function HeadStream(): ReactNode {
   const update = renderSSRHeadSuspenseChunk(head)
   // Always render script element for hydration consistency with client
   return createElement('script', {
+    nonce: head._stream?.nonce,
     suppressHydrationWarning: true,
     dangerouslySetInnerHTML: update ? { __html: update } : undefined,
   })

--- a/packages/react/test/streaming-nonce.test.tsx
+++ b/packages/react/test/streaming-nonce.test.tsx
@@ -1,0 +1,29 @@
+import { PassThrough } from 'node:stream'
+import { JSDOM } from 'jsdom'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { createStreamableHead, HeadStream, UnheadProvider } from '../src/stream/server'
+
+describe('react streaming request nonce', () => {
+  it.each(['request-a', 'request-b', 'request-"&quot;&tail=<tag>', undefined])('stamps the bootstrap and HeadStream patch: %s', async (nonce) => {
+    const context = createStreamableHead({ nonce })
+    const output = new PassThrough()
+    const collected = (async () => {
+      let html = ''
+      for await (const chunk of output) html += chunk
+      return html
+    })()
+    context.wrap((writable) => {
+      context.head.push({ title: 'Late title' })
+      writable.end(renderToString(<UnheadProvider value={context.head}><HeadStream /></UnheadProvider>))
+    }, '<html><head></head><body><!--app-html--></body></html>')(output)
+    context.onShellReady()
+    const html = await collected
+    const document = new JSDOM(html).window.document
+
+    expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([nonce ?? null, nonce ?? null])
+    const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
+    expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+    executed.close()
+  })
+})

--- a/packages/react/test/streaming-nonce.test.tsx
+++ b/packages/react/test/streaming-nonce.test.tsx
@@ -23,7 +23,7 @@ describe('react streaming request nonce', () => {
 
     expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([nonce ?? null, nonce ?? null])
     const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
-    expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+    expect(executed.__unhead__?._q).toEqual([[{ title: 'Late title' }]])
     executed.close()
   })
 })

--- a/packages/react/test/streaming-shell-body.test.ts
+++ b/packages/react/test/streaming-shell-body.test.ts
@@ -1,0 +1,36 @@
+import { PassThrough } from 'node:stream'
+import { JSDOM } from 'jsdom'
+import { describe, expect, it } from 'vitest'
+import { createStreamableHead, prepareTemplate } from '../src/stream/server'
+
+describe('streaming shell tag positions', () => {
+  it.each([false, true])('preserves initial tags around the app, prepared: %s', async (prepared) => {
+    const context = createStreamableHead({
+      init: [{
+        script: [
+          { id: 'head-prepend', src: '/first.js', tagPriority: 'high' },
+          { id: 'head-append', src: '/head.js' },
+          { id: 'body-open', src: '/open.js', tagPosition: 'bodyOpen' },
+          { id: 'body-close', src: '/close.js', tagPosition: 'bodyClose' },
+        ],
+      }],
+    })
+    const source = '<html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+    const template = prepared ? prepareTemplate(source) : source
+    const output = new PassThrough()
+    const collected = (async () => {
+      let html = ''
+      for await (const chunk of output) html += chunk
+      return html
+    })()
+    context.wrap(writable => writable.end('<main>App</main>'), template)(output)
+    context.onShellReady()
+    const html = await collected
+    const document = new JSDOM(html).window.document
+
+    expect([...document.head.querySelectorAll('script[id]')].map(script => script.id)).toEqual(['head-prepend', 'head-append'])
+    expect([...document.body.children].map(element => element.id)).toEqual(['body-open', 'app', 'body-close'])
+    expect(document.querySelector('#app')?.innerHTML).toBe('<main>App</main>')
+    expect(document.querySelectorAll('#body-open')).toHaveLength(1)
+  })
+})

--- a/packages/solid-js/src/stream/server.ts
+++ b/packages/solid-js/src/stream/server.ts
@@ -3,6 +3,7 @@ import type { PreparedTemplate, StreamingTemplateParts } from 'unhead/stream/ser
 import type { CreateStreamableServerHeadOptions, SSRHeadPayload } from 'unhead/types'
 import { useContext } from 'solid-js'
 import { ssr } from 'solid-js/web'
+import { escapeHtml } from 'unhead/server'
 import {
   createStreamableHead as _createStreamableHead,
   prepareStreamingTemplate,
@@ -291,7 +292,7 @@ export function createStreamableHead(options: CreateStreamableServerHeadOptions 
   }
 }
 
-const scriptTemplate = ['<script>', '</script>'] as TemplateStringsArray & string[]
+const scriptTemplate = ['<script', '>', '</script>'] as TemplateStringsArray & string[]
 
 /**
  * Streaming script component - outputs inline script with current head state.
@@ -314,5 +315,6 @@ export function HeadStream() {
   if (!update)
     return null
 
-  return ssr(scriptTemplate, update)
+  const nonce = head._stream?.nonce
+  return ssr(scriptTemplate, nonce ? ` nonce="${escapeHtml(nonce)}"` : '', update)
 }

--- a/packages/solid-js/test/streaming-nonce.test.ts
+++ b/packages/solid-js/test/streaming-nonce.test.ts
@@ -1,0 +1,36 @@
+import type { JSX } from 'solid-js'
+import { JSDOM } from 'jsdom'
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { createStreamableHead, HeadStream, UnheadContext } from '../src/stream/server'
+
+// This project uses browser conditions. Resolve real Solid server APIs for SSR.
+vi.mock('solid-js', () => process.getBuiltinModule('node:module').createRequire(import.meta.url)('solid-js'))
+vi.mock('solid-js/web', () => process.getBuiltinModule('node:module').createRequire(import.meta.url)('solid-js/web'))
+
+describe('solid streaming request nonce', () => {
+  it.each(['request-a', 'request-b', 'request-"&quot;&tail=<tag>', undefined])('stamps the bootstrap and HeadStream patch: %s', async (nonce) => {
+    const context = createStreamableHead({ nonce })
+    context.onCompleteShell()
+    const app = new ReadableStream<Uint8Array>({
+      start(controller) {
+        context.head.push({ title: 'Late title' })
+        const html = renderToString(() => createComponent(UnheadContext.Provider, {
+          value: context.head,
+          // Solid's client types omit the server renderer's raw HTML nodes.
+          get children() { return HeadStream() as unknown as JSX.Element },
+        }))
+        controller.enqueue(new TextEncoder().encode(html))
+        controller.close()
+      },
+    })
+    const html = await new Response(context.wrapStream(app, '<html><head></head><body><!--app-html--></body></html>')).text()
+    const document = new JSDOM(html).window.document
+
+    expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([nonce ?? null, nonce ?? null])
+    const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
+    expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+    executed.close()
+  })
+})

--- a/packages/solid-js/test/streaming-nonce.test.ts
+++ b/packages/solid-js/test/streaming-nonce.test.ts
@@ -30,7 +30,7 @@ describe('solid streaming request nonce', () => {
 
     expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([nonce ?? null, nonce ?? null])
     const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
-    expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+    expect(executed.__unhead__?._q).toEqual([[{ title: 'Late title' }]])
     executed.close()
   })
 })

--- a/packages/solid-js/test/streaming-shell-body.test.ts
+++ b/packages/solid-js/test/streaming-shell-body.test.ts
@@ -1,0 +1,34 @@
+import { JSDOM } from 'jsdom'
+import { describe, expect, it } from 'vitest'
+import { createStreamableHead, prepareTemplate } from '../src/stream/server'
+
+describe('streaming shell tag positions', () => {
+  it.each([false, true])('preserves initial tags around the app, prepared: %s', async (prepared) => {
+    const context = createStreamableHead({
+      init: [{
+        script: [
+          { id: 'head-prepend', src: '/first.js', tagPriority: 'high' },
+          { id: 'head-append', src: '/head.js' },
+          { id: 'body-open', src: '/open.js', tagPosition: 'bodyOpen' },
+          { id: 'body-close', src: '/close.js', tagPosition: 'bodyClose' },
+        ],
+      }],
+    })
+    const source = '<html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+    const template = prepared ? prepareTemplate(source) : source
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('<main>App</main>'))
+        controller.close()
+      },
+    })
+    context.onCompleteShell()
+    const html = await new Response(context.wrapStream(stream, template)).text()
+    const document = new JSDOM(html).window.document
+
+    expect([...document.head.querySelectorAll('script[id]')].map(script => script.id)).toEqual(['head-prepend', 'head-append'])
+    expect([...document.body.children].map(element => element.id)).toEqual(['body-open', 'app', 'body-close'])
+    expect(document.querySelector('#app')?.innerHTML).toBe('<main>App</main>')
+    expect(document.querySelectorAll('#body-open')).toHaveLength(1)
+  })
+})

--- a/packages/svelte/test/streaming-nonce.test.ts
+++ b/packages/svelte/test/streaming-nonce.test.ts
@@ -17,7 +17,7 @@ describe('streaming request nonce', () => {
 
     expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([nonce ?? null, nonce ?? null])
     const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
-    expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+    expect(executed.__unhead__?._q).toEqual([[{ title: 'Late title' }]])
     executed.close()
   })
 })

--- a/packages/svelte/test/streaming-nonce.test.ts
+++ b/packages/svelte/test/streaming-nonce.test.ts
@@ -1,0 +1,23 @@
+import { JSDOM } from 'jsdom'
+import { describe, expect, it } from 'vitest'
+import { createStreamableHead } from '../src/stream/server'
+
+describe('streaming request nonce', () => {
+  it.each(['request-a', 'request-b', undefined])('stamps the bootstrap and late patch: %s', async (nonce) => {
+    const { head, wrapStream } = createStreamableHead({ nonce })
+    const app = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        head.push({ title: 'Late title' })
+        controller.enqueue(new TextEncoder().encode('<main>App</main>'))
+        controller.close()
+      },
+    })
+    const html = await new Response(wrapStream(app, '<html><head></head><body><!--app-html--></body></html>')).text()
+    const document = new JSDOM(html).window.document
+
+    expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([nonce ?? null, nonce ?? null])
+    const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
+    expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+    executed.close()
+  })
+})

--- a/packages/svelte/test/streaming-shell-body.test.ts
+++ b/packages/svelte/test/streaming-shell-body.test.ts
@@ -1,0 +1,33 @@
+import { JSDOM } from 'jsdom'
+import { describe, expect, it } from 'vitest'
+import { createStreamableHead, prepareTemplate } from '../src/stream/server'
+
+describe('streaming shell tag positions', () => {
+  it.each([false, true])('preserves initial tags around the app, prepared: %s', async (prepared) => {
+    const context = createStreamableHead({
+      init: [{
+        script: [
+          { id: 'head-prepend', src: '/first.js', tagPriority: 'high' },
+          { id: 'head-append', src: '/head.js' },
+          { id: 'body-open', src: '/open.js', tagPosition: 'bodyOpen' },
+          { id: 'body-close', src: '/close.js', tagPosition: 'bodyClose' },
+        ],
+      }],
+    })
+    const source = '<html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+    const template = prepared ? prepareTemplate(source) : source
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('<main>App</main>'))
+        controller.close()
+      },
+    })
+    const html = await new Response(context.wrapStream(stream, template)).text()
+    const document = new JSDOM(html).window.document
+
+    expect([...document.head.querySelectorAll('script[id]')].map(script => script.id)).toEqual(['head-prepend', 'head-append'])
+    expect([...document.body.children].map(element => element.id)).toEqual(['body-open', 'app', 'body-close'])
+    expect(document.querySelector('#app')?.innerHTML).toBe('<main>App</main>')
+    expect(document.querySelectorAll('#body-open')).toHaveLength(1)
+  })
+})

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -186,6 +186,7 @@ function applyShellToTemplate(head: Unhead<any>, ssr: SSRHeadPayload, parsed: Re
     htmlAttrs: ssr.htmlAttrs,
     headTags: createBootstrapScript(getStreamKey(head)) + ssr.headTags,
     bodyAttrs: ssr.bodyAttrs,
+    bodyTagsOpen: ssr.bodyTagsOpen,
     bodyTags: ssr.bodyTags,
   })
 }
@@ -757,6 +758,7 @@ export function prepareStreamingTemplate(
       htmlAttrs: ssr.htmlAttrs,
       headTags: createBootstrapScript(getStreamKey(head)) + ssr.headTags,
       bodyAttrs: ssr.bodyAttrs,
+      bodyTagsOpen: ssr.bodyTagsOpen,
       bodyTags: '',
     }).replace('</body></html>', '')
 

--- a/packages/unhead/src/stream/server.ts
+++ b/packages/unhead/src/stream/server.ts
@@ -81,7 +81,7 @@ export interface WebStreamableHeadContext<T = ResolvableHead> extends BaseStream
 export function createStreamableHead<T = ResolvableHead>(
   options: CreateStreamableServerHeadOptions = {},
 ): StreamableHeadContext<T> {
-  const { streamKey, writesBodyTags, ...rest } = options
+  const { streamKey, writesBodyTags, nonce, ...rest } = options
   const parsedStreamKey = streamKey === undefined ? undefined : parseStreamKey(streamKey)
   const head = createHead<T>({
     ...rest,
@@ -89,6 +89,8 @@ export function createStreamableHead<T = ResolvableHead>(
   })
   if (writesBodyTags)
     streamState(head).writesBodyTags = true
+  if (nonce)
+    streamState(head).nonce = nonce
 
   let resolveShellReady: () => void
   const shellReady = new Promise<void>((resolve) => {
@@ -119,10 +121,14 @@ function getStreamKey(head: Unhead<any>): string {
  */
 export function createBootstrapScript(streamKey: string = DEFAULT_STREAM_KEY, nonce?: string): string {
   const parsedStreamKey = parseStreamKey(streamKey)
-  const nonceAttr = nonce ? ` nonce="${nonce.replace(/"/g, '&quot;')}"` : ''
+  const nonceAttr = renderNonceAttribute(nonce)
   // `inline` mode runs the client IIFE above this script, so never clobber an
   // already-installed queue. Doing so drops every streamed patch.
   return `<script${nonceAttr}>window.${parsedStreamKey}||(window.${parsedStreamKey}={_q:[],push(e){this._q.push(e)}})</script>`
+}
+
+function renderNonceAttribute(nonce?: string): string {
+  return nonce ? ` nonce="${nonce.replace(AMP_RE, '&amp;').replace(/"/g, '&quot;')}"` : ''
 }
 
 /**
@@ -184,7 +190,7 @@ export function renderSSRHeadShell(head: Unhead<any>, template: string | Prepare
 function applyShellToTemplate(head: Unhead<any>, ssr: SSRHeadPayload, parsed: ReturnType<typeof parseHtmlForIndexes>): string {
   return applyHeadToHtml(parsed, {
     htmlAttrs: ssr.htmlAttrs,
-    headTags: createBootstrapScript(getStreamKey(head)) + ssr.headTags,
+    headTags: createBootstrapScript(getStreamKey(head), head._stream?.nonce) + ssr.headTags,
     bodyAttrs: ssr.bodyAttrs,
     bodyTagsOpen: ssr.bodyTagsOpen,
     bodyTags: ssr.bodyTags,
@@ -523,7 +529,7 @@ export function wrapStream(
     if (!chunk)
       return ''
     // A template with no `</head>` never received the bootstrap script.
-    return `<script>window.${getStreamKey(head)}&&(${chunk});document.currentScript.remove()</script>`
+    return `<script${renderNonceAttribute(head._stream?.nonce)}>window.${getStreamKey(head)}&&(${chunk});document.currentScript.remove()</script>`
   })
   const enc = encoder ??= new TextEncoder()
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
@@ -756,7 +762,7 @@ export function prepareStreamingTemplate(
   if (layout) {
     const shell = applyHeadToHtml(layout.shellTemplate, {
       htmlAttrs: ssr.htmlAttrs,
-      headTags: createBootstrapScript(getStreamKey(head)) + ssr.headTags,
+      headTags: createBootstrapScript(getStreamKey(head), head._stream?.nonce) + ssr.headTags,
       bodyAttrs: ssr.bodyAttrs,
       bodyTagsOpen: ssr.bodyTagsOpen,
       bodyTags: '',

--- a/packages/unhead/src/types/head.ts
+++ b/packages/unhead/src/types/head.ts
@@ -167,6 +167,11 @@ export interface CreateStreamableServerHeadOptions extends Omit<CreateServerHead
    */
   streamKey?: string
   /**
+   * Request CSP nonce for the bootstrap and Unhead patch scripts.
+   * Apply the same nonce to application scripts and the response CSP header.
+   */
+  nonce?: string
+  /**
    * Set when the driver writes streamed body tags before `</body>`.
    *
    * Use `renderStreamBodyTags()` or `renderStreamEnd()` to write them.
@@ -313,7 +318,7 @@ export interface Unhead<Input = ResolvableHead, RenderResult = unknown> {
    *
    * @internal
    */
-  _stream?: { bodyTags?: any[], seen?: Set<string>, writesBodyTags?: boolean }
+  _stream?: { bodyTags?: any[], seen?: Set<string>, writesBodyTags?: boolean, nonce?: string }
 }
 
 export interface DomState {

--- a/packages/unhead/test/streaming/stream-nonce.test.ts
+++ b/packages/unhead/test/streaming/stream-nonce.test.ts
@@ -41,7 +41,7 @@ describe('streaming request nonces', () => {
       const document = new JSDOM(html).window.document
       expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([NONCES[index] ?? null, NONCES[index] ?? null])
       const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
-      expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+      expect(executed.__unhead__?._q).toEqual([[{ title: 'Late title' }]])
       executed.close()
     }
   })

--- a/packages/unhead/test/streaming/stream-nonce.test.ts
+++ b/packages/unhead/test/streaming/stream-nonce.test.ts
@@ -1,0 +1,48 @@
+import { JSDOM } from 'jsdom'
+import { createBootstrapScript, createStreamableHead, prepareStreamingTemplate, prepareTemplate, renderSSRHeadShell, wrapStream } from 'unhead/stream/server'
+import { describe, expect, it } from 'vitest'
+
+const NONCES = ['request-a', 'request-b', 'request-"&quot;&tail=<tag>', undefined]
+const TEMPLATE = '<html><head></head><body><!--app-html--></body></html>'
+
+describe('streaming request nonces', () => {
+  it.each(NONCES)('preserves the bootstrap nonce: %s', (nonce) => {
+    const document = new JSDOM(createBootstrapScript('__unhead__', nonce)).window.document
+    expect(document.querySelector('script')?.getAttribute('nonce')).toBe(nonce ?? null)
+  })
+
+  it.each([false, true])('stamps directly rendered and fallback shells, prepared: %s', (prepared) => {
+    const source = '<html><head></head><body>'
+    const template = prepared ? prepareTemplate(source) : source
+    const { head } = createStreamableHead({ nonce: 'request-nonce' })
+    const direct = renderSSRHeadShell(head, template)
+    const fallback = prepareStreamingTemplate(head, template).shell
+
+    for (const html of [direct, fallback]) {
+      expect(new JSDOM(html).window.document.querySelector('script')?.getAttribute('nonce')).toBe('request-nonce')
+    }
+  })
+
+  it('keeps bootstrap and patch nonces separate across concurrent requests', async () => {
+    const template = prepareTemplate(TEMPLATE)
+    const results = await Promise.all(NONCES.map(async (nonce) => {
+      const { head } = createStreamableHead({ nonce })
+      const app = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          head.push({ title: 'Late title' })
+          controller.enqueue(new TextEncoder().encode('<main>App</main>'))
+          controller.close()
+        },
+      })
+      return new Response(wrapStream(head, app, template)).text()
+    }))
+
+    for (const [index, html] of results.entries()) {
+      const document = new JSDOM(html).window.document
+      expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([NONCES[index] ?? null, NONCES[index] ?? null])
+      const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
+      expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+      executed.close()
+    }
+  })
+})

--- a/packages/unhead/test/streaming/stream-shell-body.test.ts
+++ b/packages/unhead/test/streaming/stream-shell-body.test.ts
@@ -1,0 +1,28 @@
+import { JSDOM } from 'jsdom'
+import { createStreamableHead, prepareStreamingTemplate, prepareTemplate, renderSSRHeadShell } from 'unhead/stream/server'
+import { describe, expect, it } from 'vitest'
+
+describe('streaming shell bodyOpen tags', () => {
+  it.each([false, true])('preserves bodyOpen when a template cannot split, prepared: %s', (prepared) => {
+    const { head } = createStreamableHead({
+      init: [{ script: [{ id: 'body-open', src: '/open.js', tagPosition: 'bodyOpen' }] }],
+    })
+    const source = '<html><head></head><body><main>App</main>'
+    const { shell, end } = prepareStreamingTemplate(head, prepared ? prepareTemplate(source) : source)
+    const document = new JSDOM(shell + end).window.document
+
+    expect([...document.body.children].map(element => element.tagName)).toEqual(['SCRIPT', 'MAIN'])
+    expect(document.querySelectorAll('#body-open')).toHaveLength(1)
+  })
+
+  it('preserves bodyOpen in a directly rendered shell', () => {
+    const { head } = createStreamableHead({
+      init: [{ script: [{ id: 'body-open', src: '/open.js', tagPosition: 'bodyOpen' }] }],
+    })
+    const html = renderSSRHeadShell(head, '<html><head></head><body><main>App</main></body></html>')
+    const document = new JSDOM(html).window.document
+
+    expect([...document.body.children].map(element => element.tagName)).toEqual(['SCRIPT', 'MAIN'])
+    expect(document.querySelectorAll('#body-open')).toHaveLength(1)
+  })
+})

--- a/packages/vue/test/streaming-nonce.test.ts
+++ b/packages/vue/test/streaming-nonce.test.ts
@@ -17,7 +17,7 @@ describe('streaming request nonce', () => {
 
     expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([nonce ?? null, nonce ?? null])
     const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
-    expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+    expect(executed.__unhead__?._q).toEqual([[{ title: 'Late title' }]])
     executed.close()
   })
 })

--- a/packages/vue/test/streaming-nonce.test.ts
+++ b/packages/vue/test/streaming-nonce.test.ts
@@ -1,0 +1,23 @@
+import { JSDOM } from 'jsdom'
+import { describe, expect, it } from 'vitest'
+import { createStreamableHead } from '../src/stream/server'
+
+describe('streaming request nonce', () => {
+  it.each(['request-a', 'request-b', undefined])('stamps the bootstrap and late patch: %s', async (nonce) => {
+    const { head, wrapStream } = createStreamableHead({ nonce })
+    const app = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        head.push({ title: 'Late title' })
+        controller.enqueue(new TextEncoder().encode('<main>App</main>'))
+        controller.close()
+      },
+    })
+    const html = await new Response(wrapStream(app, '<html><head></head><body><!--app-html--></body></html>')).text()
+    const document = new JSDOM(html).window.document
+
+    expect([...document.scripts].map(script => script.getAttribute('nonce'))).toEqual([nonce ?? null, nonce ?? null])
+    const executed = new JSDOM(html, { runScripts: 'dangerously' }).window
+    expect(executed.__unhead__._q).toEqual([[{ title: 'Late title' }]])
+    executed.close()
+  })
+})

--- a/packages/vue/test/streaming-shell-body.test.ts
+++ b/packages/vue/test/streaming-shell-body.test.ts
@@ -1,0 +1,33 @@
+import { JSDOM } from 'jsdom'
+import { describe, expect, it } from 'vitest'
+import { createStreamableHead, prepareTemplate } from '../src/stream/server'
+
+describe('streaming shell tag positions', () => {
+  it.each([false, true])('preserves initial tags around the app, prepared: %s', async (prepared) => {
+    const context = createStreamableHead({
+      init: [{
+        script: [
+          { id: 'head-prepend', src: '/first.js', tagPriority: 'high' },
+          { id: 'head-append', src: '/head.js' },
+          { id: 'body-open', src: '/open.js', tagPosition: 'bodyOpen' },
+          { id: 'body-close', src: '/close.js', tagPosition: 'bodyClose' },
+        ],
+      }],
+    })
+    const source = '<html><head></head><body><div id="app"><!--app-html--></div></body></html>'
+    const template = prepared ? prepareTemplate(source) : source
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('<main>App</main>'))
+        controller.close()
+      },
+    })
+    const html = await new Response(context.wrapStream(stream, template)).text()
+    const document = new JSDOM(html).window.document
+
+    expect([...document.head.querySelectorAll('script[id]')].map(script => script.id)).toEqual(['head-prepend', 'head-append'])
+    expect([...document.body.children].map(element => element.id)).toEqual(['body-open', 'app', 'body-close'])
+    expect(document.querySelector('#app')?.innerHTML).toBe('<main>App</main>')
+    expect(document.querySelectorAll('#body-open')).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Related to https://github.com/unjs/unhead/pull/969

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Streaming SSR dropped tags at the start of `<body>` and emitted bootstrap scripts without the request CSP nonce. It now preserves body tags and carries a request nonce through streamed scripts.

![Shells preserve body tags and pass the request nonce to bootstrap and patch scripts](https://github.com/user-attachments/assets/fa9ec3df-de6e-4073-b4b0-6e5380534f2b)

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Streaming SSR now supports request-specific CSP nonces on bootstrap and streamed head-update scripts across supported integrations.
  - Streaming preserves scripts placed at the start of the document body, including when using prepared templates.
- **Documentation**
  - Updated streaming guides with instructions for passing CSP nonces through server rendering and applying them to response headers and scripts.
  - Clarified nonce handling and simplified streaming examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->