### PR TITLE
fix(hooks): propagate synchronous render errors

### DIFF
--- a/packages/unhead/src/utils/hooks.ts
+++ b/packages/unhead/src/utils/hooks.ts
@@ -1,9 +1,23 @@
-import type { HookableCore } from 'hookable'
+import type { HookableCore, HookCallback } from 'hookable'
 import type { CoreHeadHooks, Unhead } from '../types'
 import { HookableCore as Hookable } from 'hookable'
 
+function callRegisteredHooks(hooks: HookCallback[], args: any[], start = 0): Promise<void> | void {
+  for (let i = start; i < hooks.length; i++) {
+    // Keep synchronous failures synchronous so renderers can stop before consuming entries.
+    const result = hooks[i](...args)
+    if (result && typeof result.then === 'function')
+      return Promise.resolve(result).then(() => callRegisteredHooks(hooks, args, i + 1))
+  }
+}
+
 export function createHooks<T extends CoreHeadHooks>(hooks?: Partial<T>): HookableCore<T> {
   const instance = new Hookable<T>()
+  instance.callHook = (name, ...args) => {
+    const registered = (instance as any)._hooks[name] as HookCallback[] | undefined
+    if (registered?.length)
+      return callRegisteredHooks(registered, args)
+  }
   for (const key in hooks || {}) {
     instance.hook(key as any, hooks![key as keyof typeof hooks] as any)
   }

--- a/packages/unhead/test/unit/server/hook-errors.test.ts
+++ b/packages/unhead/test/unit/server/hook-errors.test.ts
@@ -10,7 +10,8 @@ describe('synchronous render hook errors', () => {
     'ssr:render',
     'ssr:rendered',
   ] as const)(
-    'preserves pending entries when %s throws', (name) => {
+    'preserves pending entries when %s throws',
+    (name) => {
       const head = createHead({ disableDefaults: true })
       head.push({ title: 'Retry this shell' })
       const error = new Error('Render hook failed')

--- a/packages/unhead/test/unit/server/hook-errors.test.ts
+++ b/packages/unhead/test/unit/server/hook-errors.test.ts
@@ -1,0 +1,60 @@
+import { ValidatePlugin } from 'unhead/plugins'
+import { createHead } from 'unhead/server'
+import { renderShell } from 'unhead/stream/server'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('synchronous render hook errors', () => {
+  it.each([
+    'tags:resolve',
+    'ssr:beforeRender',
+    'ssr:render',
+    'ssr:rendered',
+  ] as const)(
+    'preserves pending entries when %s throws', (name) => {
+      const head = createHead({ disableDefaults: true })
+      head.push({ title: 'Retry this shell' })
+      const error = new Error('Render hook failed')
+      const unhook = head.hooks.hook(name, () => {
+        throw error
+      })
+
+      expect(() => renderShell(head)).toThrow(error)
+
+      unhook()
+      expect(renderShell(head).headTags).toBe('<title>Retry this shell</title>')
+      expect(renderShell(head).headTags).toBe('')
+    },
+  )
+
+  it('propagates errors through validation without reporting an ignored promise', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const head = createHead({
+      plugins: [ValidatePlugin({ onReport: () => {} })],
+      hooks: { 'ssr:render': () => { throw new Error('Render hook failed') } },
+    })
+
+    expect(() => head.render()).toThrow('Render hook failed')
+    expect(warn.mock.calls.filter(call => String(call[0]).includes('promise ignored'))).toEqual([])
+    warn.mockRestore()
+  })
+
+  it('preserves registration order when callers await asynchronous hooks', async () => {
+    const head = createHead({ disableDefaults: true })
+    const calls: string[] = []
+    head.hooks.hook('ssr:beforeRender', async () => {
+      await Promise.resolve()
+      calls.push('first')
+    })
+    const unhook = head.hooks.hook('ssr:beforeRender', () => {
+      calls.push('removed')
+    })
+    head.hooks.hook('ssr:beforeRender', () => {
+      calls.push('last')
+    })
+    unhook()
+
+    await head.hooks.callHook('ssr:beforeRender', { shouldRender: true })
+
+    expect(calls).toEqual(['first', 'last'])
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Found while reviewing #969.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

When an SSR hook throws, Hookable converts its error into an ignored rejection. Streaming still clears pending entries.

Synchronous render calls now throw immediately. Callers can remove the failing hook and retry.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server-side rendering hook execution so synchronous errors propagate correctly.
  - Preserved pending head entries after rendering errors, allowing subsequent renders to produce expected metadata.
  - Ensured asynchronous hooks execute sequentially and retain their registration order after hooks are removed.
  - Prevented misleading “ignored promise” warnings when rendering errors are propagated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->